### PR TITLE
inline backlinks editáveis + perf cold start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to outl are documented here. Format inspired by
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project
 uses [Semantic Versioning](https://semver.org/).
 
+## [0.2.0] — 2026-05-26
+
+Backlinks become a first-class part of the TUI: they live inline below
+the outline (no more side panel), render the referencing block with
+its children, and are fully editable in place.
+
+### TUI (`outl-tui`)
+
+- **Inline backlinks.** Replace the right-side panel with a section
+  rendered below the outline, separated by a full-width `─` rule. Each
+  source page shows up grouped under an icon + title header.
+- **Full source block + children.** Backlinks render the referencing
+  `OutlineNode` *with its subtree* (not a truncated snippet), so you
+  see context without jumping to the source page.
+- **Cursor navigation crosses the boundary.** `j`/`k` flow transparently
+  between outline and backlinks. `app.focus: Focus::{Outline,
+  Backlink{idx, sub_path}}` tracks where the cursor lives.
+- **In-place edits land on the source `.md`.** `i`/`I`/`a`/`Esc`,
+  `Ctrl+T` (TODO/DONE cycle), `o`/`O` (sibling create), `Tab`/`Shift+Tab`
+  (indent/outdent), `dd` (delete), `K`/`J` (move up/down) — all work on
+  a backlink the same way they work on the outline, persisting straight
+  to the source page via `EditTarget::SourcePage`.
+- **Optimistic index updates for snappy UX.** Edits patch the in-memory
+  `WorkspaceIndex` immediately (next frame shows the new state), then
+  save without scheduling a full workspace rebuild on the hot path.
+- Cursor column preserved when entering Insert (`i` honors vim
+  semantics; `I` still jumps home).
+- Ghost cursor on the last outline block when focus had moved into the
+  backlinks section is gone (`render_block` gates by `Focus::Outline`).
+- `view.rs` split into `view/{inline, outline, overlays, backlinks}.rs`
+  by responsibility — each file under 450 lines.
+
+### Markdown (`outl-md`)
+
+- `Backlink` carries the full `source_block: OutlineNode` and its
+  `source_block_path` (DFS path in the source AST) instead of a flat
+  index plus truncated snippet. Repeated refs to the same target inside
+  one block collapse to a single backlink.
+- `WorkspaceIndex::refresh_backlinks_from_source(path, &page)` —
+  optimistic patch of every cached `source_block` for backlinks
+  pointing at `path`. Used by the TUI's cross-page edit path.
+- `WorkspaceIndex::patch_backlink_text(path, target_path, &new_text)`
+  for text-only optimistic edits.
+
 ## [0.1.0] — 2026-05-25
 
 First public release. Single-device editor; sync transport is on the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.25.1"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
 dependencies = [
  "gimli",
 ]
@@ -40,6 +40,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
 dependencies = [
  "equator",
+]
+
+[[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -132,6 +141,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170433209e817da6aae2c51aa0dd443009a613425dd041ebfb2492d1c4c11a25"
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object 0.37.3",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,14 +205,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
+name = "atomic"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
+ "bytemuck",
+]
+
+[[package]]
+name = "attribute-derive"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05832cdddc8f2650cc2cc187cc2e952b8c133a48eb055f35211f61ee81502d77"
+dependencies = [
+ "attribute-derive-macro",
+ "derive-where",
+ "manyhow",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "attribute-derive-macro"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7cdbbd4bd005c5d3e2e9c885e6fa575db4f4a3572335b974d8db853b6beb61"
+dependencies = [
+ "collection_literals",
+ "interpolator",
+ "manyhow",
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+ "quote-use",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -232,13 +278,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -259,6 +340,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bitflagset"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64b6ee310aa7af14142c8c9121775774ff601ae055ed98ba7fac96098bcde1b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "radium",
+ "ref-cast",
+]
+
+[[package]]
 name = "bitmaps"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +370,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "boa_ast"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,7 +390,7 @@ dependencies = [
  "boa_string",
  "indexmap 2.14.0",
  "num-bigint",
- "rustc-hash 2.1.2",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -329,7 +431,7 @@ dependencies = [
  "portable-atomic",
  "rand 0.9.4",
  "regress",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "ryu-js",
  "serde",
  "serde_json",
@@ -367,7 +469,7 @@ dependencies = [
  "indexmap 2.14.0",
  "once_cell",
  "phf 0.13.1",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "static_assertions",
 ]
 
@@ -400,7 +502,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "regress",
- "rustc-hash 2.1.2",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -412,20 +514,9 @@ dependencies = [
  "fast-float2",
  "itoa",
  "paste",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "ryu-js",
  "static_assertions",
-]
-
-[[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -435,6 +526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -493,7 +585,7 @@ checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
 dependencies = [
  "cap-primitives",
  "cap-std",
- "rustix 1.1.4",
+ "rustix",
  "smallvec",
 ]
 
@@ -509,20 +601,10 @@ dependencies = [
  "io-lifetimes",
  "ipnet",
  "maybe-owned",
- "rustix 1.1.4",
+ "rustix",
  "rustix-linux-procfs",
  "windows-sys 0.59.0",
  "winx",
-]
-
-[[package]]
-name = "cap-rand"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
-dependencies = [
- "ambient-authority",
- "rand 0.8.6",
 ]
 
 [[package]]
@@ -534,7 +616,7 @@ dependencies = [
  "cap-primitives",
  "io-extras",
  "io-lifetimes",
- "rustix 1.1.4",
+ "rustix",
 ]
 
 [[package]]
@@ -547,7 +629,7 @@ dependencies = [
  "cap-primitives",
  "iana-time-zone",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "winx",
 ]
 
@@ -559,12 +641,6 @@ checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
 dependencies = [
  "unicode-normalization",
 ]
-
-[[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cast"
@@ -601,9 +677,20 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -612,10 +699,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -643,7 +728,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
- "half 2.7.1",
+ "half",
 ]
 
 [[package]]
@@ -674,7 +759,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -724,6 +809,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "collection_literals"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2550f75b8cfac212855f6b1885455df8eaee8fe8e246b647d69146142e016084"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,20 +836,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "comrak"
-version = "0.29.0"
+name = "compact_str"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c32ff8b21372fab0e9ecc4e42536055702dc5faa418362bffd1544f9d12637"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "comrak"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aac0b255932a9cd52fbfd664b67957f9f2e095ae4711cb0e41b4e291edef94c2"
 dependencies = [
  "caseless",
- "derive_builder",
  "entities",
- "memchr",
- "once_cell",
- "regex",
- "slug",
+ "finl_unicode",
+ "jetscii",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "rustc-hash",
+ "smallvec",
  "typed-arena",
- "unicode_categories",
 ]
 
 [[package]]
@@ -768,6 +873,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -801,47 +927,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-assembler-x64"
-version = "0.125.4"
+name = "cpufeatures"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c088d3406f0c0252efa7445adfd2d05736bfb5218838f64eaf79d567077aed14"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c80cf55a351448317210f26c434be761bcb25e7b36116ec92f89540b73e2833"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.125.4"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c03f887a763abb9c1dc08f722aa82b69067fda623b6f0273050f45f8b1a6776"
+checksum = "07937ca8617b340162fe3a4716be885b5847e9b56d6c7a89abbe4d42340fdc91"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.125.4"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206887a11a43f507fee320a218dc365980bfc42ec2696792079a9f8c9369e90"
+checksum = "88217b08180882436d54c0133274885c590698ae854e352bede1cda041230800"
 dependencies = [
  "cranelift-entity",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.125.4"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac0790c83cfdab95709c5d0105fd888221e3af9049a7d7ec376ec901ab4e4dba"
+checksum = "d5c3cf7ba29fa56e56040848e34835d4e45988b2760ef212413409af95ffd8c1"
 dependencies = [
  "serde",
  "serde_derive",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.125.4"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a98aed2d262eda69310e84bae8e053ee4f17dbdd3347b8d9156aa618ba2de0a"
+checksum = "ebe1aac2efd4cba2047845fce38a68519935a30e20c8a6294ba7e2f448fe722d"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -853,61 +990,63 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
+ "libm",
  "log",
  "pulley-interpreter",
  "regalloc2",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "serde",
  "smallvec",
  "target-lexicon",
- "wasmtime-internal-math",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.125.4"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6906852826988563e9b0a9232ad951f53a47aa41ffd02f8ac852d3f41aae836a"
+checksum = "0909eaf9d6f18f5bf802d50608cb4368ac340fbd03cc44f2888d1cfcc3faa64e"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
  "cranelift-srcgen",
- "heck 0.5.0",
+ "heck",
  "pulley-interpreter",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.125.4"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a50105aab667b5cc845f2be37c78475d7cc127cd8ec0a31f7b2b71d526099a7"
+checksum = "c95a8da8be283f49cda7d0ef228c94f10d791e517b27b0c7e282dadd2e79ce45"
 
 [[package]]
 name = "cranelift-control"
-version = "0.125.4"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6adcc7aa7c0bc1727176a6f2d99c28a9e79a541ccd5ca911a0cb352da8befa36"
+checksum = "f5b19c81145146da1f7afda2e7f52111842fe6793512e740ad5cf3f5639e6212"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.125.4"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "981b56af777f9a34ea6dcce93255125776d391410c2a68b75bed5941b714fa15"
+checksum = "4a55309b47e6633ab05821304206cb1e92952e845b1224985562bb7ac1e92323"
 dependencies = [
  "cranelift-bitset",
  "serde",
  "serde_derive",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.125.4"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea982589684dfb71afecb9fc09555c3a266300a1162a60d7fa39d41a5705b1c"
+checksum = "064d2d3533d9608f1cf44c8899cf2f7f33feb70300b0fb83e687b0d9e7b91147"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -917,15 +1056,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.125.4"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0422686b22ed6a1f33cc40e3c43eb84b67155788568d1a5cac8439d3dca1783"
+checksum = "1ac4e0bc095b2dab2212d1e99d7a74b62afc1485db023f1c0cb34a68758f7bd1"
 
 [[package]]
 name = "cranelift-native"
-version = "0.125.4"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f697bbbe135c655ea1deb7af0bae4a5c4fae2c88fdfc0fa57b34ae58c91040"
+checksum = "09a40053f5cb925451dd1d57393d14ad3145c8e0786701c27b5415ebb9a3ba4f"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -934,9 +1073,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.125.4"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718efe674f3df645462677e22a3128e890d88ba55821bb091083d257707be76c"
+checksum = "a3ceab9a53f7d362c89841fbaa8e63e44d47c40e91dc96ee6f777fca5d6b323b"
 
 [[package]]
 name = "crc32fast"
@@ -949,23 +1088,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -973,12 +1111,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -1026,15 +1164,17 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags 2.11.1",
  "crossterm_winapi",
- "mio 1.2.0",
+ "derive_more",
+ "document-features",
+ "mio",
  "parking_lot",
- "rustix 0.38.44",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1066,13 +1206,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.20.11"
+name = "crypto-common"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
+ "hybrid-array",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -1081,22 +1230,8 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1114,22 +1249,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.117",
 ]
@@ -1158,6 +1282,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1167,62 +1297,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_builder"
-version = "0.20.2"
+name = "derive-where"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
 ]
 
 [[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "derive_more"
-version = "1.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "1.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
+ "rustc_version 0.4.1",
  "syn 2.0.117",
- "unicode-xid",
 ]
-
-[[package]]
-name = "deunicode"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "digest"
@@ -1230,8 +1335,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1246,23 +1362,23 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1272,7 +1388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -1285,6 +1401,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1395,6 +1520,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1434,6 +1568,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex",
+]
+
+[[package]]
 name = "fast-float2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1455,7 +1599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -1469,13 +1613,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime"
-version = "0.2.29"
+name = "filedescriptor"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
 dependencies = [
- "cfg-if",
  "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -1483,6 +1628,18 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixedbitset"
@@ -1534,7 +1691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -1587,7 +1744,7 @@ version = "7.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "futures-core",
  "futures-lite",
  "pin-project",
@@ -1659,10 +1816,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1675,7 +1835,7 @@ checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
 dependencies = [
  "bitflags 2.11.1",
  "debugid",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1702,6 +1862,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "get-size-derive2"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b6d1e2f75c16bfbcd0f95d84f99858a6e2f885c2287d1f5c3a96e8444a34b4"
+dependencies = [
+ "attribute-derive",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "get-size2"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49cf31a6d70300cf81461098f7797571362387ef4bf85d32ac47eaa59b3a5a1a"
+dependencies = [
+ "compact_str 0.9.0",
+ "get-size-derive2",
+ "hashbrown 0.16.1",
+ "ordermap",
+ "smallvec",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1717,10 +1901,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1746,17 +1928,19 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.32.3"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
- "fallible-iterator",
+ "fnv",
+ "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "stable_deref_trait",
 ]
@@ -1766,12 +1950,6 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "half"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "half"
@@ -1807,10 +1985,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -1829,36 +2004,26 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "hashlink"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown 0.14.5",
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
-name = "heck"
-version = "0.4.1"
+name = "hashlink"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1894,6 +2059,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1905,7 +2079,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2120,11 +2294,11 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.9.6"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.1",
  "inotify-sys",
  "libc",
 ]
@@ -2144,12 +2318,18 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "indoc",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "interpolator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 
 [[package]]
 name = "intrusive-collections"
@@ -2188,21 +2368,10 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d57a3e447e24c22647738e4607f1df1e0ec6f72e16182c4cd199f647cdfb0e4"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi 0.5.2",
- "libc",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2210,24 +2379,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -2274,6 +2425,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "jetscii"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2306,6 +2463,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2326,10 +2494,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lalrpop-util"
-version = "0.20.2"
+name = "lab"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "lasso"
@@ -2363,39 +2531,63 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lexical-parse-float"
-version = "0.8.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
 dependencies = [
  "lexical-parse-integer",
  "lexical-util",
- "static_assertions",
 ]
 
 [[package]]
 name = "lexical-parse-integer"
-version = "0.8.6"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
 dependencies = [
  "lexical-util",
- "static_assertions",
 ]
 
 [[package]]
 name = "lexical-util"
-version = "0.8.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
-dependencies = [
- "static_assertions",
-]
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
 
 [[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libffi"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0498fe5655f857803e156523e644dcdcdc3b3c7edda42ea2afdae2e09b2db87b"
+dependencies = [
+ "libc",
+ "libffi-sys",
+]
+
+[[package]]
+name = "libffi-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d4f1d4ce15091955144350b75db16a96d4a63728500122706fb4d29a26afbb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libm"
@@ -2414,9 +2606,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2424,10 +2616,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
+name = "line-clipping"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.11.1",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2442,6 +2637,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2452,45 +2653,55 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
 name = "lua-src"
-version = "547.0.0"
+version = "550.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edaf29e3517b49b8b746701e5648ccb5785cde1c119062cbabbc5d5cd115e42"
+checksum = "e836dc8ae16806c9bdcf42003a88da27d163433e3f9684c52f0301258004a4fb"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "luajit-src"
-version = "210.5.12+a4f56a4"
+version = "210.6.6+707c12b"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a8e7962a5368d5f264d045a5a255e90f9aa3fc1941ae15a8d2940d42cac671"
+checksum = "a86cc925d4053d0526ae7f5bc765dbd0d7a5d1a63d43974f4966cb349ca63295"
 dependencies = [
  "cc",
- "which 7.0.3",
+ "which",
 ]
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.6"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
+]
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix 0.29.0",
+ "winapi",
 ]
 
 [[package]]
@@ -2503,36 +2714,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "malachite"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbdf9cb251732db30a7200ebb6ae5d22fe8e11397364416617d2c2cf0c51cb5"
-dependencies = [
- "malachite-base",
- "malachite-nz",
- "malachite-q",
-]
-
-[[package]]
 name = "malachite-base"
-version = "0.4.22"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea0ed76adf7defc1a92240b5c36d5368cfe9251640dcce5bd2d0b7c1fd87aeb"
+checksum = "a8b6f86fdbb1eb9955946be91775239dfcb0acdb1a51bb07d5fc9b8c854f5ccd"
 dependencies = [
- "hashbrown 0.14.5",
- "itertools 0.11.0",
+ "hashbrown 0.16.1",
+ "itertools 0.14.0",
  "libm",
  "ryu",
 ]
 
 [[package]]
 name = "malachite-bigint"
-version = "0.2.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d149aaa2965d70381709d9df4c7ee1fc0de1c614a4efc2ee356f5e43d68749f8"
+checksum = "67fcd6e504ffc67db2b3c6d5e90e08054646e2b04f42115a5460bf1c1e37d3bc"
 dependencies = [
- "derive_more",
- "malachite",
+ "malachite-base",
+ "malachite-nz",
  "num-integer",
  "num-traits",
  "paste",
@@ -2540,24 +2740,48 @@ dependencies = [
 
 [[package]]
 name = "malachite-nz"
-version = "0.4.22"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34a79feebb2bc9aa7762047c8e5495269a367da6b5a90a99882a0aeeac1841f7"
+checksum = "0197a2f5cfee19d59178e282985c6ca79a9233e26a2adcf40acb693896aa09f6"
 dependencies = [
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "libm",
  "malachite-base",
+ "wide",
 ]
 
 [[package]]
 name = "malachite-q"
-version = "0.4.22"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f235d5747b1256b47620f5640c2a17a88c7569eebdf27cd9cb130e1a619191"
+checksum = "be2add95162aede090c48f0ee51bea7d328847ce3180aa44588111f846cc116b"
 dependencies = [
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "malachite-base",
  "malachite-nz",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -2572,7 +2796,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.4.14",
+ "regex-automata",
 ]
 
 [[package]]
@@ -2594,7 +2818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2609,8 +2833,14 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
- "rustix 1.1.4",
+ "rustix",
 ]
+
+[[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
 
 [[package]]
 name = "memoffset"
@@ -2622,16 +2852,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.11"
+name = "minimal-lexical"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
-]
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -2647,27 +2871,29 @@ dependencies = [
 
 [[package]]
 name = "mlua"
-version = "0.10.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f5f8fbebc7db5f671671134b9321c4b9aa9adeafccfd9a8c020ae45c6a35d0"
+checksum = "ccd36acfa49ce6ee56d1307a061dd302c564eee757e6e4cd67eb4f7204846fab"
 dependencies = [
- "bstr 1.12.1",
+ "bstr",
  "either",
+ "libc",
  "mlua-sys",
  "num-traits",
  "parking_lot",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustversion",
 ]
 
 [[package]]
 name = "mlua-sys"
-version = "0.6.8"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380c1f7e2099cafcf40e51d3a9f20a346977587aa4d012eae1f043149a728a93"
+checksum = "0f1c3a7fc7580227ece249fd90aa2fa3b39eb2b49d3aec5e103b3e85f2c3dfc8"
 dependencies = [
  "cc",
  "cfg-if",
+ "libc",
  "lua-src",
  "luajit-src",
  "pkg-config",
@@ -2684,59 +2910,78 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.27.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
+ "cfg_aliases",
  "libc",
  "memoffset",
 ]
 
 [[package]]
 name = "nix"
-version = "0.28.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
 name = "notify"
-version = "6.1.1"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
  "bitflags 2.11.1",
- "crossbeam-channel",
- "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
  "log",
- "mio 0.8.11",
+ "mio",
+ "notify-types",
  "walkdir",
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "notify-debouncer-full"
-version = "0.3.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7fd166739789c9ff169e654dc1501373db9d80a4c3f972817c8a4d7cf8f34e"
+checksum = "c02b49179cfebc9932238d04d6079912d26de0379328872846118a0fa0dbb302"
 dependencies = [
- "crossbeam-channel",
  "file-id",
  "log",
  "notify",
- "parking_lot",
+ "notify-types",
  "walkdir",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2775,6 +3020,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2809,7 +3065,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
 ]
 
@@ -2850,8 +3106,17 @@ version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
  "crc32fast",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "memchr",
 ]
@@ -2888,6 +3153,15 @@ checksum = "978aa494585d3ca4ad74929863093e87cac9790d81fe7aba2b3dc2890643a0fc"
 
 [[package]]
 name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
@@ -2898,8 +3172,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordermap"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7476a5b122ff1fce7208e7ee9dccd0a516e835f5b8b19b8f3c98a34cf757c1"
+dependencies = [
+ "indexmap 2.14.0",
+]
+
+[[package]]
 name = "outl-cli"
-version = "0.1.0-beta.42"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2912,7 +3195,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "ulid",
@@ -2921,9 +3204,9 @@ dependencies = [
 
 [[package]]
 name = "outl-core"
-version = "0.1.0-beta.42"
+version = "0.2.0"
 dependencies = [
- "bincode",
+ "bincode 2.0.1",
  "chrono",
  "fs2",
  "hex",
@@ -2932,9 +3215,9 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "ulid",
  "yrs",
@@ -2942,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "outl-exec"
-version = "0.1.0-beta.42"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "boa_engine",
@@ -2952,10 +3235,10 @@ dependencies = [
  "outl-core",
  "outl-md",
  "rustpython-vm",
- "sha2",
+ "sha2 0.11.0",
  "steel-core",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "wasmtime",
  "wasmtime-wasi",
@@ -2963,7 +3246,7 @@ dependencies = [
 
 [[package]]
 name = "outl-md"
-version = "0.1.0-beta.42"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "comrak",
@@ -2973,16 +3256,16 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "walkdir",
 ]
 
 [[package]]
 name = "outl-tui"
-version = "0.1.0-beta.42"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2993,12 +3276,22 @@ dependencies = [
  "outl-md",
  "ratatui",
  "tempfile",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
  "ulid",
  "walkdir",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3043,11 +3336,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap 2.14.0",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -3057,8 +3404,9 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.13.1",
  "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -3069,6 +3417,16 @@ checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -3093,6 +3451,19 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_macros"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
@@ -3110,7 +3481,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher 1.0.3",
+ "siphasher",
 ]
 
 [[package]]
@@ -3119,7 +3490,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
- "siphasher 1.0.3",
+ "siphasher",
 ]
 
 [[package]]
@@ -3156,13 +3527,13 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pmutil"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3894e5d549cccbe44afecf72922f277f603cd4bb0219c8342631ef18fffbe004"
+checksum = "52a40bc70c2c58040d2d8b167ba9a5ff59fc9dab7ad44771cfde3dcfde7a09c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3173,9 +3544,9 @@ checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "pin-project-lite",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -3250,7 +3621,18 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeaf08a13de400bc215877b5bdc088f241b12eb42f0a548d3390dc1c56bb7071"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
 ]
 
 [[package]]
@@ -3268,8 +3650,8 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bit-set",
- "bit-vec",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
  "bitflags 2.11.1",
  "num-traits",
  "rand 0.9.4",
@@ -3282,22 +3664,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulley-interpreter"
-version = "38.0.4"
+name = "psm"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beafc309a2d35e16cc390644d88d14dfa45e45e15075ec6a9e37f6dfb43e926f"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9204ad9435f2a6fe3bd13bba52389fb8488fa20ba497e35c5d2db638166019d"
 dependencies = [
  "cranelift-bitset",
  "log",
  "pulley-macros",
- "wasmtime-internal-math",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "pulley-macros"
-version = "38.0.4"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885fbb6c07454cfc8725a18a1da3cfc328ee8c53fb8d0671ea313edc8567947"
+checksum = "53009b033747e0d79a76549a744da58e84c9da8076492c7e6d491fdc6cc41b95"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3320,6 +3712,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "quote-use"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9619db1197b497a36178cfc736dc96b271fe918875fbf1344c436a7e93d0321e"
+dependencies = [
+ "quote",
+ "quote-use-macros",
+]
+
+[[package]]
+name = "quote-use-macros"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82ebfb7faafadc06a7ab141a6f67bcfb24cb8beb158c6fe933f2f035afa99f35"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3333,9 +3747,12 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
-version = "0.7.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+checksum = "1775bc532a9bfde46e26eba441ca1171b91608d14a3bae71fea371f18a00cffe"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "radix_trie"
@@ -3367,6 +3784,17 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3409,6 +3837,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3428,23 +3862,87 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.28.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
  "bitflags 2.11.1",
- "cassowary",
- "compact_str",
- "crossterm",
- "instability",
- "itertools 0.13.0",
+ "compact_str 0.9.0",
+ "hashbrown 0.16.1",
+ "indoc",
+ "itertools 0.14.0",
+ "kasuari",
  "lru",
- "paste",
- "strum 0.26.3",
- "strum_macros 0.26.4",
+ "strum 0.27.2",
+ "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.16.1",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "strum 0.27.2",
+ "time",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -3488,16 +3986,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "regalloc2"
-version = "0.13.5"
+name = "redox_users"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08effbc1fa53aaebff69521a5c05640523fab037b34a4a2c109506bc938246fa"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "log",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "smallvec",
 ]
 
@@ -3509,15 +4038,9 @@ checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.14",
+ "regex-automata",
  "regex-syntax",
 ]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-automata"
@@ -3548,31 +4071,40 @@ dependencies = [
 
 [[package]]
 name = "result-like"
-version = "0.4.6"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc7ce6435c33898517a30e85578cd204cbb696875efb93dec19a2d31294f810"
+checksum = "bffa194499266bd8a1ac7da6ac7355aa0f81ffa1a5db2baaf20dd13854fd6f4e"
 dependencies = [
  "result-like-derive",
 ]
 
 [[package]]
 name = "result-like-derive"
-version = "0.4.6"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fabf0a2e54f711c68c50d49f648a1a8a37adcb57353f518ac4df374f0788f42"
+checksum = "01d3b03471c9700a3a6bd166550daaa6124cb4a146ea139fb028e4edaa8f4277"
 dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "syn-ext",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "rusqlite"
-version = "0.32.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
  "bitflags 2.11.1",
  "fallible-iterator",
@@ -3580,6 +4112,7 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -3587,12 +4120,6 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -3620,19 +4147,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.11.1",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3640,7 +4154,7 @@ dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -3651,287 +4165,307 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
 dependencies = [
  "once_cell",
- "rustix 1.1.4",
-]
-
-[[package]]
-name = "rustpython-ast"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cdaf8ee5c1473b993b398c174641d3aa9da847af36e8d5eb8291930b72f31a5"
-dependencies = [
- "is-macro",
- "malachite-bigint",
- "rustpython-literal",
- "rustpython-parser-core",
- "static_assertions",
+ "rustix",
 ]
 
 [[package]]
 name = "rustpython-codegen"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f101783403a69155ba7b52d8365d796c772a0bfca7df0a5f16d267f3443986"
+checksum = "12e4fc1331357a7afc6d52d637796a946b1efaaca07c914132f8fd4fd69d595f"
 dependencies = [
  "ahash",
  "bitflags 2.11.1",
  "indexmap 2.14.0",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "log",
+ "malachite-bigint",
+ "memchr",
  "num-complex",
  "num-traits",
- "rustpython-ast",
  "rustpython-compiler-core",
- "rustpython-parser-core",
+ "rustpython-literal",
+ "rustpython-ruff_python_ast",
+ "rustpython-ruff_text_size",
+ "rustpython-wtf8",
+ "thiserror 2.0.18",
+ "unicode_names2 2.0.0",
 ]
 
 [[package]]
 name = "rustpython-common"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22a5c520662f0ff98d717e2c4e52d8ba35eb1d99ee771dbdba7f09908b75bbb"
+checksum = "9f3c0808a170ea900e0489a06d6aa04ce5d27d62b347836c2f98df958f47f243"
 dependencies = [
  "ascii",
  "bitflags 2.11.1",
- "bstr 0.2.17",
  "cfg-if",
- "itertools 0.11.0",
+ "getrandom 0.3.4",
+ "itertools 0.14.0",
  "libc",
  "lock_api",
  "malachite-base",
  "malachite-bigint",
  "malachite-q",
+ "nix 0.30.1",
  "num-complex",
  "num-traits",
- "once_cell",
  "radium",
- "rand 0.8.6",
- "rustpython-format",
- "siphasher 0.3.11",
- "volatile",
+ "rustpython-literal",
+ "rustpython-wtf8",
+ "siphasher",
+ "unicode_names2 2.0.0",
  "widestring",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustpython-compiler"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c0ad9d5b948970d41b113cfc9ffe2337b10fdd41e0c92a859b9ed33c218efe"
+checksum = "f7fa83b852bbc5461c5214060099d7597785d201aa0bf1a87d77967518f60144"
 dependencies = [
  "rustpython-codegen",
  "rustpython-compiler-core",
- "rustpython-parser",
+ "rustpython-ruff_python_ast",
+ "rustpython-ruff_python_parser",
+ "rustpython-ruff_source_file",
+ "rustpython-ruff_text_size",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "rustpython-compiler-core"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd4e0c9fb7b3c70eb27b38d533edc0aa4875ea38cb06e12d76e234d00ef9766"
+checksum = "e9f18ba67b55aec49c3e2d223bbdcacff0d7e0f5d304fb0e64b044b8dca13c7c"
 dependencies = [
  "bitflags 2.11.1",
- "itertools 0.11.0",
+ "bitflagset",
+ "itertools 0.14.0",
  "lz4_flex",
  "malachite-bigint",
  "num-complex",
- "rustpython-parser-core",
+ "rustpython-ruff_source_file",
+ "rustpython-wtf8",
 ]
 
 [[package]]
 name = "rustpython-derive"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c39620497116ce2996bcc679f9be4f47c1e8915c7ff9a9f0324e9584280660"
+checksum = "6ba6c04350bee9e54b241b93675a0558c2b33fe982213e47a6da0924898af0f2"
 dependencies = [
  "rustpython-compiler",
  "rustpython-derive-impl",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "rustpython-derive-impl"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd18fa95c71a08ecc9cce739a608f5bff38805963152e671b66f5f266f0e58d"
+checksum = "322d64ea8a21d52cd769db0f6190b6e7c17963b13c8c17f39d7364e68af96731"
 dependencies = [
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "maplit",
- "once_cell",
  "proc-macro2",
  "quote",
  "rustpython-compiler-core",
  "rustpython-doc",
- "rustpython-parser-core",
- "syn 1.0.109",
+ "syn 2.0.117",
  "syn-ext",
  "textwrap",
 ]
 
 [[package]]
 name = "rustpython-doc"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885d19895d9d29656a8a2b33e967a482b92f3d891b4fd923e40849714051bcd"
+checksum = "f286d8b5872aa53dceb7a8d8c6a29fe85150f0a137fecf1c9a3e0a8345cbc19b"
 dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "rustpython-format"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0389039b132ad8e350552d771270ccd03186985696764bcee2239694e7839942"
-dependencies = [
- "bitflags 2.11.1",
- "itertools 0.11.0",
- "malachite-bigint",
- "num-traits",
- "rustpython-literal",
+ "phf 0.13.1",
 ]
 
 [[package]]
 name = "rustpython-literal"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8304be3cae00232a1721a911033e55877ca3810215f66798e964a2d8d22281d"
+checksum = "bcb46f7afce00e4797f82062e09881ec5e7226d858104bf4a8a9c3b996de2b4a"
 dependencies = [
  "hexf-parse",
  "is-macro",
  "lexical-parse-float",
  "num-traits",
+ "rustpython-wtf8",
  "unic-ucd-category",
 ]
 
 [[package]]
-name = "rustpython-parser"
-version = "0.4.0"
+name = "rustpython-ruff_python_ast"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868f724daac0caf9bd36d38caf45819905193a901e8f1c983345a68e18fb2abb"
+checksum = "f021ff72cabf5e2cd6d8ec8813d376a8445a228dc610ab56c27bd9054cda70d4"
 dependencies = [
- "anyhow",
+ "aho-corasick",
+ "bitflags 2.11.1",
+ "compact_str 0.9.0",
+ "get-size2",
  "is-macro",
- "itertools 0.11.0",
- "lalrpop-util",
- "log",
- "malachite-bigint",
- "num-traits",
- "phf 0.11.3",
- "phf_codegen",
- "rustc-hash 1.1.0",
- "rustpython-ast",
- "rustpython-parser-core",
- "tiny-keccak",
- "unic-emoji-char",
- "unic-ucd-ident",
- "unicode_names2",
+ "memchr",
+ "rustc-hash",
+ "rustpython-ruff_python_trivia",
+ "rustpython-ruff_source_file",
+ "rustpython-ruff_text_size",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
-name = "rustpython-parser-core"
-version = "0.4.0"
+name = "rustpython-ruff_python_parser"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b6c12fa273825edc7bccd9a734f0ad5ba4b8a2f4da5ff7efe946f066d0f4ad"
+checksum = "01e6ee78bd9671fb5766664b2695fe1f2a92a961f4d9101646c570d8acdb1e0b"
 dependencies = [
- "is-macro",
+ "bitflags 2.11.1",
+ "bstr",
+ "compact_str 0.9.0",
+ "get-size2",
  "memchr",
- "rustpython-parser-vendored",
+ "rustc-hash",
+ "rustpython-ruff_python_ast",
+ "rustpython-ruff_python_trivia",
+ "rustpython-ruff_text_size",
+ "static_assertions",
+ "unicode-ident",
+ "unicode-normalization",
+ "unicode_names2 1.3.0",
 ]
 
 [[package]]
-name = "rustpython-parser-vendored"
-version = "0.4.0"
+name = "rustpython-ruff_python_trivia"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04fcea49a4630a3a5d940f4d514dc4f575ed63c14c3e3ed07146634aed7f67a6"
+checksum = "79e7cfd1056f3a02ff0d2d0e4474286ca963260782f878b7b81c1dd87432e682"
+dependencies = [
+ "itertools 0.14.0",
+ "rustpython-ruff_source_file",
+ "rustpython-ruff_text_size",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustpython-ruff_source_file"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "948107aad62ddb12a11fc7bf68a49e52a0b0a3737d415a2505e54f5a9edac737"
 dependencies = [
  "memchr",
- "once_cell",
+ "rustpython-ruff_text_size",
+]
+
+[[package]]
+name = "rustpython-ruff_text_size"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8291ee0f5a779e54ccd4e0151a0c426f8b49a123f99b5b6545db17ccdd4277aa"
+dependencies = [
+ "get-size2",
 ]
 
 [[package]]
 name = "rustpython-sre_engine"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39367be5d48e1e5caaa146904ea8d35fe43928168fbeb5c1ab295a0031b179c6"
+checksum = "ad4b7bd82b2a531f7c2ad96864ce11285959fc7d8524f1ba54db8ce3a23a3d2c"
 dependencies = [
  "bitflags 2.11.1",
  "num_enum",
  "optional",
+ "rustpython-wtf8",
 ]
 
 [[package]]
 name = "rustpython-vm"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2878cc4b5679f35fa762891d812ca7e011ae7cd41b5c532eb0ad13959b522493"
+checksum = "1880770161cef896bf9c7e065dae574e3b4c3cf6172e485f1ce86f0483816ab2"
 dependencies = [
  "ahash",
  "ascii",
- "atty",
  "bitflags 2.11.1",
- "bstr 0.2.17",
+ "bstr",
  "caseless",
  "cfg-if",
  "chrono",
+ "constant_time_eq",
  "crossbeam-utils",
+ "errno",
  "exitcode",
- "getrandom 0.2.17",
+ "getrandom 0.3.4",
  "glob",
- "half 1.8.3",
+ "half",
  "hex",
  "indexmap 2.14.0",
  "is-macro",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "junction",
  "libc",
+ "libffi",
+ "libloading",
  "log",
  "malachite-bigint",
  "memchr",
- "memoffset",
- "nix 0.27.1",
+ "nix 0.30.1",
  "num-complex",
  "num-integer",
  "num-traits",
  "num_cpus",
  "num_enum",
- "once_cell",
  "optional",
  "parking_lot",
  "paste",
- "rand 0.8.6",
+ "psm",
  "result-like",
- "rustc_version 0.4.1",
- "rustpython-ast",
+ "rustix",
  "rustpython-codegen",
  "rustpython-common",
  "rustpython-compiler",
  "rustpython-compiler-core",
  "rustpython-derive",
- "rustpython-format",
  "rustpython-literal",
- "rustpython-parser",
- "rustpython-parser-core",
+ "rustpython-ruff_python_ast",
+ "rustpython-ruff_python_parser",
+ "rustpython-ruff_text_size",
  "rustpython-sre_engine",
  "rustyline",
- "schannel",
+ "scoped-tls",
+ "scopeguard",
  "static_assertions",
- "strum 0.24.1",
- "strum_macros 0.24.3",
- "thiserror 1.0.69",
- "thread_local",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
+ "thiserror 2.0.18",
  "timsort",
  "uname",
  "unic-ucd-bidi",
  "unic-ucd-category",
  "unic-ucd-ident",
  "unicode-casing",
- "unicode_names2",
- "wasm-bindgen",
- "which 4.4.2",
+ "which",
  "widestring",
- "windows",
- "windows-sys 0.52.0",
- "winreg",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustpython-wtf8"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada88d2f69ff5516d69e0f3294e9db2ff8ee71a15291b8f3f8584f07ad1ca28d"
+dependencies = [
+ "ascii",
+ "bstr",
+ "itertools 0.14.0",
+ "memchr",
 ]
 
 [[package]]
@@ -3954,9 +4488,9 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "14.0.0"
+version = "17.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
+checksum = "e902948a25149d50edc1a8e0141aad50f54e22ba83ff988cf8f7c9ef07f50564"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -3966,12 +4500,12 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix 0.28.0",
+ "nix 0.30.1",
  "radix_trie",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.2",
  "utf8parse",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3987,6 +4521,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
 
 [[package]]
+name = "safe_arch"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3996,13 +4539,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.29"
+name = "scoped-tls"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -4080,11 +4620,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4094,8 +4634,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4139,7 +4690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio 1.2.0",
+ "mio",
  "signal-hook",
 ]
 
@@ -4152,12 +4703,6 @@ dependencies = [
  "errno",
  "libc",
 ]
-
-[[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
@@ -4180,16 +4725,6 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "slug"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
-dependencies = [
- "deunicode",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "small_btree"
@@ -4229,6 +4764,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4248,10 +4795,10 @@ checksum = "b4acadc255e0d56fe71c09c605ebde51e6009b02d86ae610386f26437c4f91f8"
 dependencies = [
  "arc-swap",
  "bigdecimal",
- "bincode",
+ "bincode 1.3.3",
  "chrono",
  "codespan-reporting",
- "compact_str",
+ "compact_str 0.8.1",
  "crossbeam-channel",
  "crossbeam-queue",
  "crossbeam-utils",
@@ -4277,7 +4824,7 @@ dependencies = [
  "parking_lot",
  "polling",
  "rand 0.9.4",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "serde",
  "serde_json",
  "shared_vector",
@@ -4289,7 +4836,7 @@ dependencies = [
  "strsim",
  "thin-vec",
  "weak-table",
- "which 8.0.2",
+ "which",
  "xdg",
 ]
 
@@ -4320,7 +4867,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "769cea4a36ee603bfde799ab9c1ec1f93a67df30bcf4cd22d069eb8d4155e2b2"
 dependencies = [
- "compact_str",
+ "compact_str 0.8.1",
  "dashmap",
  "lasso",
  "log",
@@ -4328,9 +4875,9 @@ dependencies = [
  "num-rational",
  "num-traits",
  "once_cell",
- "ordered-float",
+ "ordered-float 5.3.0",
  "pretty",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "serde",
  "smallvec",
  "thin-vec",
@@ -4354,42 +4901,40 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "strum_macros 0.26.4",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.24.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "rustversion",
  "syn 2.0.117",
 ]
 
@@ -4417,11 +4962,13 @@ dependencies = [
 
 [[package]]
 name = "syn-ext"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b86cb2b68c5b3c078cac02588bc23f3c04bb828c5d3aedd17980876ec6a7be6"
+checksum = "b126de4ef6c2a628a68609dd00733766c3b015894698a438ebdf374933fc31d1"
 dependencies = [
- "syn 1.0.109",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4433,22 +4980,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "system-interface"
-version = "0.27.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
-dependencies = [
- "bitflags 2.11.1",
- "cap-fs-ext",
- "cap-std",
- "fd-lock",
- "io-lifetimes",
- "rustix 0.38.44",
- "windows-sys 0.59.0",
- "winx",
 ]
 
 [[package]]
@@ -4478,7 +5009,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -4492,10 +5023,73 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.15.2"
+name = "terminfo"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.11.1",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset 0.4.2",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix 0.29.0",
+ "num-derive",
+ "num-traits",
+ "ordered-float 4.6.0",
+ "pest",
+ "pest_derive",
+ "phf 0.11.3",
+ "sha2 0.10.9",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 
 [[package]]
 name = "thin-vec"
@@ -4595,15 +5189,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "639ce8ef6d2ba56be0383a94dd13b92138d58de44c62618303bb798fa92bdc00"
 
 [[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4647,7 +5232,7 @@ checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.2.0",
+ "mio",
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
@@ -4655,23 +5240,41 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "serde",
+ "indexmap 2.14.0",
+ "serde_core",
  "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4681,20 +5284,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap 2.14.0",
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
 ]
 
 [[package]]
@@ -4719,10 +5308,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -4776,7 +5365,7 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex-automata 0.4.14",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -4802,6 +5391,12 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "ulid"
@@ -4849,17 +5444,6 @@ name = "unic-common"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
-
-[[package]]
-name = "unic-emoji-char"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b07221e68897210270a38bde4babb655869637af0f69407f96053a34f76494d"
-dependencies = [
- "unic-char-property",
- "unic-char-range",
- "unic-ucd-version",
-]
 
 [[package]]
 name = "unic-ucd-bidi"
@@ -4933,13 +5517,13 @@ checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -4961,19 +5545,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
 name = "unicode_names2"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1673eca9782c84de5f81b82e4109dcfb3611c8ba0d52930ec4a9478f547b2dd"
 dependencies = [
  "phf 0.11.3",
- "unicode_names2_generator",
+ "unicode_names2_generator 1.3.0",
+]
+
+[[package]]
+name = "unicode_names2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d189085656ca1203291e965444e7f6a2723fbdd1dd9f34f8482e79bafd8338a0"
+dependencies = [
+ "phf 0.11.3",
+ "unicode_names2_generator 2.0.0",
 ]
 
 [[package]]
@@ -4984,9 +5572,25 @@ checksum = "b91e5b84611016120197efd7dc93ef76774f4e084cd73c9fb3ea4a86c570c56e"
 dependencies = [
  "getopts",
  "log",
- "phf_codegen",
+ "phf_codegen 0.11.3",
  "rand 0.8.6",
 ]
+
+[[package]]
+name = "unicode_names2_generator"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1262662dc96937c71115228ce2e1d30f41db71a7a45d3459e98783ef94052214"
+dependencies = [
+ "phf_codegen 0.11.3",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "url"
@@ -5024,6 +5628,8 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
+ "atomic",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -5047,10 +5653,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "volatile"
-version = "0.3.0"
+name = "virtue"
+version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e76fae08f03f96e166d2dfda232190638c10e0383841252416f9cfe2ae60e6"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -5141,13 +5756,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.239.0"
+name = "wasm-compose"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be00faa2b4950c76fe618c409d2c3ea5a3c9422013e079482d78544bb2d184c"
+checksum = "96ba953e2b9b4b4b52a31cf4e3ee1c1374c872b6e012cf2138d1c37cba00bfd6"
 dependencies = [
- "leb128fmt",
- "wasmparser 0.239.0",
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "log",
+ "petgraph",
+ "smallvec",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+ "wat",
 ]
 
 [[package]]
@@ -5158,6 +5780,16 @@ checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
@@ -5184,19 +5816,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.239.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver 1.0.28",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
@@ -5205,6 +5824,19 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver 1.0.28",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "semver 1.0.28",
+ "serde",
 ]
 
 [[package]]
@@ -5220,121 +5852,124 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.239.0"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3981f3d51f39f24f5fc90f93049a90f08dbbca8deba602cd46bb8ca67a94718"
+checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.239.0",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "38.0.4"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81eafc07c867be94c47e0dc66355d9785e09107a18901f76a20701ba0663ad7"
+checksum = "d35aec1e932d00a7c941f816ad589e65ad8db948b9e971bf8ec655a1669f1f67"
 dependencies = [
  "addr2line",
- "anyhow",
  "async-trait",
  "bitflags 2.11.1",
  "bumpalo",
  "cc",
  "cfg-if",
  "encoding_rs",
+ "futures",
  "fxprof-processed-profile",
  "gimli",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
  "ittapi",
  "libc",
  "log",
  "mach2",
  "memfd",
- "object",
+ "object 0.39.1",
  "once_cell",
  "postcard",
  "pulley-interpreter",
  "rayon",
- "rustix 1.1.4",
+ "rustix",
  "semver 1.0.28",
  "serde",
  "serde_derive",
  "serde_json",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.239.0",
- "wasmparser 0.239.0",
+ "tempfile",
+ "wasm-compose",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
  "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
  "wasmtime-internal-fiber",
  "wasmtime-internal-jit-debug",
  "wasmtime-internal-jit-icache-coherence",
- "wasmtime-internal-math",
- "wasmtime-internal-slab",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
  "wasmtime-internal-winch",
  "wat",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "38.0.4"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78587abe085a44a13c90fa16fea6db014e9883e627a7044d7f0cb397ad08d1da"
+checksum = "d7da3dcce82a7e784121c19c8c9c5f69a743088264ff5212033e4a1f1b9dfaaf"
 dependencies = [
  "anyhow",
  "cpp_demangle",
+ "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-entity",
  "gimli",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "log",
- "object",
+ "object 0.39.1",
  "postcard",
  "rustc-demangle",
  "semver 1.0.28",
  "serde",
  "serde_derive",
+ "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.239.0",
- "wasmparser 0.239.0",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
  "wasmprinter",
  "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "38.0.4"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78fb9299e318b0af3efb75d88321515a20a5ccb040bcde1f0f7d46d656fa8fef"
+checksum = "ef87f84d976e2f98a541eaf5837df0424e2039837fc20bd6cd4b4b5a322939c0"
 dependencies = [
- "anyhow",
  "base64",
  "directories-next",
  "log",
  "postcard",
- "rustix 1.1.4",
+ "rustix",
  "serde",
  "serde_derive",
- "sha2",
- "toml",
- "windows-sys 0.60.2",
+ "sha2 0.10.9",
+ "toml 0.9.12+spec-1.1.0",
+ "wasmtime-environ",
+ "windows-sys 0.61.2",
  "zstd",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "38.0.4"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d843bb444f2d1509ea9304ad749242d1fa5de95cde67665bfcdcafa0f360925c"
+checksum = "86991f201391afc1504e4fc363dc29b66f92af0287b4ac2efc3c0b0c19435eeb"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -5342,22 +5977,33 @@ dependencies = [
  "syn 2.0.117",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.239.0",
+ "wit-parser 0.248.0",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "38.0.4"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801ee1a80ab66f065a88c6a62f2d495d5540d027b366757c6a53e9c42f153aef"
+checksum = "47fda091250d7ab839ea51e4d98190b6eee37e9de4ab2462e8fe8465369c1986"
+
+[[package]]
+name = "wasmtime-internal-core"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bdae4b55b15a23d774b15f6e7cd90ae0d0aa17c47c12b4db098b3dd11ba9d58"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
+ "libm",
+ "serde",
+]
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "38.0.4"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb50f1c50365c32e557266ca85acdf77696c44a3f98797ba6af58cebc6d6d1e"
+checksum = "5773b36b87566239b020f1d01aa753a35626df85030485e40e36fc42a97acf4f"
 dependencies = [
- "anyhow",
  "cfg-if",
  "cranelift-codegen",
  "cranelift-control",
@@ -5367,90 +6013,75 @@ dependencies = [
  "gimli",
  "itertools 0.14.0",
  "log",
- "object",
+ "object 0.39.1",
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.239.0",
+ "wasmparser 0.248.0",
  "wasmtime-environ",
- "wasmtime-internal-math",
+ "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "38.0.4"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9308cdb17f8d51e3164185616d809e28c29a6515c03b9dd95c89436b71f6d154"
+checksum = "402cce4bba4c8c92a6fbaff39a6b23f8aa626d64b218ecf6dd3eeee8705cf096"
 dependencies = [
- "anyhow",
  "cc",
  "cfg-if",
  "libc",
- "rustix 1.1.4",
+ "rustix",
+ "wasmtime-environ",
  "wasmtime-internal-versioned-export-macros",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "38.0.4"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c9b63a22bf2a8b6a149a41c6768bc17a8b2e3288a249cb8216987fbd7128e81"
+checksum = "8b426a5d0ec9c11a1a4525ed4e973b7caf40223b6d392588bb9f6468e4ae9d29"
 dependencies = [
  "cc",
- "object",
- "rustix 1.1.4",
+ "object 0.39.1",
+ "rustix",
  "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "38.0.4"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb8e042b6e3de2f3d708279f89f50b4b9aa1b9bab177300cdffb0ffcd2816df5"
+checksum = "8a312ba8bb77955dcd44294a223e7f124c3071ff966583d385d3f6a4639c62e3"
 dependencies = [
- "anyhow",
  "cfg-if",
  "libc",
- "windows-sys 0.60.2",
+ "wasmtime-internal-core",
+ "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "wasmtime-internal-math"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1f0674f38cd7d014eb1a49ea1d1766cca1a64459e8856ee118a10005302e16"
-dependencies = [
- "libm",
-]
-
-[[package]]
-name = "wasmtime-internal-slab"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb24b7535306713e7a250f8b71e35f05b6a5031bf9c3ed7330c308e899cbe7d3"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "38.0.4"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d5a80e2623a49cb8e8c419542337b8fe0260b162c40dcc201080a84cbe9b7c"
+checksum = "4a62ad422ee3cbf1e87c2242dc0717a01c7a5878fbc3a68abc4b4d2fff3e85e1"
 dependencies = [
- "anyhow",
  "cfg-if",
  "cranelift-codegen",
  "log",
- "object",
+ "object 0.39.1",
+ "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "38.0.4"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e277f734b9256359b21517c3b0c26a2a9de6c53a51b670ae55cdcde548bf4e"
+checksum = "2c660c5b091648cffdd84a34dc24ffcdb9d027f9048fe7bd5e01896adbd0935f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5459,17 +6090,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "38.0.4"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4dc9333737142f6ece4369c8bcdda03a11edbd43d8fbd3e15004c194b9b743"
+checksum = "d2aceb92b48b6e3a5cc2a05ab7a2dcb565eaf86fb870d04664b7f12cf9bba39a"
 dependencies = [
- "anyhow",
  "cranelift-codegen",
  "gimli",
  "log",
- "object",
+ "object 0.39.1",
  "target-lexicon",
- "wasmparser 0.239.0",
+ "wasmparser 0.248.0",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
@@ -5477,38 +6107,37 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "38.0.4"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f758625553fe33fdce0713f63bb7784c4f5fecb7f7cd4813414519ec24b6a4c"
+checksum = "ce382df367ad2a2d48e139b191dbca3329f7232a43057dc9efc889dac54f1b0b"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "heck 0.5.0",
+ "heck",
  "indexmap 2.14.0",
- "wit-parser 0.239.0",
+ "wit-parser 0.248.0",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "38.0.4"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55abdad51f519217927f45eaae73ca0cd46eb76688628a49784f41b5b19b8ed6"
+checksum = "fb1e92a304eaafd672718011c69084041db74fa0fcc3532c5920f492c557b721"
 dependencies = [
- "anyhow",
  "async-trait",
  "bitflags 2.11.1",
  "bytes",
  "cap-fs-ext",
  "cap-net-ext",
- "cap-rand",
  "cap-std",
  "cap-time-ext",
+ "cfg-if",
  "fs-set-times",
  "futures",
  "io-extras",
  "io-lifetimes",
- "rustix 1.1.4",
- "system-interface",
+ "rand 0.10.1",
+ "rustix",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5516,19 +6145,19 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi-io",
  "wiggle",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "38.0.4"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489d7f6e8ea0c4842e31b01721527a825f55ae73a2fa095d8b3f7ddbd75e3661"
+checksum = "8e0013e1f37d2e0e1b030fa186972f6f5819f69814bb07d3b6d3cab0c40b50e2"
 dependencies = [
- "anyhow",
  "async-trait",
  "bytes",
  "futures",
+ "tracing",
  "wasmtime",
 ]
 
@@ -5580,27 +6209,75 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
+name = "wezterm-bidi"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
 dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
+ "log",
+ "wezterm-dynamic",
 ]
 
 [[package]]
-name = "which"
-version = "7.0.3"
+name = "wezterm-blob-leases"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
- "either",
- "env_home",
- "rustix 1.1.4",
- "winsafe",
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float 4.6.0",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -5613,6 +6290,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wide"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7714cd0430a663154667c74da5d09325c2387695bee18b3f7f72825aa3693a"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5620,38 +6307,37 @@ checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "wiggle"
-version = "38.0.4"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ee0c6dd73bdf0aff4404059bdc24ca61ad92056d20f4e59b8b0780789cafb4"
+checksum = "f7c048e5d47058ff8b60cef771dd6276f2cf4508bc7f604b93c8d5d643ad41fc"
 dependencies = [
- "anyhow",
- "async-trait",
  "bitflags 2.11.1",
  "thiserror 2.0.18",
  "tracing",
  "wasmtime",
+ "wasmtime-environ",
  "wiggle-macro",
 ]
 
 [[package]]
 name = "wiggle-generate"
-version = "38.0.4"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e415549583fd492ccab881076fa5c41590362d3b5e99df793f619d67333c97b"
+checksum = "3b867ae624c2006976985444321d429ee2d0c6784ca5c6e45bc140c48141bb0c"
 dependencies = [
- "anyhow",
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+ "wasmtime-environ",
  "witx",
 ]
 
 [[package]]
 name = "wiggle-macro"
-version = "38.0.4"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a533b4fdc593bf9c4bf52ae0b3a126f15babfb25fce03bfe0bcc84e1172222"
+checksum = "463d6d4c0c100180fdfc586d555ed1c22376114944841629cff0d746666e30a4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5692,11 +6378,10 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "38.0.4"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c0bb17ae9bf89ebc74512150e6ee0a27b1eac5ff3b54d8cec264f4b4255022d"
+checksum = "3128bd53313b132e8737d7d318edbc438bab1abe525ac037bbf9857839e717e2"
 dependencies = [
- "anyhow",
  "cranelift-assembler-x64",
  "cranelift-codegen",
  "gimli",
@@ -5704,29 +6389,10 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.239.0",
+ "wasmparser 0.248.0",
  "wasmtime-environ",
+ "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
- "wasmtime-internal-math",
-]
-
-[[package]]
-name = "windows"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
-dependencies = [
- "windows-core 0.52.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5790,24 +6456,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -5831,21 +6479,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5883,12 +6516,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5901,12 +6528,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5916,12 +6537,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5949,12 +6564,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5964,12 +6573,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5985,12 +6588,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6000,12 +6597,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6024,9 +6615,6 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"
@@ -6036,21 +6624,6 @@ checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "winreg"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "winx"
@@ -6084,7 +6657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "wit-parser 0.244.0",
 ]
 
@@ -6095,7 +6668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
@@ -6140,24 +6713,6 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.239.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c92c939d667b7bf0c6bf2d1f67196529758f99a2a45a3355cc56964fd5315d"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver 1.0.28",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.239.0",
-]
-
-[[package]]
-name = "wit-parser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
@@ -6172,6 +6727,25 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "247ad505da2915a082fe13204c5ba8788425aea1de54f43b284818cf82637856"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver 1.0.28",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
@@ -6235,9 +6809,9 @@ dependencies = [
 
 [[package]]
 name = "yrs"
-version = "0.21.3"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81de5913bca29f43a1d12ca92a7b39a2945e9420e01602a7563917c7bfc60f70"
+checksum = "89512f2d869f9947e1c58d57ef86c8f4ca1b1e8ccf24d6e1ff8c7cdbd67d54df"
 dependencies = [
  "arc-swap",
  "async-lock",
@@ -6248,7 +6822,7 @@ dependencies = [
  "serde_json",
  "smallstr",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-rust-version = "1.88"
+rust-version = "1.95"
 license = "MIT"
 authors = ["Avelino <avelinorun@gmail.com>"]
 repository = "https://github.com/avelino/outl"
@@ -20,10 +20,10 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Internal crates
-outl-core = { path = "crates/outl-core", version = "0.1.0" }
-outl-md = { path = "crates/outl-md", version = "0.1.0" }
-outl-exec = { path = "crates/outl-exec", version = "0.1.0" }
-outl-tui = { path = "crates/outl-tui", version = "0.1.0" }
+outl-core = { path = "crates/outl-core", version = "0.2.0" }
+outl-md = { path = "crates/outl-md", version = "0.2.0" }
+outl-exec = { path = "crates/outl-exec", version = "0.2.0" }
+outl-tui = { path = "crates/outl-tui", version = "0.2.0" }
 
 # IDs and time
 ulid = { version = "1", features = ["serde"] }
@@ -31,11 +31,11 @@ ulid = { version = "1", features = ["serde"] }
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-bincode = "1"
-toml = "0.8"
+bincode = { version = "2", features = ["serde"] }
+toml = "1.1"
 
 # Errors
-thiserror = "1"
+thiserror = "2"
 anyhow = "1"
 
 # Logging
@@ -43,24 +43,24 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # CRDT
-yrs = "0.21"
+yrs = "0.26"
 
 # Storage
-rusqlite = { version = "0.32", features = ["bundled"] }
+rusqlite = { version = "0.39", features = ["bundled"] }
 
 # Markdown
-comrak = { version = "0.29", default-features = false }
+comrak = { version = "0.52", default-features = false }
 
 # TUI
-ratatui = "0.28"
-crossterm = "0.28"
+ratatui = "0.30"
+crossterm = "0.29"
 
 # CLI
 clap = { version = "4", features = ["derive"] }
 
 # Filesystem
-notify = "6"
-notify-debouncer-full = "0.3"
+notify = "8"
+notify-debouncer-full = "0.7"
 walkdir = "2"
 fs2 = "0.4"
 
@@ -68,7 +68,7 @@ fs2 = "0.4"
 parking_lot = "0.12"
 
 # Misc
-sha2 = "0.10"
+sha2 = "0.11"
 hex = "0.4"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 

--- a/crates/outl-cli/src/cmd/serve.rs
+++ b/crates/outl-cli/src/cmd/serve.rs
@@ -3,7 +3,7 @@
 use crate::sync_engine::{reconcile_dir, reconcile_md, ReconcileReport};
 use crate::workspace_layout::{is_workspace_md, read_config, Paths};
 use anyhow::{Context, Result};
-use notify::{RecursiveMode, Watcher};
+use notify::RecursiveMode;
 use notify_debouncer_full::new_debouncer;
 use outl_core::hlc::HlcGenerator;
 use outl_core::storage::SqliteStorage;
@@ -48,11 +48,10 @@ pub fn run(path: &Path, once: bool) -> Result<()> {
     })
     .with_context(|| "creating file watcher")?;
 
-    let watcher = debouncer.watcher();
-    watcher
+    debouncer
         .watch(&paths.pages, RecursiveMode::NonRecursive)
         .with_context(|| format!("watching {}", paths.pages.display()))?;
-    watcher
+    debouncer
         .watch(&paths.journals, RecursiveMode::NonRecursive)
         .with_context(|| format!("watching {}", paths.journals.display()))?;
 

--- a/crates/outl-core/src/storage/sqlite.rs
+++ b/crates/outl-core/src/storage/sqlite.rs
@@ -107,11 +107,17 @@ impl SqliteStorage {
 }
 
 fn serialize_op(op: &Op) -> Result<Vec<u8>, StorageError> {
-    bincode::serialize(op).map_err(|e| StorageError::Serialize(e.to_string()))
+    // `legacy()` keeps wire-compat with bincode 1.x (fixed-width ints,
+    // little-endian, no limit) so existing op logs on disk stay readable
+    // after the 1.x → 2.x bump.
+    bincode::serde::encode_to_vec(op, bincode::config::legacy())
+        .map_err(|e| StorageError::Serialize(e.to_string()))
 }
 
 fn deserialize_op(bytes: &[u8]) -> Result<Op, StorageError> {
-    bincode::deserialize(bytes).map_err(|e| StorageError::Serialize(e.to_string()))
+    let (op, _) = bincode::serde::decode_from_slice(bytes, bincode::config::legacy())
+        .map_err(|e| StorageError::Serialize(e.to_string()))?;
+    Ok(op)
 }
 
 fn op_kind(op: &Op) -> &'static str {

--- a/crates/outl-core/tests/convergence.rs
+++ b/crates/outl-core/tests/convergence.rs
@@ -22,7 +22,7 @@ fn three_replicas_three_orders_converge() {
     let n3 = NodeId::new();
     let root = NodeId::root();
 
-    let ops = vec![
+    let ops = [
         op_at(actor_a, 1, 0, create_op(n1, root, pos("a"))),
         op_at(actor_b, 2, 0, create_op(n2, root, pos("b"))),
         op_at(actor_c, 3, 0, create_op(n3, n1, pos("a"))),

--- a/crates/outl-exec/Cargo.toml
+++ b/crates/outl-exec/Cargo.toml
@@ -44,18 +44,17 @@ tracing.workspace = true
 # Python/Lua out of the box.
 steel-core = { version = "0.8", optional = true }
 boa_engine = { version = "0.21", optional = true }
-rustpython-vm = { version = "0.4", optional = true, default-features = false, features = ["compiler"] }
-mlua = { version = "0.10", optional = true, features = ["lua54", "vendored"] }
+rustpython-vm = { version = "0.5", optional = true, default-features = false, features = ["compiler"] }
+mlua = { version = "0.11", optional = true, features = ["lua54", "vendored"] }
 
 # Source hashing (auto-run cache key, sidecar content hash). Used
 # unconditionally; cheap dep.
 sha2 = { workspace = true }
 
-# WASM sandbox stack (gated behind `wasm`). wasmtime 38 is the highest
-# release that still supports rustc 1.88 (our workspace MSRV).
-wasmtime = { version = "38", optional = true }
-wasmtime-wasi = { version = "38", optional = true }
-dirs = { version = "5", optional = true }
+# WASM sandbox stack (gated behind `wasm`). Workspace MSRV is rust 1.95.
+wasmtime = { version = "45", optional = true }
+wasmtime-wasi = { version = "45", optional = true }
+dirs = { version = "6", optional = true }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/outl-exec/src/runtimes/python.rs
+++ b/crates/outl-exec/src/runtimes/python.rs
@@ -67,7 +67,7 @@ impl Runtime for PythonRuntime {
                     .call_method(&captured, "__getitem__", (idx,))
                     .map_err(|e| pyerr_string(vm, e))?;
                 let s = item.str(vm).map_err(|e| pyerr_string(vm, e))?;
-                buf.push_str(s.as_str());
+                buf.push_str(s.to_str().unwrap_or_default());
             }
             Ok(buf)
         });

--- a/crates/outl-exec/src/runtimes/python.rs
+++ b/crates/outl-exec/src/runtimes/python.rs
@@ -67,7 +67,15 @@ impl Runtime for PythonRuntime {
                     .call_method(&captured, "__getitem__", (idx,))
                     .map_err(|e| pyerr_string(vm, e))?;
                 let s = item.str(vm).map_err(|e| pyerr_string(vm, e))?;
-                buf.push_str(s.to_str().unwrap_or_default());
+                // Surface non-UTF-8 conversion failures instead of
+                // silently dropping bytes from stdout. Python 3 strs
+                // are notionally UTF-8, but a buggy/native extension
+                // could feed in something we can't decode — better to
+                // fail loudly than to ship truncated output.
+                let chunk = s
+                    .to_str()
+                    .ok_or_else(|| PyErrString("python stdout has non-UTF-8 bytes".into()))?;
+                buf.push_str(chunk);
             }
             Ok(buf)
         });

--- a/crates/outl-exec/src/wasm/cache.rs
+++ b/crates/outl-exec/src/wasm/cache.rs
@@ -48,7 +48,12 @@ pub fn cache_path_for_source(language: &str, source: &str) -> Option<PathBuf> {
     std::fs::create_dir_all(&dir).ok()?;
     let mut hasher = Sha256::new();
     hasher.update(source.as_bytes());
-    let hash = format!("{:x}", hasher.finalize());
+    let digest = hasher.finalize();
+    let mut hash = String::with_capacity(digest.len() * 2);
+    for b in digest {
+        use std::fmt::Write;
+        let _ = write!(hash, "{b:02x}");
+    }
     dir.push(format!("{hash}.wasm"));
     Some(dir)
 }

--- a/crates/outl-exec/src/wasm/engine.rs
+++ b/crates/outl-exec/src/wasm/engine.rs
@@ -45,7 +45,6 @@ pub fn make_engine() -> Engine {
     let mut cfg = Config::new();
     cfg.consume_fuel(true);
     cfg.epoch_interruption(true);
-    cfg.async_support(false);
     cfg.cranelift_opt_level(OptLevel::Speed);
     // WASI requires multi-memory and bulk-memory; both enabled by
     // default on recent wasmtime, but be explicit.

--- a/crates/outl-md/Cargo.toml
+++ b/crates/outl-md/Cargo.toml
@@ -29,7 +29,7 @@ walkdir = { workspace = true }
 proptest = { workspace = true }
 tempfile = { workspace = true }
 outl-core = { workspace = true }
-criterion = { version = "0.5", default-features = false, features = ["html_reports"] }
+criterion = { version = "0.8", default-features = false, features = ["html_reports"] }
 
 [[bench]]
 name = "index"

--- a/crates/outl-md/benches/index.rs
+++ b/crates/outl-md/benches/index.rs
@@ -13,8 +13,9 @@
 //!
 //! HTML reports land in `target/criterion/`.
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use outl_md::index::WorkspaceIndex;
+use std::hint::black_box;
 
 #[path = "common.rs"]
 mod common;

--- a/crates/outl-md/benches/parse.rs
+++ b/crates/outl-md/benches/parse.rs
@@ -9,8 +9,9 @@
 //! cargo bench -p outl-md --bench parse
 //! ```
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use outl_md::parse::parse;
+use std::hint::black_box;
 
 #[path = "common.rs"]
 mod common;

--- a/crates/outl-md/src/index.rs
+++ b/crates/outl-md/src/index.rs
@@ -38,6 +38,12 @@ pub struct PageEntry {
 }
 
 /// One backlink — a block in another page that references this slug.
+///
+/// Carries the full source `OutlineNode` (including its children
+/// subtree) so the UI can render the referencing block in context —
+/// not just as a truncated snippet. Editing surfaces resolve the
+/// target block by descending into `source_block` along an extra
+/// sub-path relative to `source_block_path`.
 #[derive(Debug, Clone)]
 pub struct Backlink {
     /// Slug of the page containing the reference.
@@ -45,15 +51,20 @@ pub struct Backlink {
     /// Title of the source page.
     pub source_title: String,
     /// Icon of the source page (if any) — propagated so backlink
-    /// panels can render the same `<icon> <title>` shape every other
+    /// surfaces can render the same `<icon> <title>` shape every other
     /// surface uses.
     pub source_icon: Option<String>,
     /// Filesystem path of the source.
     pub source_path: PathBuf,
-    /// Block index inside the source page (DFS preorder).
-    pub block_index: usize,
-    /// Block text snippet (for display).
-    pub snippet: String,
+    /// DFS path of the referencing block inside the source page's AST.
+    /// Combined with a sub-path inside `source_block`, this lets the
+    /// TUI/editor locate the exact node to mutate when the user edits
+    /// a backlink in place.
+    pub source_block_path: Vec<usize>,
+    /// The referencing `OutlineNode` itself, including children.
+    /// Cloned so backlink consumers don't need to re-read the source
+    /// page from disk to render context.
+    pub source_block: OutlineNode,
 }
 
 /// Full workspace index.
@@ -152,8 +163,8 @@ impl WorkspaceIndex {
             let Some(entry) = idx.pages.get(slug).cloned() else {
                 continue;
             };
-            let mut block_idx = 0usize;
-            collect_backlinks_recursive(&parsed.blocks, &mut block_idx, &entry, &mut idx);
+            let mut path_stack: Vec<usize> = Vec::new();
+            collect_backlinks_recursive(&parsed.blocks, &mut path_stack, &entry, &mut idx);
         }
 
         idx
@@ -190,6 +201,147 @@ impl WorkspaceIndex {
             .unwrap_or(&[])
     }
 
+    /// Re-index a single page in place — replacement for the global
+    /// scan when only one page changed.
+    ///
+    /// Removes every backlink whose source was this slug, walks the
+    /// new AST to emit fresh backlinks, and refreshes the `PageEntry`
+    /// metadata (title/icon). `is_journal` is inferred from the
+    /// parent directory of `path` (`journals/...` vs anything else).
+    ///
+    /// Roughly `O(blocks_in_this_page)` — orders of magnitude cheaper
+    /// than `build`, which walks every `.md` in the workspace. Use
+    /// this on every page save so the index stays fresh without
+    /// paying for a full rescan.
+    pub fn patch_page(&mut self, path: &Path, page: &crate::parse::ParsedPage) {
+        let Some(slug) = path.file_stem().and_then(|s| s.to_str()) else {
+            return;
+        };
+        let slug = slug.to_string();
+        let is_journal = path
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            == Some("journals");
+
+        let title = page
+            .properties
+            .iter()
+            .find(|(k, _)| k == "title")
+            .map(|(_, v)| v.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| slug.clone());
+        let icon = page
+            .properties
+            .iter()
+            .find(|(k, _)| k == "icon")
+            .map(|(_, v)| v.trim().to_string())
+            .filter(|s| !s.is_empty());
+
+        // Drop every backlink that used to come from this page —
+        // we'll re-emit the fresh set below.
+        for list in self.backlinks.values_mut() {
+            list.retain(|bl| bl.source_slug != slug);
+        }
+        self.backlinks.retain(|_, v| !v.is_empty());
+
+        // Forget the page's previous `title -> slug` mapping in case
+        // the title changed (otherwise a stale alias would shadow the
+        // new one for `by_title` lookups).
+        self.title_to_slug.retain(|_, s| s != &slug);
+
+        let entry = PageEntry {
+            path: path.to_path_buf(),
+            slug: slug.clone(),
+            title: title.clone(),
+            icon,
+            is_journal,
+        };
+        self.pages.insert(slug.clone(), entry.clone());
+        self.title_to_slug.insert(title, slug);
+
+        let mut path_stack: Vec<usize> = Vec::new();
+        collect_backlinks_recursive(&page.blocks, &mut path_stack, &entry, self);
+    }
+
+    /// Drop a page from the index entirely. Use when a `.md` is
+    /// deleted on disk. Removes the `PageEntry`, its title alias, and
+    /// every backlink whose source was this slug.
+    pub fn remove_page(&mut self, slug: &str) {
+        self.pages.remove(slug);
+        self.title_to_slug.retain(|_, s| s != slug);
+        for list in self.backlinks.values_mut() {
+            list.retain(|bl| bl.source_slug != slug);
+        }
+        self.backlinks.retain(|_, v| !v.is_empty());
+    }
+
+    /// Re-clone the cached `source_block` of every backlink whose
+    /// `source_path` matches, pulling fresh content from `source_page`.
+    ///
+    /// Used as an **optimistic** refresh after the TUI mutates the
+    /// source page in memory (e.g. structural ops triggered from
+    /// inside a backlink). Lets the next frame show the new tree
+    /// without paying for a full workspace rebuild. The next natural
+    /// rebuild reconverges with disk truth.
+    ///
+    /// Backlinks whose `source_block_path` no longer resolves (e.g.
+    /// the referencing block was moved or deleted) keep their stale
+    /// node — the canonical fix happens when the index rebuilds.
+    pub fn refresh_backlinks_from_source(
+        &mut self,
+        source_path: &Path,
+        source_page: &crate::parse::ParsedPage,
+    ) {
+        for list in self.backlinks.values_mut() {
+            for bl in list.iter_mut() {
+                if bl.source_path != source_path {
+                    continue;
+                }
+                if let Some(node) = walk_node(&source_page.blocks, &bl.source_block_path) {
+                    bl.source_block = node.clone();
+                }
+            }
+        }
+    }
+
+    /// Apply `new_text` to every cached `source_block` whose `(source_path,
+    /// absolute_block_path)` matches `(source_path, target_path)`.
+    ///
+    /// `target_path` is interpreted as the DFS path inside the source
+    /// page's AST — i.e. `source_block_path` (where the referencing
+    /// block lives) concatenated with the sub-path *inside* that block
+    /// (zero or more steps).
+    ///
+    /// This is an **optimistic** in-memory patch used by the TUI to
+    /// reflect a backlink edit instantly while the actual disk write
+    /// and reconcile happen out of the critical path. The next full
+    /// index rebuild reconverges this with disk truth — until then,
+    /// every backlink list that references the same source block
+    /// stays consistent because they all carry their own clone of the
+    /// node, and this method walks them all.
+    pub fn patch_backlink_text(
+        &mut self,
+        source_path: &Path,
+        target_path: &[usize],
+        new_text: &str,
+    ) {
+        for list in self.backlinks.values_mut() {
+            for bl in list.iter_mut() {
+                if bl.source_path != source_path {
+                    continue;
+                }
+                if !target_path.starts_with(&bl.source_block_path) {
+                    continue;
+                }
+                let tail = &target_path[bl.source_block_path.len()..];
+                if let Some(node) = walk_node_mut(&mut bl.source_block, tail) {
+                    node.text = new_text.to_string();
+                }
+            }
+        }
+    }
+
     /// Titles starting with `prefix` (case-insensitive), best-effort
     /// for autocomplete. Returns at most `limit` results sorted by
     /// title length (shorter first).
@@ -206,30 +358,48 @@ impl WorkspaceIndex {
     }
 }
 
+fn walk_node_mut<'a>(root: &'a mut OutlineNode, path: &[usize]) -> Option<&'a mut OutlineNode> {
+    let mut node = root;
+    for &i in path {
+        node = node.children.get_mut(i)?;
+    }
+    Some(node)
+}
+
+fn walk_node<'a>(blocks: &'a [OutlineNode], path: &[usize]) -> Option<&'a OutlineNode> {
+    let mut current = blocks;
+    let mut node: Option<&OutlineNode> = None;
+    for &i in path {
+        let n = current.get(i)?;
+        node = Some(n);
+        current = &n.children;
+    }
+    node
+}
+
 fn collect_backlinks_recursive(
     blocks: &[OutlineNode],
-    cursor: &mut usize,
+    path_stack: &mut Vec<usize>,
     source: &PageEntry,
     idx: &mut WorkspaceIndex,
 ) {
-    for b in blocks {
-        let block_index = *cursor;
-        let snippet = b.text.clone();
+    for (i, b) in blocks.iter().enumerate() {
+        path_stack.push(i);
+        // A block may reference several pages/tags — but we record one
+        // backlink per *unique* target slug so a page referenced twice
+        // in the same block doesn't show up duplicated.
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
         for tok in tokenize(&b.text) {
-            match tok {
-                InlineTok::PageRef { name } => {
-                    let target_slug = slugify(name);
-                    push_backlink(idx, &target_slug, source, block_index, &snippet);
-                }
-                InlineTok::Tag { name } => {
-                    let target_slug = slugify(name);
-                    push_backlink(idx, &target_slug, source, block_index, &snippet);
-                }
-                _ => {}
+            let target_slug = match tok {
+                InlineTok::PageRef { name } | InlineTok::Tag { name } => slugify(name),
+                _ => continue,
+            };
+            if seen.insert(target_slug.clone()) {
+                push_backlink(idx, &target_slug, source, path_stack, b);
             }
         }
-        *cursor += 1;
-        collect_backlinks_recursive(&b.children, cursor, source, idx);
+        collect_backlinks_recursive(&b.children, path_stack, source, idx);
+        path_stack.pop();
     }
 }
 
@@ -237,8 +407,8 @@ fn push_backlink(
     idx: &mut WorkspaceIndex,
     target_slug: &str,
     source: &PageEntry,
-    block_index: usize,
-    snippet: &str,
+    source_block_path: &[usize],
+    source_block: &OutlineNode,
 ) {
     // Skip self-references: a page linking to itself is noise.
     if target_slug == source.slug {
@@ -252,8 +422,8 @@ fn push_backlink(
             source_title: source.title.clone(),
             source_icon: source.icon.clone(),
             source_path: source.path.clone(),
-            block_index,
-            snippet: snippet.to_string(),
+            source_block_path: source_block_path.to_vec(),
+            source_block: source_block.clone(),
         });
 }
 
@@ -273,6 +443,75 @@ mod tests {
             fs::write(full, content).unwrap();
         }
         dir
+    }
+
+    #[test]
+    fn patch_page_replaces_backlinks_for_that_slug_only() {
+        // Initial state: projeto.md and journal both reference Avelino.
+        let dir = write_workspace(&[
+            ("pages/avelino.md", "title:: Avelino\n\n- author\n"),
+            (
+                "pages/projeto.md",
+                "title:: Projeto\n\n- led by [[Avelino]]\n",
+            ),
+            ("journals/2026-05-24.md", "- meeting with [[Avelino]]\n"),
+        ]);
+        let mut idx = WorkspaceIndex::build(dir.path());
+        assert_eq!(idx.backlinks("avelino").len(), 2);
+
+        // User rewrites projeto.md so it no longer references Avelino
+        // and now references "Other Page" instead. patch_page must:
+        //   1. drop projeto's old backlink to Avelino
+        //   2. emit a new backlink from projeto to other-page
+        // ...without touching the journal's backlink.
+        let new_md = "title:: Projeto\n\n- led by [[Other Page]]\n";
+        let new_page = crate::parse::parse(new_md);
+        let proj_path = dir.path().join("pages/projeto.md");
+        idx.patch_page(&proj_path, &new_page);
+
+        let avelino_bls = idx.backlinks("avelino");
+        assert_eq!(avelino_bls.len(), 1, "journal backlink should survive");
+        assert_eq!(avelino_bls[0].source_slug, "2026-05-24");
+
+        let other_bls = idx.backlinks("other-page");
+        assert_eq!(other_bls.len(), 1);
+        assert_eq!(other_bls[0].source_slug, "projeto");
+    }
+
+    #[test]
+    fn patch_page_updates_title_and_icon() {
+        let dir = write_workspace(&[("pages/x.md", "title:: Old Title\nicon:: 🦀\n\n- body\n")]);
+        let mut idx = WorkspaceIndex::build(dir.path());
+        assert_eq!(idx.by_slug("x").unwrap().title, "Old Title");
+        assert_eq!(idx.by_slug("x").unwrap().icon.as_deref(), Some("🦀"));
+
+        let new_page = crate::parse::parse("title:: New Title\nicon:: 🚀\n\n- body\n");
+        idx.patch_page(&dir.path().join("pages/x.md"), &new_page);
+
+        let entry = idx.by_slug("x").unwrap();
+        assert_eq!(entry.title, "New Title");
+        assert_eq!(entry.icon.as_deref(), Some("🚀"));
+        // by_title should follow the new title and forget the old one.
+        assert!(idx.by_title("Old Title").is_none());
+        assert_eq!(idx.by_title("New Title").unwrap().slug, "x");
+    }
+
+    #[test]
+    fn remove_page_drops_entry_and_its_backlinks() {
+        let dir = write_workspace(&[
+            ("pages/avelino.md", "title:: Avelino\n\n- author\n"),
+            (
+                "pages/projeto.md",
+                "title:: Projeto\n\n- led by [[Avelino]]\n",
+            ),
+        ]);
+        let mut idx = WorkspaceIndex::build(dir.path());
+        assert_eq!(idx.backlinks("avelino").len(), 1);
+
+        idx.remove_page("projeto");
+        assert!(idx.by_slug("projeto").is_none());
+        assert!(idx.by_title("Projeto").is_none());
+        assert!(idx.backlinks("avelino").is_empty());
     }
 
     #[test]
@@ -380,6 +619,59 @@ mod tests {
         let idx = WorkspaceIndex::build(dir.path());
         let entry = idx.by_slug("2026-05-24").unwrap();
         assert!(entry.is_journal);
+    }
+
+    #[test]
+    fn source_block_carries_text_and_children() {
+        // The Backlink struct holds the full referencing block, not a
+        // truncated snippet. The TUI relies on `source_block.children`
+        // to draw nested context.
+        let dir = write_workspace(&[
+            ("pages/avelino.md", "title:: Avelino\n\n- author\n"),
+            (
+                "pages/projeto.md",
+                "title:: Projeto\n\n- led by [[Avelino]]\n  - milestone A\n  - milestone B\n",
+            ),
+        ]);
+        let idx = WorkspaceIndex::build(dir.path());
+        let bls = idx.backlinks("avelino");
+        assert_eq!(bls.len(), 1);
+        assert_eq!(bls[0].source_block.text, "led by [[Avelino]]");
+        assert_eq!(bls[0].source_block.children.len(), 2);
+        assert_eq!(bls[0].source_block.children[0].text, "milestone A");
+        assert_eq!(bls[0].source_block.children[1].text, "milestone B");
+    }
+
+    #[test]
+    fn source_block_path_points_to_referencing_block() {
+        // A backlink coming from a nested block records the DFS path
+        // [parent_idx, child_idx] so the editor can navigate straight
+        // to the right node without re-walking the AST.
+        let dir = write_workspace(&[
+            ("pages/avelino.md", "title:: Avelino\n\n- author\n"),
+            (
+                "pages/projeto.md",
+                "title:: Projeto\n\n- root block\n  - nested ref to [[Avelino]]\n",
+            ),
+        ]);
+        let idx = WorkspaceIndex::build(dir.path());
+        let bls = idx.backlinks("avelino");
+        assert_eq!(bls.len(), 1);
+        assert_eq!(bls[0].source_block_path, vec![0, 0]);
+        assert_eq!(bls[0].source_block.text, "nested ref to [[Avelino]]");
+    }
+
+    #[test]
+    fn block_with_repeated_reference_only_emits_one_backlink() {
+        let dir = write_workspace(&[
+            ("pages/avelino.md", "title:: Avelino\n\n- author\n"),
+            (
+                "pages/projeto.md",
+                "title:: Projeto\n\n- [[Avelino]] and again [[Avelino]] same block\n",
+            ),
+        ]);
+        let idx = WorkspaceIndex::build(dir.path());
+        assert_eq!(idx.backlinks("avelino").len(), 1);
     }
 
     #[test]

--- a/crates/outl-md/src/slug.rs
+++ b/crates/outl-md/src/slug.rs
@@ -23,9 +23,7 @@ pub fn slugify(name: &str) -> String {
     let mut out = String::with_capacity(name.len());
     let mut prev_dash = true; // suppress leading '-'
     for ch in name.chars() {
-        let normalized = fold_char(ch);
-        if normalized.is_some() {
-            let n = normalized.unwrap();
+        if let Some(n) = fold_char(ch) {
             if n.is_ascii_alphanumeric() {
                 out.push(n.to_ascii_lowercase());
                 prev_dash = false;

--- a/crates/outl-tui/CLAUDE.md
+++ b/crates/outl-tui/CLAUDE.md
@@ -117,17 +117,28 @@ reconcile path; the sidecar `last_synced_hash` short-circuits no-ops.
 src/
 ├── main.rs              # binary entry (clap + outl_tui::run)
 ├── lib.rs               # exposes `run` so outl-cli can reuse the TUI
-├── app.rs               # state, mode, key handling, render, AST helpers
+├── app.rs               # thin re-export shim + cross-module tests
+├── state.rs             # plain data: App, Mode, Focus, Overlay, snapshots
+├── actions/             # impl App { ... } blocks, one per concern
+│   ├── lifecycle.rs     # load / save / external-edit polling / new
+│   ├── nav.rs           # page/journal jumps, cursor, ref open, Focus-aware move
+│   ├── block.rs         # Insert mode, create/indent/outdent/delete blocks
+│   ├── history.rs       # undo / redo snapshots
+│   ├── visual.rs        # Visual mode + range ops
+│   ├── yank.rs          # yank register, paste
+│   ├── exec.rs          # run code block via outl_exec
+│   └── overlay.rs       # quick switcher, search, palette, autocomplete
+├── input.rs             # key → action routing
+├── view.rs              # render_app orchestrator; thin
+├── view/
+│   ├── inline.rs        # span-level markdown (highlight + pretty)
+│   ├── outline.rs       # outline rendering (render_outline, render_block, …)
+│   ├── overlays.rs      # every modal popup
+│   └── backlinks.rs     # inline backlinks section (below outline, ─ rule)
+├── outline_ops.rs       # pure AST helpers (flat_count, paths, flatten_backlink_subtree)
 ├── edit_buffer.rs       # cursor + chars; isolated, well-tested
-├── input.rs             # keymap documentation
 ├── editor.rs            # placeholder for phase 4 (block-level editor widgets)
-└── ui/
-    ├── pages.rs         # phase 3+ placeholder
-    ├── journal.rs       # phase 3+ placeholder
-    ├── outline.rs       # phase 3+ placeholder (logic lives in app::render_outline)
-    ├── tags.rs          # phase 3+ placeholder
-    ├── backlinks.rs     # phase 3+ placeholder
-    └── command.rs       # phase 3+ placeholder
+└── ui/                  # legacy placeholders; logic lives in view/
 ```
 
 ## Dependencies

--- a/crates/outl-tui/src/actions/block.rs
+++ b/crates/outl-tui/src/actions/block.rs
@@ -11,12 +11,26 @@ use crate::outline_ops::{
     insert_sibling_after, insert_sibling_before, node_at_path, node_at_path_mut, outdent_at_path,
     path_for_index, siblings_mut,
 };
-use crate::state::{App, Mode, DONE_PREFIX, TODO_PREFIX};
-use outl_md::parse::OutlineNode;
+use crate::state::{App, EditTarget, Focus, Mode, DONE_PREFIX, TODO_PREFIX};
+use outl_md::parse::{parse, OutlineNode, ParsedPage};
 
 impl App {
-    /// Enter Insert mode at the currently selected block (cursor at end).
+    /// Enter Insert mode at the currently focused block (cursor at end).
+    ///
+    /// Dispatches by `Focus`: outline blocks edit `App.page`; backlink
+    /// blocks load the source page from disk and edit it in place via
+    /// `EditTarget::SourcePage`.
     pub(crate) fn enter_insert(&mut self, at_start: bool) {
+        if let Focus::Backlink { .. } = self.focus.clone() {
+            self.enter_insert_backlink(at_start);
+            return;
+        }
+        self.enter_insert_outline(at_start);
+    }
+
+    /// Insert path for the current page. Mutations land on `app.page`
+    /// and commit through the usual `save()`.
+    fn enter_insert_outline(&mut self, at_start: bool) {
         if self.flat_len == 0 {
             // No blocks yet — create one and start editing.
             self.page.blocks.push(OutlineNode::default());
@@ -30,57 +44,294 @@ impl App {
             return;
         };
         let mut buf = EditBuffer::from_text(&node.text);
-        if at_start {
-            buf.move_home();
-        }
+        // Preserve the column the user was on in Normal mode (vim:
+        // `i` lands *at* the cursor, not at end of line). `I` still
+        // forces home via `at_start`. Clamp because `cursor_col` can
+        // sit one past the last char after `$`.
+        buf.cursor = if at_start {
+            0
+        } else {
+            self.cursor_col.min(buf.chars.len())
+        };
         self.mode = Mode::Insert {
+            target: EditTarget::CurrentPage,
             block_path: path,
             buffer: buf,
             original_text: node.text.clone(),
         };
     }
 
+    /// Insert path for a backlink block. Loads the source page fresh
+    /// from disk (the indexed copy may lag a beat), resolves the
+    /// absolute path inside that AST, and stashes both in the
+    /// `EditTarget::SourcePage` so `commit_insert` knows where to
+    /// write back.
+    fn enter_insert_backlink(&mut self, at_start: bool) {
+        let (source_path, abs_path) = {
+            let Focus::Backlink { idx, sub_path } = &self.focus else {
+                return;
+            };
+            let backlinks = self.index.backlinks(&self.current_slug());
+            let Some(bl) = backlinks.get(*idx) else {
+                return;
+            };
+            let mut full = bl.source_block_path.clone();
+            full.extend_from_slice(sub_path);
+            (bl.source_path.clone(), full)
+        };
+
+        // Authoritative read: don't trust the cached `source_block`
+        // — it might be stale relative to a recent disk write (e.g.
+        // `outl serve` reconciled in the background).
+        let Ok(text) = std::fs::read_to_string(&source_path) else {
+            self.status = format!("cannot read backlink source: {}", source_path.display());
+            return;
+        };
+        let source_page = parse(&text);
+        let Some(node) = node_at_path(&source_page.blocks, &abs_path) else {
+            self.status = "backlink source block missing — index may be stale".into();
+            return;
+        };
+        let original_text = node.text.clone();
+        let mut buf = EditBuffer::from_text(&original_text);
+        // Same vim convention as the outline path: `i` keeps the
+        // cursor where it was in Normal, `I` jumps home.
+        buf.cursor = if at_start {
+            0
+        } else {
+            self.cursor_col.min(buf.chars.len())
+        };
+        self.mode = Mode::Insert {
+            target: EditTarget::SourcePage {
+                path: source_path,
+                page: source_page,
+            },
+            block_path: abs_path,
+            buffer: buf,
+            original_text,
+        };
+    }
+
     /// Commit Insert: write buffer back into the AST and persist.
+    ///
+    /// Routes by `EditTarget`:
+    /// - `CurrentPage`: mutate `app.page`, snapshot undo, `save()`.
+    /// - `SourcePage`: mutate the loaded source AST and write it via
+    ///   `save_page_with(.., false)`. No undo snapshot — cross-page
+    ///   history would be confusing (undo here = revert change to
+    ///   another file you can't currently see). The in-memory index
+    ///   is patched optimistically so the next frame already shows
+    ///   the new text — no waiting for a workspace rebuild.
     pub(crate) fn commit_insert(&mut self) {
         if let Mode::Insert {
+            target,
             block_path,
             buffer,
             original_text,
         } = std::mem::replace(&mut self.mode, Mode::Normal)
         {
             let new_text = buffer.as_string();
-            if new_text != original_text {
-                // Only snapshot when the user actually changed something —
-                // pressing Esc without typing should not pollute history.
-                self.snapshot_for_undo();
-                if let Some(node) = node_at_path_mut(&mut self.page.blocks, &block_path) {
-                    node.text = new_text;
+            match target {
+                EditTarget::CurrentPage => {
+                    if new_text != original_text {
+                        // Only snapshot when the user actually changed
+                        // something — pressing Esc without typing
+                        // should not pollute history.
+                        self.snapshot_for_undo();
+                        if let Some(node) = node_at_path_mut(&mut self.page.blocks, &block_path) {
+                            node.text = new_text;
+                        }
+                        self.save();
+                    } else if let Some(node) = node_at_path_mut(&mut self.page.blocks, &block_path)
+                    {
+                        // Empty round-trip; restore exactly to be safe.
+                        node.text = original_text;
+                    }
                 }
-                self.save();
-            } else if let Some(node) = node_at_path_mut(&mut self.page.blocks, &block_path) {
-                // Empty round-trip; restore exactly to be safe.
-                node.text = original_text;
+                EditTarget::SourcePage { path, mut page } => {
+                    if new_text != original_text {
+                        if let Some(node) = node_at_path_mut(&mut page.blocks, &block_path) {
+                            node.text = new_text;
+                        }
+                        // Optimistic: patch every backlink that points
+                        // at this source page so the UI reflects the
+                        // edit *this frame*, not after the next index
+                        // rebuild finishes (which scans the whole
+                        // workspace and is the dominant cost).
+                        self.index.refresh_backlinks_from_source(&path, &page);
+                        self.save_page_with(&path, &page, false);
+                    }
+                    // No restore needed — `page` was a working copy
+                    // and is dropped here.
+                }
             }
         }
     }
 
     /// Abort Insert: throw away the buffer, leave AST unchanged.
     pub(crate) fn abort_insert(&mut self) {
-        if let Mode::Insert {
+        let Mode::Insert {
+            target,
             block_path,
             original_text,
             ..
         } = std::mem::replace(&mut self.mode, Mode::Normal)
+        else {
+            return;
+        };
+        // SourcePage: nothing to restore on `app.page` (we never
+        // mutated it). The working copy in `target.page` is just
+        // dropped.
+        if let (EditTarget::CurrentPage, Some(node)) =
+            (target, node_at_path_mut(&mut self.page.blocks, &block_path))
         {
-            if let Some(node) = node_at_path_mut(&mut self.page.blocks, &block_path) {
-                node.text = original_text;
-            }
+            node.text = original_text;
         }
+    }
+
+    /// Run an op on the source page of the focused backlink and persist.
+    ///
+    /// `f` receives the source AST (mutable) and the absolute path of
+    /// the currently focused block inside that AST, also mutable. The
+    /// closure mutates the tree and (when the op changes where the
+    /// focused block lives — indent/outdent/move) updates the path
+    /// in place. After `f` returns:
+    ///
+    /// 1. `Focus.sub_path` is rewritten from the post-op absolute path
+    ///    (relative to `source_block_path`; clamped to `[]` if the op
+    ///    moved the block out of the backlink's scope).
+    /// 2. The cached `source_block` of every backlink that points at
+    ///    this source page is refreshed in-place (optimistic — no
+    ///    workspace rebuild needed). UI sees the new tree this frame.
+    /// 3. The page is saved with `save_page_with(.., false)` (no
+    ///    index rebuild — step 2 already covered it).
+    ///
+    /// Returns the post-op `ParsedPage` so callers that need to follow
+    /// up (e.g. enter Insert on the newly created block) can reuse it
+    /// without re-reading from disk.
+    fn apply_to_backlink_source<F>(&mut self, mut f: F) -> Option<(std::path::PathBuf, ParsedPage)>
+    where
+        F: FnMut(&mut ParsedPage, &mut Vec<usize>),
+    {
+        let (source_path, source_block_path) = match &self.focus {
+            Focus::Backlink { idx, .. } => {
+                let backlinks = self.index.backlinks(&self.current_slug());
+                let bl = backlinks.get(*idx)?;
+                (bl.source_path.clone(), bl.source_block_path.clone())
+            }
+            _ => return None,
+        };
+        let sub_path = match &self.focus {
+            Focus::Backlink { sub_path, .. } => sub_path.clone(),
+            _ => return None,
+        };
+
+        // Reuse the working copy if we're already mid-edit on this
+        // source — avoids re-reading the file *and* preserves the
+        // user's in-flight buffer (we commit it into the AST below).
+        let mut source_page = if let Mode::Insert {
+            target: EditTarget::SourcePage { path, page },
+            block_path,
+            buffer,
+            ..
+        } = &self.mode
+        {
+            if path == &source_path {
+                let mut p = page.clone();
+                if let Some(node) = node_at_path_mut(&mut p.blocks, block_path) {
+                    node.text = buffer.as_string();
+                }
+                p
+            } else {
+                parse(&std::fs::read_to_string(&source_path).ok()?)
+            }
+        } else {
+            parse(&std::fs::read_to_string(&source_path).ok()?)
+        };
+
+        let mut abs_path = source_block_path.clone();
+        abs_path.extend_from_slice(&sub_path);
+
+        f(&mut source_page, &mut abs_path);
+
+        // Rewrite focus.sub_path from the post-op absolute path. If
+        // the op pushed the focused block out of the backlink's
+        // visible scope (i.e. it's no longer a descendant of
+        // source_block_path), fall back to focusing the source block
+        // itself.
+        let new_sub_path: Vec<usize> = if abs_path.starts_with(&source_block_path) {
+            abs_path[source_block_path.len()..].to_vec()
+        } else {
+            Vec::new()
+        };
+        if let Focus::Backlink { sub_path, .. } = &mut self.focus {
+            *sub_path = new_sub_path;
+        }
+
+        self.index
+            .refresh_backlinks_from_source(&source_path, &source_page);
+        self.save_page_with(&source_path, &source_page, false);
+
+        Some((source_path, source_page))
     }
 
     /// Create a new block after the current selection at the same indent,
     /// then enter Insert. Used by `o` (Normal) and Enter (Insert).
     pub(crate) fn create_block_below(&mut self) {
+        // Cross-page route (focus on a backlink, or in-place Insert on
+        // a source page). The op mutates the source AST, refreshes the
+        // index optimistically, and re-enters Insert on the new block.
+        if matches!(self.focus, Focus::Backlink { .. })
+            || matches!(
+                &self.mode,
+                Mode::Insert {
+                    target: EditTarget::SourcePage { .. },
+                    ..
+                }
+            )
+        {
+            // Drop the existing Insert mode *without* triggering the
+            // disk save — we already have the buffer captured via the
+            // working copy in `apply_to_backlink_source`, and we'll
+            // save once below.
+            self.mode = Mode::Normal;
+
+            let result = self.apply_to_backlink_source(|page, abs_path| {
+                insert_sibling_after(&mut page.blocks, abs_path);
+                // Sibling-after lives at parent ++ [last + 1].
+                if let Some(last) = abs_path.last_mut() {
+                    *last += 1;
+                }
+            });
+            if let Some((source_path, source_page)) = result {
+                // Enter Insert on the freshly inserted block.
+                let Focus::Backlink { idx, sub_path } = &self.focus else {
+                    return;
+                };
+                let backlinks = self.index.backlinks(&self.current_slug());
+                let Some(bl) = backlinks.get(*idx) else {
+                    return;
+                };
+                let mut abs = bl.source_block_path.clone();
+                abs.extend_from_slice(sub_path);
+                if let Some(node) = node_at_path(&source_page.blocks, &abs) {
+                    let buf = EditBuffer::from_text(&node.text);
+                    let original_text = node.text.clone();
+                    self.cursor_col = 0;
+                    self.mode = Mode::Insert {
+                        target: EditTarget::SourcePage {
+                            path: source_path,
+                            page: source_page,
+                        },
+                        block_path: abs,
+                        buffer: buf,
+                        original_text,
+                    };
+                }
+            }
+            return;
+        }
+
         let path = if let Mode::Insert { block_path, .. } = &self.mode {
             block_path.clone()
         } else {
@@ -101,6 +352,42 @@ impl App {
 
     /// Create a new block above the current selection, then enter Insert.
     pub(crate) fn create_block_above(&mut self) {
+        if matches!(self.focus, Focus::Backlink { .. }) {
+            self.mode = Mode::Normal;
+            let result = self.apply_to_backlink_source(|page, abs_path| {
+                insert_sibling_before(&mut page.blocks, abs_path);
+                // The new block now occupies the slot the focused
+                // one used to — focus stays at `abs_path` unchanged
+                // (the closure does nothing to it), which means we
+                // end up inserting *and* selecting the new block.
+            });
+            if let Some((source_path, source_page)) = result {
+                let Focus::Backlink { idx, sub_path } = &self.focus else {
+                    return;
+                };
+                let backlinks = self.index.backlinks(&self.current_slug());
+                let Some(bl) = backlinks.get(*idx) else {
+                    return;
+                };
+                let mut abs = bl.source_block_path.clone();
+                abs.extend_from_slice(sub_path);
+                if let Some(node) = node_at_path(&source_page.blocks, &abs) {
+                    let buf = EditBuffer::from_text(&node.text);
+                    let original_text = node.text.clone();
+                    self.cursor_col = 0;
+                    self.mode = Mode::Insert {
+                        target: EditTarget::SourcePage {
+                            path: source_path,
+                            page: source_page,
+                        },
+                        block_path: abs,
+                        buffer: buf,
+                        original_text,
+                    };
+                }
+            }
+            return;
+        }
         let path = path_for_index(&self.page.blocks, self.selected).unwrap_or_else(|| vec![0]);
         self.snapshot_for_undo();
         insert_sibling_before(&mut self.page.blocks, &path);
@@ -110,6 +397,58 @@ impl App {
     }
 
     pub(crate) fn indent_current(&mut self) -> bool {
+        if matches!(self.focus, Focus::Backlink { .. })
+            || matches!(
+                &self.mode,
+                Mode::Insert {
+                    target: EditTarget::SourcePage { .. },
+                    ..
+                }
+            )
+        {
+            let in_insert = matches!(self.mode, Mode::Insert { .. });
+            let buf_state = if let Mode::Insert { buffer, .. } = &self.mode {
+                Some(buffer.clone())
+            } else {
+                None
+            };
+            self.mode = Mode::Normal;
+            let mut moved = false;
+            let result = self.apply_to_backlink_source(|page, abs_path| {
+                if let Some(new_path) = indent_at_path(&mut page.blocks, abs_path) {
+                    *abs_path = new_path;
+                    moved = true;
+                }
+            });
+            // Re-enter Insert if we were editing, on the (possibly
+            // re-pathed) block.
+            if let (Some(buf), Some((source_path, source_page))) = (buf_state, result) {
+                if in_insert {
+                    let Focus::Backlink { idx, sub_path } = &self.focus else {
+                        return moved;
+                    };
+                    let backlinks = self.index.backlinks(&self.current_slug());
+                    let Some(bl) = backlinks.get(*idx) else {
+                        return moved;
+                    };
+                    let mut abs = bl.source_block_path.clone();
+                    abs.extend_from_slice(sub_path);
+                    if let Some(node) = node_at_path(&source_page.blocks, &abs) {
+                        let original_text = node.text.clone();
+                        self.mode = Mode::Insert {
+                            target: EditTarget::SourcePage {
+                                path: source_path,
+                                page: source_page,
+                            },
+                            block_path: abs,
+                            buffer: buf,
+                            original_text,
+                        };
+                    }
+                }
+            }
+            return moved;
+        }
         let path = if let Mode::Insert { block_path, .. } = &self.mode {
             block_path.clone()
         } else if let Some(p) = path_for_index(&self.page.blocks, self.selected) {
@@ -138,6 +477,56 @@ impl App {
     }
 
     pub(crate) fn outdent_current(&mut self) -> bool {
+        if matches!(self.focus, Focus::Backlink { .. })
+            || matches!(
+                &self.mode,
+                Mode::Insert {
+                    target: EditTarget::SourcePage { .. },
+                    ..
+                }
+            )
+        {
+            let in_insert = matches!(self.mode, Mode::Insert { .. });
+            let buf_state = if let Mode::Insert { buffer, .. } = &self.mode {
+                Some(buffer.clone())
+            } else {
+                None
+            };
+            self.mode = Mode::Normal;
+            let mut moved = false;
+            let result = self.apply_to_backlink_source(|page, abs_path| {
+                if let Some(new_path) = outdent_at_path(&mut page.blocks, abs_path) {
+                    *abs_path = new_path;
+                    moved = true;
+                }
+            });
+            if let (Some(buf), Some((source_path, source_page))) = (buf_state, result) {
+                if in_insert {
+                    let Focus::Backlink { idx, sub_path } = &self.focus else {
+                        return moved;
+                    };
+                    let backlinks = self.index.backlinks(&self.current_slug());
+                    let Some(bl) = backlinks.get(*idx) else {
+                        return moved;
+                    };
+                    let mut abs = bl.source_block_path.clone();
+                    abs.extend_from_slice(sub_path);
+                    if let Some(node) = node_at_path(&source_page.blocks, &abs) {
+                        let original_text = node.text.clone();
+                        self.mode = Mode::Insert {
+                            target: EditTarget::SourcePage {
+                                path: source_path,
+                                page: source_page,
+                            },
+                            block_path: abs,
+                            buffer: buf,
+                            original_text,
+                        };
+                    }
+                }
+            }
+            return moved;
+        }
         let path = if let Mode::Insert { block_path, .. } = &self.mode {
             block_path.clone()
         } else if let Some(p) = path_for_index(&self.page.blocks, self.selected) {
@@ -163,6 +552,17 @@ impl App {
     }
 
     pub(crate) fn delete_current(&mut self) {
+        if matches!(self.focus, Focus::Backlink { .. }) {
+            self.mode = Mode::Normal;
+            self.apply_to_backlink_source(|page, abs_path| {
+                delete_at_path(&mut page.blocks, abs_path);
+                // After delete, the focused path no longer resolves;
+                // collapse to source_block_path (handled outside via
+                // the clamp to `[]`).
+                abs_path.clear();
+            });
+            return;
+        }
         let Some(path) = path_for_index(&self.page.blocks, self.selected) else {
             return;
         };
@@ -174,6 +574,21 @@ impl App {
     /// Swap the current block with its previous sibling (drags its
     /// subtree). No-op if already at the top of its parent.
     pub(crate) fn move_block_up(&mut self) {
+        if matches!(self.focus, Focus::Backlink { .. }) {
+            self.apply_to_backlink_source(|page, abs_path| {
+                let Some(&last) = abs_path.last() else {
+                    return;
+                };
+                if last == 0 {
+                    return;
+                }
+                let parent = &abs_path[..abs_path.len() - 1];
+                let siblings = siblings_mut(&mut page.blocks, parent);
+                siblings.swap(last - 1, last);
+                *abs_path.last_mut().unwrap() = last - 1;
+            });
+            return;
+        }
         let Some(path) = path_for_index(&self.page.blocks, self.selected) else {
             return;
         };
@@ -195,6 +610,22 @@ impl App {
 
     /// Swap with the next sibling.
     pub(crate) fn move_block_down(&mut self) {
+        if matches!(self.focus, Focus::Backlink { .. }) {
+            self.apply_to_backlink_source(|page, abs_path| {
+                let Some(&last) = abs_path.last() else {
+                    return;
+                };
+                let parent = abs_path[..abs_path.len() - 1].to_vec();
+                let sibling_count = siblings_mut(&mut page.blocks, &parent).len();
+                if last + 1 >= sibling_count {
+                    return;
+                }
+                let siblings = siblings_mut(&mut page.blocks, &parent);
+                siblings.swap(last, last + 1);
+                *abs_path.last_mut().unwrap() = last + 1;
+            });
+            return;
+        }
         let Some(path) = path_for_index(&self.page.blocks, self.selected) else {
             return;
         };
@@ -262,14 +693,56 @@ impl App {
     }
 
     pub(crate) fn toggle_todo(&mut self) {
-        let Some(path) = path_for_index(&self.page.blocks, self.selected) else {
+        match self.focus.clone() {
+            Focus::Outline => {
+                let Some(path) = path_for_index(&self.page.blocks, self.selected) else {
+                    return;
+                };
+                self.snapshot_for_undo();
+                if let Some(node) = node_at_path_mut(&mut self.page.blocks, &path) {
+                    node.text = cycle_todo_state(&node.text);
+                }
+                self.save();
+            }
+            Focus::Backlink { idx, sub_path } => {
+                self.toggle_todo_backlink(idx, &sub_path);
+            }
+        }
+    }
+
+    /// Cross-page TODO cycle: load the source page, mutate the
+    /// referencing block (resolved via `source_block_path + sub_path`),
+    /// and save it through `save_page` so reconcile keeps IDs stable.
+    /// No undo snapshot — same rationale as `commit_insert` on a
+    /// `SourcePage`: undo in this view shouldn't silently flip TODOs
+    /// in a different file.
+    fn toggle_todo_backlink(&mut self, idx: usize, sub_path: &[usize]) {
+        let (source_path, abs_path) = {
+            let backlinks = self.index.backlinks(&self.current_slug());
+            let Some(bl) = backlinks.get(idx) else {
+                return;
+            };
+            let mut full = bl.source_block_path.clone();
+            full.extend_from_slice(sub_path);
+            (bl.source_path.clone(), full)
+        };
+        let Ok(text) = std::fs::read_to_string(&source_path) else {
+            self.status = format!("cannot read backlink source: {}", source_path.display());
             return;
         };
-        self.snapshot_for_undo();
-        if let Some(node) = node_at_path_mut(&mut self.page.blocks, &path) {
-            node.text = cycle_todo_state(&node.text);
-        }
-        self.save();
+        let mut source_page = parse(&text);
+        let Some(node) = node_at_path_mut(&mut source_page.blocks, &abs_path) else {
+            self.status = "backlink source block missing — index may be stale".into();
+            return;
+        };
+        node.text = cycle_todo_state(&node.text);
+        // Optimistic: patch the in-memory index so the new TODO/DONE
+        // prefix shows up *this frame*. Persist the source page without
+        // triggering a full workspace rebuild (the dominant cost) —
+        // the next natural rebuild reconverges.
+        self.index
+            .refresh_backlinks_from_source(&source_path, &source_page);
+        self.save_page_with(&source_path, &source_page, false);
     }
 }
 

--- a/crates/outl-tui/src/actions/block.rs
+++ b/crates/outl-tui/src/actions/block.rs
@@ -290,12 +290,10 @@ impl App {
                 }
             )
         {
-            // Drop the existing Insert mode *without* triggering the
-            // disk save — we already have the buffer captured via the
-            // working copy in `apply_to_backlink_source`, and we'll
-            // save once below.
-            self.mode = Mode::Normal;
-
+            // Don't drop `Mode::Insert` before calling the helper —
+            // it inspects the live mode to commit the user's in-flight
+            // buffer into the source AST. Resetting first would
+            // discard whatever was typed into the prior block.
             let result = self.apply_to_backlink_source(|page, abs_path| {
                 insert_sibling_after(&mut page.blocks, abs_path);
                 // Sibling-after lives at parent ++ [last + 1].
@@ -353,7 +351,9 @@ impl App {
     /// Create a new block above the current selection, then enter Insert.
     pub(crate) fn create_block_above(&mut self) {
         if matches!(self.focus, Focus::Backlink { .. }) {
-            self.mode = Mode::Normal;
+            // Keep `Mode::Insert` alive: `apply_to_backlink_source`
+            // needs it to commit the in-flight buffer before the
+            // sibling-before is inserted.
             let result = self.apply_to_backlink_source(|page, abs_path| {
                 insert_sibling_before(&mut page.blocks, abs_path);
                 // The new block now occupies the slot the focused
@@ -412,7 +412,10 @@ impl App {
             } else {
                 None
             };
-            self.mode = Mode::Normal;
+            // Don't reset Mode::Insert before the helper — it needs
+            // to see the live buffer to commit it into the source AST
+            // before the indent. (Resetting first would save a
+            // structural change against stale text.)
             let mut moved = false;
             let result = self.apply_to_backlink_source(|page, abs_path| {
                 if let Some(new_path) = indent_at_path(&mut page.blocks, abs_path) {
@@ -492,7 +495,8 @@ impl App {
             } else {
                 None
             };
-            self.mode = Mode::Normal;
+            // Same rationale as `indent_current`: keep Mode::Insert
+            // so the helper commits the buffer before the outdent.
             let mut moved = false;
             let result = self.apply_to_backlink_source(|page, abs_path| {
                 if let Some(new_path) = outdent_at_path(&mut page.blocks, abs_path) {

--- a/crates/outl-tui/src/actions/lifecycle.rs
+++ b/crates/outl-tui/src/actions/lifecycle.rs
@@ -6,7 +6,7 @@
 
 use crate::commands::CommandRegistry;
 use crate::outline_ops::flat_count;
-use crate::state::{App, Mode, View};
+use crate::state::{App, Focus, Mode, View};
 use crate::theme::Theme;
 use anyhow::{Context, Result};
 use chrono::Local;
@@ -51,6 +51,7 @@ impl App {
             index: WorkspaceIndex::default(),
             index_rx: None,
             show_backlinks: true,
+            focus: Focus::Outline,
             scroll_y: 0,
             viewport_height: 0,
             last_mtime: None,
@@ -104,6 +105,14 @@ impl App {
             })
             .expect("spawning the index worker thread should not fail");
         self.index_rx = Some(rx);
+    }
+
+    /// `true` while a workspace-index rebuild is in flight on a worker
+    /// thread. The event loop uses this to shorten its
+    /// `event::poll` timeout so the freshly-built index shows up in
+    /// the UI within a frame, not after the next 750 ms key timeout.
+    pub(crate) fn has_pending_index(&self) -> bool {
+        self.index_rx.is_some()
     }
 
     /// Non-blocking check: if the background index build has finished,
@@ -205,6 +214,10 @@ impl App {
         if self.selected >= self.flat_len {
             self.selected = self.flat_len.saturating_sub(1);
         }
+        // Any view change snaps focus back to the outline. Carrying a
+        // stale `Focus::Backlink { idx, … }` across pages would point
+        // at the wrong backlink list (the new page has its own).
+        self.focus = Focus::Outline;
         // Snapshot the file's mtime so the polling loop can tell when
         // an *external* edit lands (vs. our own save).
         self.last_mtime = file_mtime(&path);
@@ -247,9 +260,62 @@ impl App {
         }
 
         self.load_current();
-        self.spawn_index_rebuild();
+        // External edit changes one file — incremental patch is enough
+        // to bring the index in sync. (A full rebuild is the wrong
+        // tool: it would block on rescanning every other page that
+        // didn't change.)
+        let cur_path = self.current_path();
+        self.index.patch_page(&cur_path, &self.page);
         self.status = "reloaded from disk".into();
         true
+    }
+
+    /// Render an arbitrary `ParsedPage` to `path` and reconcile.
+    ///
+    /// Used by the cross-page commit route (editing a backlink): the
+    /// caller has a working copy of a *different* page than
+    /// `current_path()`, and wants to persist it without disturbing
+    /// `app.view` / `app.page`. Updates status on failure, rebuilds
+    /// the workspace index, and keeps `last_mtime` honest when the
+    /// path happens to coincide with the open view.
+    #[allow(dead_code)]
+    pub(crate) fn save_page(&mut self, path: &Path, page: &ParsedPage) {
+        self.save_page_with(path, page, true);
+    }
+
+    /// Same as [`Self::save_page`] but skips the index rebuild when
+    /// the caller has already patched the in-memory state optimistically.
+    ///
+    /// On `rebuild_index == true`, the cheaper [`patch_page`] is used
+    /// instead of the workspace-wide rescan — single-file work
+    /// proportional to the page's block count, not to the workspace
+    /// size.
+    ///
+    /// [`patch_page`]: outl_md::index::WorkspaceIndex::patch_page
+    pub(crate) fn save_page_with(&mut self, path: &Path, page: &ParsedPage, rebuild_index: bool) {
+        let md = render(page);
+        if let Err(e) = outl_md::write_atomic(path, md.as_bytes()) {
+            self.status = format!("save (source) failed: {e}");
+            return;
+        }
+        if let Err(e) = reconcile_md(
+            &mut self.workspace,
+            &self.hlc,
+            path,
+            Some(&self.orphans_log),
+        ) {
+            self.status = format!("reconcile (source) failed: {e}");
+            return;
+        }
+        self.status.clear();
+        if rebuild_index {
+            // Incremental: just re-index this one page. Full workspace
+            // rescans are reserved for cold start and `Ctrl+L`.
+            self.index.patch_page(path, page);
+        }
+        if path == self.current_path() {
+            self.last_mtime = file_mtime(path);
+        }
     }
 
     /// Render the in-memory `page` back to disk and reconcile.
@@ -280,11 +346,11 @@ impl App {
             let _ = outl_md::write_atomic(&path, render(&self.page).as_bytes());
         }
         self.selected = self.selected.min(self.flat_len.saturating_sub(1));
-        // Refresh derived data (backlinks, icons, ...) off the
-        // critical path. The UI stays responsive while the worker
-        // re-scans; `poll_index_updates` swaps the result in when
-        // ready (usually next frame).
-        self.spawn_index_rebuild();
+        // Incremental re-index: only this page changed, so just
+        // refresh its entries (backlinks, title, icon). Cheap and
+        // synchronous — no waiting for a worker to rescan the whole
+        // workspace.
+        self.index.patch_page(&path, &self.page);
         // Update mtime AFTER the write so the polling loop doesn't
         // mistake our own save for an external edit.
         self.last_mtime = file_mtime(&path);

--- a/crates/outl-tui/src/actions/mod.rs
+++ b/crates/outl-tui/src/actions/mod.rs
@@ -33,4 +33,3 @@ pub(crate) mod yank;
 // `read_page_title` directly via the submodule path — listing them
 // here too would warn-as-unused under `--release` / non-test builds.
 pub(crate) use block::cycle_todo_inline;
-pub(crate) use overlay::truncate_for_snippet;

--- a/crates/outl-tui/src/actions/nav.rs
+++ b/crates/outl-tui/src/actions/nav.rs
@@ -135,29 +135,35 @@ impl App {
                 false
             }
             Focus::Backlink { idx, sub_path } => {
-                let backlinks = self.index.backlinks(&self.current_slug()).to_vec();
-                let Some(bl) = backlinks.get(idx) else {
-                    return false;
+                // Borrow the backlinks slice directly instead of
+                // cloning the whole `Vec<Backlink>` (each entry
+                // carries an `OutlineNode` subtree — non-trivial to
+                // clone per keystroke).
+                let slug = self.current_slug();
+                let new_focus = {
+                    let backlinks = self.index.backlinks(&slug);
+                    let Some(bl) = backlinks.get(idx) else {
+                        return false;
+                    };
+                    let paths = flatten_backlink_subtree(&bl.source_block);
+                    let cur_pos = paths.iter().position(|p| p == &sub_path).unwrap_or(0);
+                    if cur_pos + 1 < paths.len() {
+                        Focus::Backlink {
+                            idx,
+                            sub_path: paths[cur_pos + 1].clone(),
+                        }
+                    } else if idx + 1 < backlinks.len() {
+                        Focus::Backlink {
+                            idx: idx + 1,
+                            sub_path: Vec::new(),
+                        }
+                    } else {
+                        return false;
+                    }
                 };
-                let paths = flatten_backlink_subtree(&bl.source_block);
-                let cur_pos = paths.iter().position(|p| p == &sub_path).unwrap_or(0);
-                if cur_pos + 1 < paths.len() {
-                    self.focus = Focus::Backlink {
-                        idx,
-                        sub_path: paths[cur_pos + 1].clone(),
-                    };
-                    self.cursor_col = 0;
-                    return true;
-                }
-                if idx + 1 < backlinks.len() {
-                    self.focus = Focus::Backlink {
-                        idx: idx + 1,
-                        sub_path: Vec::new(),
-                    };
-                    self.cursor_col = 0;
-                    return true;
-                }
-                false
+                self.focus = new_focus;
+                self.cursor_col = 0;
+                true
             }
         }
     }
@@ -174,35 +180,41 @@ impl App {
                 false
             }
             Focus::Backlink { idx, sub_path } => {
-                let backlinks = self.index.backlinks(&self.current_slug()).to_vec();
-                let Some(bl) = backlinks.get(idx) else {
-                    return false;
+                let slug = self.current_slug();
+                // Resolve the new focus value while only borrowing the
+                // backlinks slice — no `to_vec` clone per keystroke.
+                let new_focus_opt = {
+                    let backlinks = self.index.backlinks(&slug);
+                    let Some(bl) = backlinks.get(idx) else {
+                        return false;
+                    };
+                    let paths = flatten_backlink_subtree(&bl.source_block);
+                    let cur_pos = paths.iter().position(|p| p == &sub_path).unwrap_or(0);
+                    if cur_pos > 0 {
+                        Some(Focus::Backlink {
+                            idx,
+                            sub_path: paths[cur_pos - 1].clone(),
+                        })
+                    } else if idx > 0 {
+                        // Jump to the last block of the previous backlink.
+                        let prev_paths = flatten_backlink_subtree(&backlinks[idx - 1].source_block);
+                        let last = prev_paths.last().cloned().unwrap_or_default();
+                        Some(Focus::Backlink {
+                            idx: idx - 1,
+                            sub_path: last,
+                        })
+                    } else {
+                        // Topping out → fall back into the outline.
+                        None
+                    }
                 };
-                let paths = flatten_backlink_subtree(&bl.source_block);
-                let cur_pos = paths.iter().position(|p| p == &sub_path).unwrap_or(0);
-                if cur_pos > 0 {
-                    self.focus = Focus::Backlink {
-                        idx,
-                        sub_path: paths[cur_pos - 1].clone(),
-                    };
-                    self.cursor_col = 0;
-                    return true;
+                match new_focus_opt {
+                    Some(f) => self.focus = f,
+                    None => {
+                        self.focus = Focus::Outline;
+                        self.selected = self.flat_len.saturating_sub(1);
+                    }
                 }
-                if idx > 0 {
-                    // Jump to the last block of the previous backlink.
-                    let prev_paths = flatten_backlink_subtree(&backlinks[idx - 1].source_block);
-                    let last = prev_paths.last().cloned().unwrap_or_default();
-                    self.focus = Focus::Backlink {
-                        idx: idx - 1,
-                        sub_path: last,
-                    };
-                    self.cursor_col = 0;
-                    return true;
-                }
-                // Topping out of the backlinks zone → fall back into
-                // the outline at its last block.
-                self.focus = Focus::Outline;
-                self.selected = self.flat_len.saturating_sub(1);
                 self.cursor_col = 0;
                 true
             }

--- a/crates/outl-tui/src/actions/nav.rs
+++ b/crates/outl-tui/src/actions/nav.rs
@@ -6,8 +6,8 @@
 //! `self.selected`, and `self.cursor_col`. The lifecycle module is
 //! the one that touches disk.
 
-use crate::outline_ops::{node_at_path, path_for_index};
-use crate::state::{App, Mode, View};
+use crate::outline_ops::{flatten_backlink_subtree, node_at_path, path_for_index};
+use crate::state::{App, Focus, Mode, View};
 use anyhow::Result;
 use chrono::{Duration, Local};
 use outl_md::inline::{ref_at_cursor, RefTarget};
@@ -89,28 +89,160 @@ impl App {
     }
 
     pub(crate) fn move_selection(&mut self, delta: i32) {
-        if self.flat_len == 0 {
+        if self.flat_len == 0 && matches!(self.focus, Focus::Outline) {
             self.selected = 0;
             self.cursor_col = 0;
             return;
         }
-        let cur = self.selected as i32;
-        let next = (cur + delta).clamp(0, self.flat_len as i32 - 1) as usize;
-        if next != self.selected {
-            self.selected = next;
-            // Each block has its own cursor context; reset to start.
-            self.cursor_col = 0;
+        if delta > 0 {
+            for _ in 0..delta {
+                if !self.step_forward() {
+                    break;
+                }
+            }
+        } else {
+            for _ in 0..(-delta) {
+                if !self.step_backward() {
+                    break;
+                }
+            }
         }
     }
 
+    /// Advance the cursor by one position in the virtual flat list
+    /// `outline blocks ++ backlink section blocks`. Returns `true` if
+    /// the cursor moved, `false` when already at the bottom.
+    ///
+    /// Crosses the boundary between outline and backlinks transparently
+    /// when the inline section is shown and non-empty.
+    fn step_forward(&mut self) -> bool {
+        match self.focus.clone() {
+            Focus::Outline => {
+                if self.selected + 1 < self.flat_len {
+                    self.selected += 1;
+                    self.cursor_col = 0;
+                    return true;
+                }
+                // Bottom of outline → try entering the backlinks zone.
+                if self.backlinks_navigable() {
+                    self.focus = Focus::Backlink {
+                        idx: 0,
+                        sub_path: Vec::new(),
+                    };
+                    self.cursor_col = 0;
+                    return true;
+                }
+                false
+            }
+            Focus::Backlink { idx, sub_path } => {
+                let backlinks = self.index.backlinks(&self.current_slug()).to_vec();
+                let Some(bl) = backlinks.get(idx) else {
+                    return false;
+                };
+                let paths = flatten_backlink_subtree(&bl.source_block);
+                let cur_pos = paths.iter().position(|p| p == &sub_path).unwrap_or(0);
+                if cur_pos + 1 < paths.len() {
+                    self.focus = Focus::Backlink {
+                        idx,
+                        sub_path: paths[cur_pos + 1].clone(),
+                    };
+                    self.cursor_col = 0;
+                    return true;
+                }
+                if idx + 1 < backlinks.len() {
+                    self.focus = Focus::Backlink {
+                        idx: idx + 1,
+                        sub_path: Vec::new(),
+                    };
+                    self.cursor_col = 0;
+                    return true;
+                }
+                false
+            }
+        }
+    }
+
+    /// Mirror of [`step_forward`], moving one position upward.
+    fn step_backward(&mut self) -> bool {
+        match self.focus.clone() {
+            Focus::Outline => {
+                if self.selected > 0 {
+                    self.selected -= 1;
+                    self.cursor_col = 0;
+                    return true;
+                }
+                false
+            }
+            Focus::Backlink { idx, sub_path } => {
+                let backlinks = self.index.backlinks(&self.current_slug()).to_vec();
+                let Some(bl) = backlinks.get(idx) else {
+                    return false;
+                };
+                let paths = flatten_backlink_subtree(&bl.source_block);
+                let cur_pos = paths.iter().position(|p| p == &sub_path).unwrap_or(0);
+                if cur_pos > 0 {
+                    self.focus = Focus::Backlink {
+                        idx,
+                        sub_path: paths[cur_pos - 1].clone(),
+                    };
+                    self.cursor_col = 0;
+                    return true;
+                }
+                if idx > 0 {
+                    // Jump to the last block of the previous backlink.
+                    let prev_paths = flatten_backlink_subtree(&backlinks[idx - 1].source_block);
+                    let last = prev_paths.last().cloned().unwrap_or_default();
+                    self.focus = Focus::Backlink {
+                        idx: idx - 1,
+                        sub_path: last,
+                    };
+                    self.cursor_col = 0;
+                    return true;
+                }
+                // Topping out of the backlinks zone → fall back into
+                // the outline at its last block.
+                self.focus = Focus::Outline;
+                self.selected = self.flat_len.saturating_sub(1);
+                self.cursor_col = 0;
+                true
+            }
+        }
+    }
+
+    /// `true` when the inline backlinks section is rendered *and* has
+    /// at least one block the cursor can land on. Drives the cross-zone
+    /// transition in `step_forward`/`step_backward`.
+    fn backlinks_navigable(&self) -> bool {
+        self.show_backlinks && !self.index.backlinks(&self.current_slug()).is_empty()
+    }
+
     /// Current selected block's text (or empty if no selection).
+    /// Honours `app.focus` so backlink blocks return their own text.
     pub(crate) fn current_block_text(&self) -> String {
-        let Some(path) = path_for_index(&self.page.blocks, self.selected) else {
-            return String::new();
-        };
-        node_at_path(&self.page.blocks, &path)
-            .map(|n| n.text.clone())
-            .unwrap_or_default()
+        match &self.focus {
+            Focus::Outline => {
+                let Some(path) = path_for_index(&self.page.blocks, self.selected) else {
+                    return String::new();
+                };
+                node_at_path(&self.page.blocks, &path)
+                    .map(|n| n.text.clone())
+                    .unwrap_or_default()
+            }
+            Focus::Backlink { idx, sub_path } => {
+                let backlinks = self.index.backlinks(&self.current_slug());
+                let Some(bl) = backlinks.get(*idx) else {
+                    return String::new();
+                };
+                let mut node = &bl.source_block;
+                for &i in sub_path {
+                    let Some(child) = node.children.get(i) else {
+                        return String::new();
+                    };
+                    node = child;
+                }
+                node.text.clone()
+            }
+        }
     }
 
     pub(crate) fn current_block_char_count(&self) -> usize {

--- a/crates/outl-tui/src/actions/overlay.rs
+++ b/crates/outl-tui/src/actions/overlay.rs
@@ -231,7 +231,7 @@ impl App {
                 );
             }
         }
-        hits.sort_by(|a, b| b.score.cmp(&a.score));
+        hits.sort_by_key(|b| std::cmp::Reverse(b.score));
         hits.truncate(30);
         if let Some(Overlay::Search(ref mut s)) = self.overlay {
             s.hits = hits;
@@ -565,8 +565,14 @@ impl App {
     }
 
     /// Slash branch of [`accept_autocomplete`]: erase `/<query>` from
-    /// the buffer, commit the Insert (we don't want the in-flight
-    /// edit to live alongside a command run), then dispatch.
+    /// the buffer, then dispatch.
+    ///
+    /// Commands that **don't** insert text into the buffer
+    /// (`inserts_inline() == false`, i.e. the default) get the Insert
+    /// committed first — we don't want the in-flight edit alive
+    /// alongside an overlay-opening command. Inline-insert commands
+    /// (`/date-today` and friends) skip the commit so they can call
+    /// `buffer.insert_str(...)` at the cursor.
     fn accept_slash_inline(&mut self, ac: &AutocompleteState, choice: &str) {
         let trigger_len = 1 + ac.query.chars().count();
         if let Mode::Insert { buffer, .. } = &mut self.mode {
@@ -574,17 +580,16 @@ impl App {
                 buffer.delete_back();
             }
         }
-        // Commit so the page state is consistent before we run the
-        // command (which might save again or open an overlay).
-        self.commit_insert();
 
         let registry = self.command_registry.clone();
-        // Need to know `needs_args` to decide whether to drop the
-        // user into the `:` palette or run the command immediately.
         let Some(cmd) = registry.get(choice) else {
+            self.commit_insert();
             self.status = format!("unknown command: {choice}");
             return;
         };
+        if !cmd.inserts_inline() {
+            self.commit_insert();
+        }
         if cmd.needs_args() {
             self.overlay = Some(Overlay::Command(CommandState {
                 buffer: format!("{choice} "),

--- a/crates/outl-tui/src/commands/builtins.rs
+++ b/crates/outl-tui/src/commands/builtins.rs
@@ -17,9 +17,10 @@
 //! - Arg-taking commands explain expected format in `description`.
 
 use anyhow::Result;
+use chrono::{Datelike, Duration, Local, Months, NaiveDate, Weekday};
 
 use super::{CommandRegistry, SlashCommand};
-use crate::state::App;
+use crate::state::{App, Mode};
 use crate::theme;
 
 /// Hook for [`CommandRegistry::with_builtins`].
@@ -35,6 +36,137 @@ pub(super) fn register_all(reg: &mut CommandRegistry) {
     reg.register(HelpCommand);
     reg.register(QuitCommand);
     reg.register(OpenCommand);
+    // Date / time inserters (Insert mode only — slash dispatcher
+    // skips `commit_insert` for these because they need the buffer
+    // alive at the cursor).
+    reg.register(DateTodayCommand);
+    reg.register(DateTomorrowCommand);
+    reg.register(DateYesterdayCommand);
+    reg.register(DateNextWeekCommand);
+    reg.register(DateLastWeekCommand);
+    reg.register(DateNextMondayCommand);
+    reg.register(DateNextTuesdayCommand);
+    reg.register(DateNextWednesdayCommand);
+    reg.register(DateNextThursdayCommand);
+    reg.register(DateNextFridayCommand);
+    reg.register(DateNextSaturdayCommand);
+    reg.register(DateNextSundayCommand);
+    reg.register(DateCommand);
+    reg.register(IsoDateTodayCommand);
+    reg.register(IsoDateTomorrowCommand);
+    reg.register(IsoDateYesterdayCommand);
+    reg.register(TimeNowCommand);
+    reg.register(DateTimeNowCommand);
+    reg.register(WeekNumCommand);
+}
+
+/// Insert `text` at the cursor if we're in Insert mode; otherwise
+/// surface a status message — date commands only make sense while
+/// the user is typing.
+fn insert_or_warn(app: &mut App, command_name: &str, text: &str) {
+    if let Mode::Insert { buffer, .. } = &mut app.mode {
+        buffer.insert_str(text);
+    } else {
+        app.status = format!("/{command_name} only works in Insert mode (would insert {text})");
+    }
+}
+
+/// `[[YYYY-MM-DD]]` for today + `days_offset`. Negative offsets are
+/// past, positive are future. Extracted so the date-shifting logic is
+/// unit-testable without standing up a full `App`.
+fn journal_link_offset(days_offset: i64) -> String {
+    let d = Local::now().date_naive() + Duration::days(days_offset);
+    format!("[[{}]]", d.format("%Y-%m-%d"))
+}
+
+/// `HH:MM` for the current local time. Plain text — not a journal ref.
+fn time_text() -> String {
+    Local::now().format("%H:%M").to_string()
+}
+
+/// `[[YYYY-MM-DD]] HH:MM` — the "stamp this moment" combo.
+fn datetime_text() -> String {
+    let now = Local::now();
+    format!(
+        "[[{}]] {}",
+        now.date_naive().format("%Y-%m-%d"),
+        now.format("%H:%M")
+    )
+}
+
+/// Plain `YYYY-MM-DD` (no brackets) for property values like
+/// `due:: 2026-05-26`. ISO 8601 short date.
+fn iso_date_offset(days_offset: i64) -> String {
+    let d = Local::now().date_naive() + Duration::days(days_offset);
+    d.format("%Y-%m-%d").to_string()
+}
+
+/// `#YYYY-Www` tag for the ISO week of `date` (e.g. `#2026-W21`).
+/// Uses ISO 8601 week numbering — weeks start on Monday and `%G`
+/// is the ISO week-numbering year (which can differ from `%Y` for
+/// a handful of days near year boundaries).
+fn week_tag(date: NaiveDate) -> String {
+    format!("#{}", date.format("%G-W%V"))
+}
+
+/// Number of days from `today` to the next occurrence of `weekday`,
+/// strictly in the future. If today already is that weekday, returns
+/// 7 (next week's same day), not 0 — `/date-next-monday` on a Monday
+/// should mean "next Monday", not "today".
+fn days_until_next_weekday(today: NaiveDate, weekday: Weekday) -> i64 {
+    let today_n = today.weekday().num_days_from_monday() as i64;
+    let target_n = weekday.num_days_from_monday() as i64;
+    let diff = (target_n - today_n).rem_euclid(7);
+    if diff == 0 {
+        7
+    } else {
+        diff
+    }
+}
+
+/// Parse a date argument: ISO absolute (`2026-06-15`) or relative
+/// (`+3d`, `-2w`, `+1m`). Returns `None` on unrecognized input so
+/// the command can surface a usage hint.
+fn parse_date_arg(arg: &str, today: NaiveDate) -> Option<NaiveDate> {
+    let arg = arg.trim();
+    if arg.is_empty() {
+        return None;
+    }
+    // Absolute ISO date wins first — `2026-06-15` is unambiguous.
+    if let Ok(d) = NaiveDate::parse_from_str(arg, "%Y-%m-%d") {
+        return Some(d);
+    }
+    // Relative: `+Nd`, `-Nw`, `+Nm` (also bare `Nd` / `Nw` / `Nm`,
+    // treated as positive — nice when the user forgets the sign).
+    let (sign, rest) = if let Some(rest) = arg.strip_prefix('+') {
+        (1i64, rest)
+    } else if let Some(rest) = arg.strip_prefix('-') {
+        (-1i64, rest)
+    } else {
+        (1i64, arg)
+    };
+    let last = rest.chars().last()?;
+    if !"dwm".contains(last) {
+        return None;
+    }
+    let num_str = &rest[..rest.len() - last.len_utf8()];
+    let n: i64 = num_str.parse().ok()?;
+    let signed = sign * n;
+    match last {
+        'd' => Some(today + Duration::days(signed)),
+        'w' => Some(today + Duration::weeks(signed)),
+        'm' => {
+            // Months need calendar-aware arithmetic — `chrono::Months`
+            // clamps on overflow (Jan 31 + 1 month → Feb 28/29).
+            let months = u32::try_from(signed.unsigned_abs()).ok()?;
+            if signed >= 0 {
+                today.checked_add_months(Months::new(months))
+            } else {
+                today.checked_sub_months(Months::new(months))
+            }
+        }
+        _ => None,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -298,5 +430,579 @@ impl SlashCommand for OpenCommand {
         }
         app.open_page_by_name(args)?;
         Ok(false)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// date-today / date-tomorrow / date-yesterday — insert a journal ref
+// ---------------------------------------------------------------------------
+//
+// All three insert `[[YYYY-MM-DD]]` at the cursor. ISO format matches
+// outl's journal slug, so the inserted ref is also a live link to that
+// day's journal — clickable from the rendered view.
+
+pub struct DateTodayCommand;
+impl SlashCommand for DateTodayCommand {
+    fn name(&self) -> &'static str {
+        "date-today"
+    }
+    fn description(&self) -> &'static str {
+        "Insert today's journal ref — `[[YYYY-MM-DD]]`"
+    }
+    fn aliases(&self) -> &'static [&'static str] {
+        &["dt"]
+    }
+    fn inserts_inline(&self) -> bool {
+        true
+    }
+    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
+        insert_or_warn(app, "date-today", &journal_link_offset(0));
+        Ok(false)
+    }
+}
+
+pub struct DateTomorrowCommand;
+impl SlashCommand for DateTomorrowCommand {
+    fn name(&self) -> &'static str {
+        "date-tomorrow"
+    }
+    fn description(&self) -> &'static str {
+        "Insert tomorrow's journal ref — `[[YYYY-MM-DD]]`"
+    }
+    fn aliases(&self) -> &'static [&'static str] {
+        &["dtm"]
+    }
+    fn inserts_inline(&self) -> bool {
+        true
+    }
+    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
+        insert_or_warn(app, "date-tomorrow", &journal_link_offset(1));
+        Ok(false)
+    }
+}
+
+pub struct DateYesterdayCommand;
+impl SlashCommand for DateYesterdayCommand {
+    fn name(&self) -> &'static str {
+        "date-yesterday"
+    }
+    fn description(&self) -> &'static str {
+        "Insert yesterday's journal ref — `[[YYYY-MM-DD]]`"
+    }
+    fn aliases(&self) -> &'static [&'static str] {
+        &["dy"]
+    }
+    fn inserts_inline(&self) -> bool {
+        true
+    }
+    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
+        insert_or_warn(app, "date-yesterday", &journal_link_offset(-1));
+        Ok(false)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// time-now — plain `HH:MM`, no brackets (it's not a journal ref)
+// ---------------------------------------------------------------------------
+
+pub struct TimeNowCommand;
+impl SlashCommand for TimeNowCommand {
+    fn name(&self) -> &'static str {
+        "time-now"
+    }
+    fn description(&self) -> &'static str {
+        "Insert the current local time — `HH:MM` (no brackets)"
+    }
+    fn aliases(&self) -> &'static [&'static str] {
+        &["now", "tn"]
+    }
+    fn inserts_inline(&self) -> bool {
+        true
+    }
+    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
+        insert_or_warn(app, "time-now", &time_text());
+        Ok(false)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// datetime-now — `[[YYYY-MM-DD]] HH:MM`, the "timestamp this moment" marker
+// ---------------------------------------------------------------------------
+
+pub struct DateTimeNowCommand;
+impl SlashCommand for DateTimeNowCommand {
+    fn name(&self) -> &'static str {
+        "datetime-now"
+    }
+    fn description(&self) -> &'static str {
+        "Insert journal ref + time — `[[YYYY-MM-DD]] HH:MM`"
+    }
+    fn aliases(&self) -> &'static [&'static str] {
+        &["dtn", "stamp"]
+    }
+    fn inserts_inline(&self) -> bool {
+        true
+    }
+    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
+        insert_or_warn(app, "datetime-now", &datetime_text());
+        Ok(false)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// date-next-week / date-last-week — same weekday, ±7 days
+// ---------------------------------------------------------------------------
+
+pub struct DateNextWeekCommand;
+impl SlashCommand for DateNextWeekCommand {
+    fn name(&self) -> &'static str {
+        "date-next-week"
+    }
+    fn description(&self) -> &'static str {
+        "Insert next week's journal ref (today + 7 days)"
+    }
+    fn aliases(&self) -> &'static [&'static str] {
+        &["dnw"]
+    }
+    fn inserts_inline(&self) -> bool {
+        true
+    }
+    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
+        insert_or_warn(app, "date-next-week", &journal_link_offset(7));
+        Ok(false)
+    }
+}
+
+pub struct DateLastWeekCommand;
+impl SlashCommand for DateLastWeekCommand {
+    fn name(&self) -> &'static str {
+        "date-last-week"
+    }
+    fn description(&self) -> &'static str {
+        "Insert last week's journal ref (today − 7 days)"
+    }
+    fn aliases(&self) -> &'static [&'static str] {
+        &["dlw"]
+    }
+    fn inserts_inline(&self) -> bool {
+        true
+    }
+    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
+        insert_or_warn(app, "date-last-week", &journal_link_offset(-7));
+        Ok(false)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// date-next-<weekday> — next occurrence of that weekday (skips today)
+// ---------------------------------------------------------------------------
+//
+// Seven small structs share one body via a macro because the only
+// thing that varies is the name string and the `Weekday` value.
+macro_rules! next_weekday_command {
+    ($struct_name:ident, $name:literal, $weekday:expr, $aliases:expr) => {
+        pub struct $struct_name;
+        impl SlashCommand for $struct_name {
+            fn name(&self) -> &'static str {
+                $name
+            }
+            fn description(&self) -> &'static str {
+                concat!(
+                    "Insert next ",
+                    stringify!($weekday),
+                    "'s journal ref — `[[YYYY-MM-DD]]`"
+                )
+            }
+            fn aliases(&self) -> &'static [&'static str] {
+                $aliases
+            }
+            fn inserts_inline(&self) -> bool {
+                true
+            }
+            fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
+                let today = Local::now().date_naive();
+                let days = days_until_next_weekday(today, $weekday);
+                insert_or_warn(app, $name, &journal_link_offset(days));
+                Ok(false)
+            }
+        }
+    };
+}
+
+next_weekday_command!(
+    DateNextMondayCommand,
+    "date-next-monday",
+    Weekday::Mon,
+    &["dnmon"]
+);
+next_weekday_command!(
+    DateNextTuesdayCommand,
+    "date-next-tuesday",
+    Weekday::Tue,
+    &["dntue"]
+);
+next_weekday_command!(
+    DateNextWednesdayCommand,
+    "date-next-wednesday",
+    Weekday::Wed,
+    &["dnwed"]
+);
+next_weekday_command!(
+    DateNextThursdayCommand,
+    "date-next-thursday",
+    Weekday::Thu,
+    &["dnthu"]
+);
+next_weekday_command!(
+    DateNextFridayCommand,
+    "date-next-friday",
+    Weekday::Fri,
+    &["dnfri"]
+);
+next_weekday_command!(
+    DateNextSaturdayCommand,
+    "date-next-saturday",
+    Weekday::Sat,
+    &["dnsat"]
+);
+next_weekday_command!(
+    DateNextSundayCommand,
+    "date-next-sunday",
+    Weekday::Sun,
+    &["dnsun"]
+);
+
+// ---------------------------------------------------------------------------
+// date — flexible: `/date +3d`, `/date -2w`, `/date +1m`, `/date 2026-06-15`
+// ---------------------------------------------------------------------------
+
+pub struct DateCommand;
+impl SlashCommand for DateCommand {
+    fn name(&self) -> &'static str {
+        "date"
+    }
+    fn description(&self) -> &'static str {
+        "Insert a journal ref by offset or ISO date — `date +3d` · `date -2w` · `date +1m` · `date 2026-06-15`"
+    }
+    fn needs_args(&self) -> bool {
+        true
+    }
+    fn inserts_inline(&self) -> bool {
+        true
+    }
+    fn execute(&self, app: &mut App, args: &str) -> Result<bool> {
+        let today = Local::now().date_naive();
+        match parse_date_arg(args, today) {
+            Some(d) => {
+                let s = format!("[[{}]]", d.format("%Y-%m-%d"));
+                insert_or_warn(app, "date", &s);
+            }
+            None => {
+                app.status = "usage: date +Nd | -Nw | +Nm | YYYY-MM-DD".into();
+            }
+        }
+        Ok(false)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// iso-date-{today,tomorrow,yesterday} — plain `YYYY-MM-DD` (no brackets)
+// ---------------------------------------------------------------------------
+//
+// Useful for property values like `due:: 2026-05-26` where you don't
+// want the auto-link semantics of `[[...]]`.
+
+pub struct IsoDateTodayCommand;
+impl SlashCommand for IsoDateTodayCommand {
+    fn name(&self) -> &'static str {
+        "iso-date-today"
+    }
+    fn description(&self) -> &'static str {
+        "Insert today's date as plain ISO — `YYYY-MM-DD` (no brackets, for `due::` etc)"
+    }
+    fn aliases(&self) -> &'static [&'static str] {
+        &["isod"]
+    }
+    fn inserts_inline(&self) -> bool {
+        true
+    }
+    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
+        insert_or_warn(app, "iso-date-today", &iso_date_offset(0));
+        Ok(false)
+    }
+}
+
+pub struct IsoDateTomorrowCommand;
+impl SlashCommand for IsoDateTomorrowCommand {
+    fn name(&self) -> &'static str {
+        "iso-date-tomorrow"
+    }
+    fn description(&self) -> &'static str {
+        "Insert tomorrow's date as plain ISO — `YYYY-MM-DD` (no brackets)"
+    }
+    fn aliases(&self) -> &'static [&'static str] {
+        &["isodtm"]
+    }
+    fn inserts_inline(&self) -> bool {
+        true
+    }
+    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
+        insert_or_warn(app, "iso-date-tomorrow", &iso_date_offset(1));
+        Ok(false)
+    }
+}
+
+pub struct IsoDateYesterdayCommand;
+impl SlashCommand for IsoDateYesterdayCommand {
+    fn name(&self) -> &'static str {
+        "iso-date-yesterday"
+    }
+    fn description(&self) -> &'static str {
+        "Insert yesterday's date as plain ISO — `YYYY-MM-DD` (no brackets)"
+    }
+    fn aliases(&self) -> &'static [&'static str] {
+        &["isody"]
+    }
+    fn inserts_inline(&self) -> bool {
+        true
+    }
+    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
+        insert_or_warn(app, "iso-date-yesterday", &iso_date_offset(-1));
+        Ok(false)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// week-num — `#YYYY-Www` tag for the current ISO week
+// ---------------------------------------------------------------------------
+//
+// Inserted as a `#tag` (not `[[ref]]`) so it routes through the
+// existing tag indexing — weekly notes show up in backlinks for
+// the tag page if it exists.
+
+pub struct WeekNumCommand;
+impl SlashCommand for WeekNumCommand {
+    fn name(&self) -> &'static str {
+        "week-num"
+    }
+    fn description(&self) -> &'static str {
+        "Insert current ISO week as a tag — `#YYYY-Www`"
+    }
+    fn aliases(&self) -> &'static [&'static str] {
+        &["wn", "week"]
+    }
+    fn inserts_inline(&self) -> bool {
+        true
+    }
+    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
+        let s = week_tag(Local::now().date_naive());
+        insert_or_warn(app, "week-num", &s);
+        Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Strip the `[[ ... ]]` wrap and parse the inner ISO date.
+    fn parse_link(s: &str) -> chrono::NaiveDate {
+        assert!(
+            s.starts_with("[[") && s.ends_with("]]"),
+            "not a link: {s:?}"
+        );
+        let inner = &s[2..s.len() - 2];
+        chrono::NaiveDate::parse_from_str(inner, "%Y-%m-%d").unwrap_or_else(|e| {
+            panic!("inner {inner:?} not ISO date: {e}");
+        })
+    }
+
+    #[test]
+    fn today_link_format_matches_journal_slug() {
+        let s = journal_link_offset(0);
+        assert_eq!(s.len(), 14, "expected `[[YYYY-MM-DD]]`, got {s:?}");
+        parse_link(&s); // panics if format is off
+    }
+
+    #[test]
+    fn tomorrow_minus_today_is_one_day() {
+        let today = parse_link(&journal_link_offset(0));
+        let tomorrow = parse_link(&journal_link_offset(1));
+        assert_eq!(tomorrow - today, Duration::days(1));
+    }
+
+    #[test]
+    fn yesterday_minus_today_is_negative_one_day() {
+        let today = parse_link(&journal_link_offset(0));
+        let yesterday = parse_link(&journal_link_offset(-1));
+        assert_eq!(yesterday - today, Duration::days(-1));
+    }
+
+    #[test]
+    fn time_text_is_plain_hhmm() {
+        let s = time_text();
+        assert_eq!(s.len(), 5, "expected HH:MM, got {s:?}");
+        assert!(!s.contains('['), "time should not be a link");
+        assert_eq!(s.chars().nth(2), Some(':'));
+    }
+
+    #[test]
+    fn datetime_text_has_link_then_time() {
+        let s = datetime_text();
+        assert_eq!(s.len(), 20, "expected `[[YYYY-MM-DD]] HH:MM`, got {s:?}");
+        let (link, time) = s.split_once(' ').expect("space between link and time");
+        parse_link(link);
+        assert_eq!(time.len(), 5);
+        assert_eq!(time.chars().nth(2), Some(':'));
+    }
+
+    /// All commands marked `inserts_inline = true` write at the
+    /// cursor — the slash dispatcher relies on this flag to skip the
+    /// `commit_insert()` step. If anyone adds a new inline command,
+    /// this guard catches a missing override.
+    #[test]
+    fn date_commands_advertise_inline_inserts() {
+        assert!(DateTodayCommand.inserts_inline());
+        assert!(DateTomorrowCommand.inserts_inline());
+        assert!(DateYesterdayCommand.inserts_inline());
+        assert!(TimeNowCommand.inserts_inline());
+        assert!(DateTimeNowCommand.inserts_inline());
+        assert!(DateNextWeekCommand.inserts_inline());
+        assert!(DateLastWeekCommand.inserts_inline());
+        assert!(DateNextMondayCommand.inserts_inline());
+        assert!(DateNextFridayCommand.inserts_inline());
+        assert!(DateNextSundayCommand.inserts_inline());
+        assert!(DateCommand.inserts_inline());
+        assert!(IsoDateTodayCommand.inserts_inline());
+        assert!(IsoDateTomorrowCommand.inserts_inline());
+        assert!(IsoDateYesterdayCommand.inserts_inline());
+        assert!(WeekNumCommand.inserts_inline());
+    }
+
+    /// Sanity: existing non-inline commands keep the default `false`,
+    /// so we don't accidentally break the commit-then-dispatch flow.
+    #[test]
+    fn non_date_commands_stay_non_inline() {
+        assert!(!TodayCommand.inserts_inline());
+        assert!(!OpenCommand.inserts_inline());
+        assert!(!SearchCommand.inserts_inline());
+    }
+
+    #[test]
+    fn next_week_is_seven_days_ahead() {
+        let today = parse_link(&journal_link_offset(0));
+        let nw = parse_link(&journal_link_offset(7));
+        assert_eq!(nw - today, Duration::days(7));
+    }
+
+    #[test]
+    fn last_week_is_seven_days_back() {
+        let today = parse_link(&journal_link_offset(0));
+        let lw = parse_link(&journal_link_offset(-7));
+        assert_eq!(today - lw, Duration::days(7));
+    }
+
+    // -- days_until_next_weekday ---------------------------------------------
+
+    #[test]
+    fn next_weekday_on_same_weekday_jumps_seven() {
+        // 2026-05-25 is a Monday.
+        let mon = NaiveDate::from_ymd_opt(2026, 5, 25).unwrap();
+        assert_eq!(days_until_next_weekday(mon, Weekday::Mon), 7);
+    }
+
+    #[test]
+    fn next_weekday_in_same_week() {
+        // Monday → Friday is 4 days.
+        let mon = NaiveDate::from_ymd_opt(2026, 5, 25).unwrap();
+        assert_eq!(days_until_next_weekday(mon, Weekday::Fri), 4);
+    }
+
+    #[test]
+    fn next_weekday_wraps_across_weekend() {
+        // Friday → Monday is 3 days.
+        let fri = NaiveDate::from_ymd_opt(2026, 5, 29).unwrap();
+        assert_eq!(days_until_next_weekday(fri, Weekday::Mon), 3);
+    }
+
+    #[test]
+    fn next_weekday_one_day_forward() {
+        // Tuesday → Wednesday is 1 day.
+        let tue = NaiveDate::from_ymd_opt(2026, 5, 26).unwrap();
+        assert_eq!(days_until_next_weekday(tue, Weekday::Wed), 1);
+    }
+
+    // -- parse_date_arg ------------------------------------------------------
+
+    #[test]
+    fn parse_absolute_iso_date() {
+        let today = NaiveDate::from_ymd_opt(2026, 5, 26).unwrap();
+        let d = parse_date_arg("2026-06-15", today).unwrap();
+        assert_eq!(d, NaiveDate::from_ymd_opt(2026, 6, 15).unwrap());
+    }
+
+    #[test]
+    fn parse_positive_days_offset() {
+        let today = NaiveDate::from_ymd_opt(2026, 5, 26).unwrap();
+        let d = parse_date_arg("+3d", today).unwrap();
+        assert_eq!(d, NaiveDate::from_ymd_opt(2026, 5, 29).unwrap());
+    }
+
+    #[test]
+    fn parse_negative_weeks_offset() {
+        let today = NaiveDate::from_ymd_opt(2026, 5, 26).unwrap();
+        let d = parse_date_arg("-2w", today).unwrap();
+        assert_eq!(d, NaiveDate::from_ymd_opt(2026, 5, 12).unwrap());
+    }
+
+    #[test]
+    fn parse_months_offset_clamps_in_short_months() {
+        // Jan 31 + 1 month → Feb 28 (or 29 in leap years). chrono::Months
+        // clamps to the last valid day, which is exactly what we want.
+        let today = NaiveDate::from_ymd_opt(2026, 1, 31).unwrap();
+        let d = parse_date_arg("+1m", today).unwrap();
+        assert_eq!(d, NaiveDate::from_ymd_opt(2026, 2, 28).unwrap());
+    }
+
+    #[test]
+    fn parse_bare_offset_is_positive() {
+        // No sign means `+` — a UX kindness.
+        let today = NaiveDate::from_ymd_opt(2026, 5, 26).unwrap();
+        let d = parse_date_arg("5d", today).unwrap();
+        assert_eq!(d, NaiveDate::from_ymd_opt(2026, 5, 31).unwrap());
+    }
+
+    #[test]
+    fn parse_rejects_garbage() {
+        let today = NaiveDate::from_ymd_opt(2026, 5, 26).unwrap();
+        assert!(parse_date_arg("nope", today).is_none());
+        assert!(parse_date_arg("+3x", today).is_none());
+        assert!(parse_date_arg("", today).is_none());
+        assert!(parse_date_arg("2026-13-99", today).is_none());
+    }
+
+    // -- iso_date / week_tag -------------------------------------------------
+
+    #[test]
+    fn iso_date_offset_has_no_brackets() {
+        let s = iso_date_offset(0);
+        assert_eq!(s.len(), 10, "expected YYYY-MM-DD, got {s:?}");
+        assert!(!s.contains('['));
+        assert!(NaiveDate::parse_from_str(&s, "%Y-%m-%d").is_ok());
+    }
+
+    #[test]
+    fn week_tag_format_is_hash_year_w_week() {
+        // 2026-05-25 is Monday of ISO week 22 of year 2026.
+        let mon = NaiveDate::from_ymd_opt(2026, 5, 25).unwrap();
+        assert_eq!(week_tag(mon), "#2026-W22");
+    }
+
+    #[test]
+    fn week_tag_uses_iso_week_year_at_boundary() {
+        // 2025-12-31 (Wed) is ISO week 1 of 2026 — `%G` (ISO year)
+        // differs from `%Y` (calendar year) here. Confirms we used %G.
+        let last_of_year = NaiveDate::from_ymd_opt(2025, 12, 31).unwrap();
+        assert_eq!(week_tag(last_of_year), "#2026-W01");
     }
 }

--- a/crates/outl-tui/src/commands/builtins.rs
+++ b/crates/outl-tui/src/commands/builtins.rs
@@ -600,18 +600,14 @@ impl SlashCommand for DateLastWeekCommand {
 // Seven small structs share one body via a macro because the only
 // thing that varies is the name string and the `Weekday` value.
 macro_rules! next_weekday_command {
-    ($struct_name:ident, $name:literal, $weekday:expr, $aliases:expr) => {
+    ($struct_name:ident, $name:literal, $weekday:expr, $label:literal, $aliases:expr) => {
         pub struct $struct_name;
         impl SlashCommand for $struct_name {
             fn name(&self) -> &'static str {
                 $name
             }
             fn description(&self) -> &'static str {
-                concat!(
-                    "Insert next ",
-                    stringify!($weekday),
-                    "'s journal ref — `[[YYYY-MM-DD]]`"
-                )
+                concat!("Insert next ", $label, "'s journal ref — `[[YYYY-MM-DD]]`")
             }
             fn aliases(&self) -> &'static [&'static str] {
                 $aliases
@@ -633,42 +629,49 @@ next_weekday_command!(
     DateNextMondayCommand,
     "date-next-monday",
     Weekday::Mon,
+    "Monday",
     &["dnmon"]
 );
 next_weekday_command!(
     DateNextTuesdayCommand,
     "date-next-tuesday",
     Weekday::Tue,
+    "Tuesday",
     &["dntue"]
 );
 next_weekday_command!(
     DateNextWednesdayCommand,
     "date-next-wednesday",
     Weekday::Wed,
+    "Wednesday",
     &["dnwed"]
 );
 next_weekday_command!(
     DateNextThursdayCommand,
     "date-next-thursday",
     Weekday::Thu,
+    "Thursday",
     &["dnthu"]
 );
 next_weekday_command!(
     DateNextFridayCommand,
     "date-next-friday",
     Weekday::Fri,
+    "Friday",
     &["dnfri"]
 );
 next_weekday_command!(
     DateNextSaturdayCommand,
     "date-next-saturday",
     Weekday::Sat,
+    "Saturday",
     &["dnsat"]
 );
 next_weekday_command!(
     DateNextSundayCommand,
     "date-next-sunday",
     Weekday::Sun,
+    "Sunday",
     &["dnsun"]
 );
 

--- a/crates/outl-tui/src/commands/mod.rs
+++ b/crates/outl-tui/src/commands/mod.rs
@@ -47,6 +47,15 @@ pub(crate) trait SlashCommand: Send + Sync {
         &[]
     }
 
+    /// Whether the command writes text directly into the in-flight
+    /// Insert buffer (`buffer.insert_str(...)`). When `true`, the
+    /// slash dispatcher will *not* commit the Insert before
+    /// dispatching — the command needs the buffer alive at the
+    /// cursor position. Commands like `/date-today` set this.
+    fn inserts_inline(&self) -> bool {
+        false
+    }
+
     /// Run the command. May mutate `app`; returns `Ok(true)` if the
     /// app should quit (used by `:q`).
     fn execute(&self, app: &mut App, args: &str) -> Result<bool>;

--- a/crates/outl-tui/src/fuzzy.rs
+++ b/crates/outl-tui/src/fuzzy.rs
@@ -165,7 +165,7 @@ mod tests {
             .iter()
             .filter_map(|h| fuzzy_score("re", h).map(|s| (s, *h)))
             .collect();
-        scored.sort_by(|a, b| b.0.cmp(&a.0));
+        scored.sort_by_key(|b| std::cmp::Reverse(b.0));
         // The two that *start* with "re" should rank above "meals" / "remember".
         let top_two: Vec<&str> = scored.iter().take(2).map(|(_, h)| *h).collect();
         assert!(top_two.contains(&"readme"));

--- a/crates/outl-tui/src/input.rs
+++ b/crates/outl-tui/src/input.rs
@@ -273,6 +273,11 @@ pub(crate) fn handle_normal_key(app: &mut App, key: KeyEvent) -> Result<bool> {
             return Ok(false);
         }
         KeyCode::Char('?') => app.show_help = !app.show_help,
+        // `Ctrl+T` is the portable alias for `Ctrl+Enter` (TODO toggle)
+        // — tmux without `extended-keys` and Terminal.app collapse
+        // `Ctrl+Enter` to plain `Enter`, so the chord we *want* never
+        // arrives. Must come BEFORE the bare `t` arm.
+        KeyCode::Char('t') if key.modifiers.contains(KeyModifiers::CONTROL) => app.toggle_todo(),
         // `t` and `Home` were sharing one binding: `t` jumps to today,
         // `Home` should move the cursor to the start of the current
         // block. Split them.
@@ -309,11 +314,10 @@ pub(crate) fn handle_normal_key(app: &mut App, key: KeyEvent) -> Result<bool> {
         // Enter is overloaded: if the cursor is sitting on a `[[ref]]`
         // / `#tag` / journal date, open it. Otherwise enter Insert
         // mode (the original behavior).
-        KeyCode::Enter => {
-            if !app.try_open_under_cursor()? {
-                app.enter_insert(false);
-            }
+        KeyCode::Enter if !app.try_open_under_cursor()? => {
+            app.enter_insert(false);
         }
+        KeyCode::Enter => {}
         KeyCode::Char('i') => app.enter_insert(false),
         KeyCode::Char('I') => app.enter_insert(true),
         KeyCode::Char('o') => app.create_block_below(),
@@ -410,7 +414,15 @@ pub(crate) fn handle_insert_key(app: &mut App, key: KeyEvent) -> Result<()> {
         }
         // `Ctrl+Enter` toggles TODO directly inside the buffer — no
         // commit, no new block, cursor preserved relative to text.
+        // `Ctrl+T` is the portable alias for terminals/multiplexers
+        // (tmux, Terminal.app) that collapse `Ctrl+Enter` into plain
+        // `Enter`.
         KeyCode::Enter if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            if let Mode::Insert { buffer, .. } = &mut app.mode {
+                cycle_todo_inline(buffer);
+            }
+        }
+        KeyCode::Char('t') if key.modifiers == KeyModifiers::CONTROL => {
             if let Mode::Insert { buffer, .. } = &mut app.mode {
                 cycle_todo_inline(buffer);
             }

--- a/crates/outl-tui/src/input.rs
+++ b/crates/outl-tui/src/input.rs
@@ -422,7 +422,7 @@ pub(crate) fn handle_insert_key(app: &mut App, key: KeyEvent) -> Result<()> {
                 cycle_todo_inline(buffer);
             }
         }
-        KeyCode::Char('t') if key.modifiers == KeyModifiers::CONTROL => {
+        KeyCode::Char('t') if key.modifiers.contains(KeyModifiers::CONTROL) => {
             if let Mode::Insert { buffer, .. } = &mut app.mode {
                 cycle_todo_inline(buffer);
             }

--- a/crates/outl-tui/src/outline_ops.rs
+++ b/crates/outl-tui/src/outline_ops.rs
@@ -186,6 +186,31 @@ pub fn outdent_at_path(blocks: &mut Vec<OutlineNode>, path: &[usize]) -> Option<
     Some(new_path)
 }
 
+/// Flatten the subtree rooted at `root` into a DFS-ordered sequence of
+/// paths relative to that root. The first entry is always the empty
+/// path `[]` (the root itself); subsequent entries descend into
+/// children in order.
+///
+/// Used by the inline backlinks section so `j`/`k` can step through a
+/// referencing block and its children the same way the main outline
+/// stepping works on `app.page`.
+pub fn flatten_backlink_subtree(root: &OutlineNode) -> Vec<Vec<usize>> {
+    let mut out = Vec::new();
+    let mut stack: Vec<usize> = Vec::new();
+    out.push(stack.clone()); // the root, path = []
+    walk_subtree(root, &mut stack, &mut out);
+    out
+}
+
+fn walk_subtree(node: &OutlineNode, stack: &mut Vec<usize>, out: &mut Vec<Vec<usize>>) {
+    for (i, child) in node.children.iter().enumerate() {
+        stack.push(i);
+        out.push(stack.clone());
+        walk_subtree(child, stack, out);
+        stack.pop();
+    }
+}
+
 /// Delete the node at `path`. Silently no-ops on out-of-range or root.
 pub fn delete_at_path(blocks: &mut Vec<OutlineNode>, path: &[usize]) {
     if path.is_empty() {
@@ -297,6 +322,39 @@ mod tests {
         delete_at_path(&mut blocks, &[0]);
         assert_eq!(blocks.len(), 1);
         assert_eq!(blocks[0].text, "b");
+    }
+
+    #[test]
+    fn flatten_backlink_subtree_returns_dfs_paths() {
+        let root = OutlineNode {
+            text: "root".into(),
+            children: vec![
+                OutlineNode {
+                    text: "a".into(),
+                    children: vec![block("a1"), block("a2")],
+                    ..Default::default()
+                },
+                block("b"),
+            ],
+            ..Default::default()
+        };
+        // DFS preorder: root, a, a1, a2, b
+        assert_eq!(
+            flatten_backlink_subtree(&root),
+            vec![
+                vec![],     // root
+                vec![0],    // a
+                vec![0, 0], // a1
+                vec![0, 1], // a2
+                vec![1],    // b
+            ]
+        );
+    }
+
+    #[test]
+    fn flatten_backlink_subtree_leaf_returns_just_root() {
+        let leaf = block("only-me");
+        assert_eq!(flatten_backlink_subtree(&leaf), vec![Vec::<usize>::new()]);
     }
 
     #[test]

--- a/crates/outl-tui/src/runtime.rs
+++ b/crates/outl-tui/src/runtime.rs
@@ -36,6 +36,15 @@ use std::time::Duration;
 /// filesystem.
 const POLL_INTERVAL: Duration = Duration::from_millis(750);
 
+/// Shorter poll cadence used while a background workspace-index
+/// rebuild is in flight. The worker finishes in tens of ms on a small
+/// vault but the result only reaches the UI on the next event-loop
+/// iteration — without this, the user waits up to `POLL_INTERVAL`
+/// (750 ms) to see backlinks fill in after opening the app. ~60 fps
+/// while we wait costs nothing on idle hardware and disappears the
+/// moment the index lands.
+const POLL_INTERVAL_PENDING_INDEX: Duration = Duration::from_millis(16);
+
 /// Run the TUI against the workspace at `path`.
 ///
 /// Picks the active theme from `.outl/config.toml`'s `[theme] preset`
@@ -210,7 +219,17 @@ fn event_loop(
         // changed under us (external editor saved). This is the
         // simplest hot-reload path — no filesystem watcher, no
         // background thread — and good enough at human latency.
-        if !event::poll(POLL_INTERVAL).unwrap_or(false) {
+        //
+        // While a background index rebuild is in flight, shorten the
+        // timeout so the freshly-built `WorkspaceIndex` shows up in
+        // the UI within ~16 ms of arriving (instead of waiting up to
+        // 750 ms for the next external-edit poll).
+        let poll_timeout = if app.has_pending_index() {
+            POLL_INTERVAL_PENDING_INDEX
+        } else {
+            POLL_INTERVAL
+        };
+        if !event::poll(poll_timeout).unwrap_or(false) {
             app.check_external_changes();
             continue;
         }

--- a/crates/outl-tui/src/state.rs
+++ b/crates/outl-tui/src/state.rs
@@ -21,9 +21,9 @@ use std::path::PathBuf;
 use std::time::SystemTime;
 
 pub(crate) const HELP_HINT_NORMAL: &str =
-    "i edit  o new  h/l cursor  Enter open ref  K/J move  C-Enter TODO  u undo  ? help  q";
+    "i edit  o new  h/l cursor  Enter open ref  K/J move  C-T TODO  u undo  ? help  q";
 pub(crate) const HELP_HINT_INSERT: &str =
-    "Esc commit  Enter new block  Ctrl+Enter TODO  Tab indent  Shift-Tab outdent";
+    "Esc commit  Enter new block  Ctrl+T TODO  Tab indent  Shift-Tab outdent";
 pub(crate) const HELP_HINT_VISUAL: &str =
     "j/k extend  d/x delete  y yank  Tab indent  S-Tab outdent  Esc cancel";
 
@@ -35,6 +35,24 @@ pub(crate) const MAX_HISTORY: usize = 200;
 pub(crate) const TODO_PREFIX: &str = "TODO ";
 pub(crate) const DONE_PREFIX: &str = "DONE ";
 
+/// Where Insert-mode edits get committed.
+///
+/// `CurrentPage` is the historical path: mutate `App.page` and save
+/// through `current_path()`. `SourcePage` is the cross-page route used
+/// when the user edits a backlink in place — the buffer commits
+/// directly into the source page's `.md` without changing `App.view`.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum EditTarget {
+    CurrentPage,
+    SourcePage {
+        path: PathBuf,
+        /// Working copy of the source page's AST. Mutated by the
+        /// buffer commit, then written back to `path` via
+        /// `App::save_page`.
+        page: ParsedPage,
+    },
+}
+
 /// Insert vs Normal vs Visual.
 ///
 /// Visual is a Normal sibling that adds a range anchor: every block
@@ -43,8 +61,11 @@ pub(crate) const DONE_PREFIX: &str = "DONE ";
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum Mode {
     Normal,
-    /// Editing the block at `path` (index into the flattened outline).
+    /// Editing the block at `path`. `block_path` is interpreted
+    /// against `App.page` when `target == CurrentPage`, otherwise
+    /// against `target.page` (the loaded source AST).
     Insert {
+        target: EditTarget,
         block_path: Vec<usize>,
         buffer: EditBuffer,
         original_text: String,
@@ -61,6 +82,30 @@ pub(crate) enum Mode {
 pub(crate) enum View {
     Journal(NaiveDate),
     Page(PathBuf),
+}
+
+/// Where the cursor lives — inside the current page's outline (default)
+/// or inside the inline backlinks section below it.
+///
+/// We carry focus as a *peer of `Mode`* rather than rewriting
+/// `selected: usize` because the vast majority of action methods
+/// (delete, indent, yank, visual range, undo snapshots) operate on the
+/// current page only. Splitting `selected` into a Selection enum would
+/// touch ~40 call sites for a feature that's really a different mode
+/// with a different commit target.
+///
+/// `Focus::Backlink { idx, sub_path }`:
+/// - `idx` indexes `app.index.backlinks(current_slug)`.
+/// - `sub_path` is a DFS path *inside* `Backlink.source_block` — empty
+///   means the source block itself; `[0]` its first child; etc.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) enum Focus {
+    #[default]
+    Outline,
+    Backlink {
+        idx: usize,
+        sub_path: Vec<usize>,
+    },
 }
 
 /// One reversible step.
@@ -283,8 +328,14 @@ pub(crate) struct App {
     /// date.
     pub(crate) index_rx: Option<std::sync::mpsc::Receiver<WorkspaceIndex>>,
 
-    /// Whether to draw the backlinks panel to the right of the outline.
+    /// Whether to draw the inline backlinks section below the outline.
+    /// Toggled with `B`. Default `true` so users discover the feature.
     pub(crate) show_backlinks: bool,
+
+    /// Where the cursor lives — outline (default) or inside the inline
+    /// backlinks section. Reset to `Focus::Outline` whenever the view
+    /// changes (page open, journal navigation, etc).
+    pub(crate) focus: Focus,
 
     /// First visible line of the outline (vertical scroll offset). The
     /// view module keeps this in sync with `selected` — when navigation

--- a/crates/outl-tui/src/view.rs
+++ b/crates/outl-tui/src/view.rs
@@ -1,417 +1,57 @@
 //! ratatui rendering: turn the current `App` into a frame.
 //!
-//! This is the *only* place in the crate that produces `ratatui::Line`
-//! and `Span` values. Anything else (state, actions, key handling) is
-//! UI-agnostic. The block decomposition itself lives upstream in
-//! [`outl_md::view`] so Tauri and mobile clients consume the same
-//! row classification and only need to swap this file out.
+//! This file is the orchestrator — it composes the panels but delegates
+//! the actual painting to siblings:
+//!
+//! - [`overlays`] — every modal popup (quick switcher, search, slash,
+//!   command bar, error, help, inline autocomplete).
+//! - [`outline`] — the current page's block tree.
+//! - [`backlinks`] — the inline backlinks section below the outline.
+//! - [`inline`] — span-level markdown (used by `outline` and
+//!   `backlinks`).
+//!
+//! Only `render_app` is callable from outside the module — the rest is
+//! `pub(crate)` for cross-file reuse inside `view/`.
 
-use crate::actions::truncate_for_snippet;
-use crate::outline_ops::path_for_index;
+mod backlinks;
+mod inline;
+mod outline;
+mod overlays;
+
 use crate::state::{
-    App, AutocompleteKind, AutocompleteState, CommandState, ErrorState, Mode, Overlay,
-    QuickSwitchState, SearchState, SlashState, SwitchKind, View, HELP_HINT_INSERT,
-    HELP_HINT_NORMAL, HELP_HINT_VISUAL,
+    App, Focus, Mode, Overlay, View, HELP_HINT_INSERT, HELP_HINT_NORMAL, HELP_HINT_VISUAL,
 };
-use crate::theme::Theme;
-use outl_md::inline::{byte_index_for_char, tokenize, InlineTok};
-use outl_md::parse::{OutlineNode, ParsedPage};
-use outl_md::view::{block_to_rows, BlockRowKind};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
-use ratatui::style::Style;
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+// Inline-rendering helpers used by tests in `app.rs` — keep them
+// reachable via `crate::view::…` for backwards compat with the
+// pre-split layout.
+#[cfg(test)]
+pub(crate) use inline::{highlight_inline, render_markdown_inline, split_todo_prefix};
 
 pub(crate) fn render_app(f: &mut ratatui::Frame<'_>, app: &mut App) {
     let area = f.area();
-    let backlinks = app.index.backlinks(&app.current_slug()).to_vec();
-    let show_bl = app.show_backlinks && !backlinks.is_empty();
-
-    // Layout: outline takes the whole width when backlinks are off,
-    // outline + backlinks panel when the current page has incoming
-    // refs and the user hasn't toggled it off with `B`.
-    let constraints: Vec<Constraint> = if show_bl {
-        vec![Constraint::Min(40), Constraint::Length(32)]
-    } else {
-        vec![Constraint::Min(40)]
-    };
-    let cols = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints(constraints)
-        .split(area);
-    if show_bl {
-        render_backlinks_panel(f, cols[1], app, &backlinks);
-    }
-    render_main(f, cols[0], app);
+    render_main(f, area, app);
 
     // Overlays draw on top of everything else.
     match &app.overlay {
-        Some(Overlay::QuickSwitch(qs)) => render_quick_switch(f, area, app, qs),
-        Some(Overlay::Search(s)) => render_search_overlay(f, area, app, s),
-        Some(Overlay::Command(c)) => render_command_bar(f, area, app, c),
-        Some(Overlay::Error(e)) => render_error_overlay(f, area, app, e),
-        Some(Overlay::Slash(s)) => render_slash_overlay(f, area, app, s),
+        Some(Overlay::QuickSwitch(qs)) => overlays::render_quick_switch(f, area, app, qs),
+        Some(Overlay::Search(s)) => overlays::render_search_overlay(f, area, app, s),
+        Some(Overlay::Command(c)) => overlays::render_command_bar(f, area, app, c),
+        Some(Overlay::Error(e)) => overlays::render_error_overlay(f, area, app, e),
+        Some(Overlay::Slash(s)) => overlays::render_slash_overlay(f, area, app, s),
         None => {}
     }
 
     if let Some(ac) = &app.autocomplete {
-        render_autocomplete(f, area, app, ac);
+        overlays::render_autocomplete(f, area, app, ac);
     }
 
     if app.show_help {
-        render_help_popup(f, area, app);
+        overlays::render_help_popup(f, area, app);
     }
-}
-
-fn render_autocomplete(f: &mut ratatui::Frame<'_>, full: Rect, app: &App, ac: &AutocompleteState) {
-    let height = (ac.candidates.len() as u16 + 2).min(10);
-    if height < 3 {
-        return;
-    }
-    let width = 36u16.min(full.width.saturating_sub(4));
-    // Bottom-right anchor so it doesn't fight with the outline.
-    let area = Rect {
-        x: full.x + full.width.saturating_sub(width + 2),
-        y: full.y + full.height.saturating_sub(height + 2),
-        width,
-        height,
-    };
-    f.render_widget(Clear, area);
-    let title = match ac.kind {
-        AutocompleteKind::PageRef => format!("[[{}]]", ac.query),
-        AutocompleteKind::Tag => format!("#{}", ac.query),
-        AutocompleteKind::SlashCommand => format!("/{}", ac.query),
-    };
-    let items: Vec<ListItem<'_>> = ac
-        .candidates
-        .iter()
-        .enumerate()
-        .map(|(i, c)| {
-            let style = if i == ac.selected {
-                app.theme.list_selected
-            } else {
-                Style::default()
-            };
-            // Decorate the candidate row according to its kind. For
-            // pages/tags we prepend the page's `icon::` (display-only);
-            // for slash commands we append a dim description so the
-            // popup doubles as in-context help.
-            match ac.kind {
-                AutocompleteKind::PageRef | AutocompleteKind::Tag => {
-                    let icon = match ac.kind {
-                        AutocompleteKind::PageRef => {
-                            app.index.by_title(c).and_then(|p| p.icon.clone())
-                        }
-                        AutocompleteKind::Tag => app.index.by_slug(c).and_then(|p| p.icon.clone()),
-                        _ => None,
-                    };
-                    let label = match icon {
-                        Some(ic) => format!("{ic} {c}"),
-                        None => c.clone(),
-                    };
-                    ListItem::new(Line::from(Span::styled(label, style)))
-                }
-                AutocompleteKind::SlashCommand => {
-                    let cmd = app.command_registry.get(c);
-                    let description = cmd.as_ref().map(|cmd| cmd.description()).unwrap_or("");
-                    let needs_args = cmd.as_ref().map(|cmd| cmd.needs_args()).unwrap_or(false);
-                    let suffix = if needs_args { " …" } else { "" };
-                    ListItem::new(Line::from(vec![
-                        Span::styled(format!("{c}{suffix}  "), style),
-                        Span::styled(description.to_string(), app.theme.dim),
-                    ]))
-                }
-            }
-        })
-        .collect();
-    let list = List::new(items)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(app.theme.border)
-                .title(Span::styled(title, app.theme.help_title)),
-        )
-        .style(Style::default().bg(app.theme.popup_bg));
-    f.render_widget(list, area);
-}
-
-fn centered_rect(full: Rect, w_pct: u16, h_pct: u16) -> Rect {
-    let w = (full.width as u32 * w_pct as u32 / 100) as u16;
-    let h = (full.height as u32 * h_pct as u32 / 100) as u16;
-    Rect {
-        x: full.x + (full.width.saturating_sub(w)) / 2,
-        y: full.y + (full.height.saturating_sub(h)) / 2,
-        width: w,
-        height: h,
-    }
-}
-
-fn render_quick_switch(f: &mut ratatui::Frame<'_>, full: Rect, app: &App, qs: &QuickSwitchState) {
-    let area = centered_rect(full, 60, 60);
-    f.render_widget(Clear, area);
-
-    let outer = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Length(3), Constraint::Min(3)])
-        .split(area);
-
-    let input = Paragraph::new(Line::from(vec![
-        Span::styled(" › ", app.theme.help_title),
-        Span::raw(qs.query.clone()),
-        Span::styled("▏", app.theme.cursor_caret),
-    ]))
-    .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_style(app.theme.border)
-            .title(Span::styled("Quick Switcher", app.theme.help_title)),
-    )
-    .style(Style::default().bg(app.theme.popup_bg));
-    f.render_widget(input, outer[0]);
-
-    let items: Vec<ListItem<'_>> = qs
-        .candidates
-        .iter()
-        .enumerate()
-        .map(|(i, c)| {
-            let icon = match c.kind {
-                SwitchKind::Page => "📄 ",
-                SwitchKind::Journal => "📅 ",
-            };
-            let style = if i == qs.selected {
-                app.theme.list_selected
-            } else {
-                Style::default()
-            };
-            ListItem::new(Line::from(vec![
-                Span::raw(icon),
-                Span::styled(c.label.clone(), style),
-            ]))
-        })
-        .collect();
-    let list = List::new(items)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(app.theme.border)
-                .title(format!(
-                    "{} matches  ↑↓ navigate · Enter open · Esc cancel",
-                    qs.candidates.len()
-                )),
-        )
-        .style(Style::default().bg(app.theme.popup_bg));
-    f.render_widget(list, outer[1]);
-}
-
-fn render_search_overlay(f: &mut ratatui::Frame<'_>, full: Rect, app: &App, s: &SearchState) {
-    let area = centered_rect(full, 75, 70);
-    f.render_widget(Clear, area);
-
-    let outer = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Length(3), Constraint::Min(3)])
-        .split(area);
-
-    let input = Paragraph::new(Line::from(vec![
-        Span::styled(" / ", app.theme.help_title),
-        Span::raw(s.query.clone()),
-        Span::styled("▏", app.theme.cursor_caret),
-    ]))
-    .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_style(app.theme.border)
-            .title(Span::styled("Search", app.theme.help_title)),
-    )
-    .style(Style::default().bg(app.theme.popup_bg));
-    f.render_widget(input, outer[0]);
-
-    let lines: Vec<Line<'_>> = s
-        .hits
-        .iter()
-        .enumerate()
-        .map(|(i, h)| {
-            let style = if i == s.selected {
-                app.theme.list_selected
-            } else {
-                Style::default()
-            };
-            let icon_prefix = h
-                .page_icon
-                .as_deref()
-                .map(|i| format!("{i} "))
-                .unwrap_or_default();
-            Line::from(vec![
-                Span::styled(format!(" {icon_prefix}{} · ", h.page_label), app.theme.dim),
-                Span::styled(h.snippet.clone(), style),
-            ])
-        })
-        .collect();
-    let list = Paragraph::new(lines)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(app.theme.border)
-                .title(format!(
-                    "{} hits  ↑↓ navigate · Enter jump · Esc cancel",
-                    s.hits.len()
-                )),
-        )
-        .style(Style::default().bg(app.theme.popup_bg))
-        .wrap(ratatui::widgets::Wrap { trim: false });
-    f.render_widget(list, outer[1]);
-}
-
-fn render_slash_overlay(f: &mut ratatui::Frame<'_>, full: Rect, app: &App, s: &SlashState) {
-    let area = centered_rect(full, 60, 60);
-    f.render_widget(Clear, area);
-
-    let outer = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Length(3), Constraint::Min(3)])
-        .split(area);
-
-    let input = Paragraph::new(Line::from(vec![
-        Span::styled(" / ", app.theme.help_title),
-        Span::raw(s.query.clone()),
-        Span::styled("▏", app.theme.cursor_caret),
-    ]))
-    .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_style(app.theme.border)
-            .title(Span::styled("Commands", app.theme.help_title)),
-    )
-    .style(Style::default().bg(app.theme.popup_bg));
-    f.render_widget(input, outer[0]);
-
-    let items: Vec<ListItem<'_>> = s
-        .candidates
-        .iter()
-        .enumerate()
-        .map(|(i, c)| {
-            let style = if i == s.selected {
-                app.theme.list_selected
-            } else {
-                Style::default()
-            };
-            // Two-column-ish: name on the left, description dimmed
-            // on the right. The `…` glyph hints at "this one asks
-            // for args next".
-            let suffix = if c.needs_args { " …" } else { "" };
-            ListItem::new(Line::from(vec![
-                Span::styled(format!(" {}{suffix}  ", c.name), style),
-                Span::styled(c.description.to_string(), app.theme.dim),
-            ]))
-        })
-        .collect();
-    let list = List::new(items)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(app.theme.border)
-                .title(format!(
-                    "{} commands  ↑↓ navigate · Enter run · Esc cancel",
-                    s.candidates.len()
-                )),
-        )
-        .style(Style::default().bg(app.theme.popup_bg));
-    f.render_widget(list, outer[1]);
-}
-
-fn render_error_overlay(f: &mut ratatui::Frame<'_>, full: Rect, app: &App, err: &ErrorState) {
-    // Auto-size: pick 80% of the viewport, capped so a tiny body
-    // doesn't draw a giant empty modal.
-    let body_lines = err.body.lines().count().max(1) as u16;
-    let popup_w = (full.width as f32 * 0.8) as u16;
-    let popup_h = (body_lines + 4).min((full.height as f32 * 0.7) as u16);
-    let x = (full.width.saturating_sub(popup_w)) / 2;
-    let y = (full.height.saturating_sub(popup_h)) / 2;
-    let area = Rect {
-        x,
-        y,
-        width: popup_w,
-        height: popup_h,
-    };
-    f.render_widget(Clear, area);
-
-    let lines: Vec<Line<'_>> = err
-        .body
-        .lines()
-        .map(|l| Line::from(Span::raw(l.to_string())))
-        .collect();
-
-    let title = format!(" ✕ {} · press any key to dismiss ", err.title);
-    let widget = Paragraph::new(lines)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(app.theme.status_message)
-                .title(Span::styled(title, app.theme.status_message)),
-        )
-        .style(Style::default().bg(app.theme.popup_bg))
-        .wrap(ratatui::widgets::Wrap { trim: false });
-    f.render_widget(widget, area);
-}
-
-fn render_command_bar(f: &mut ratatui::Frame<'_>, full: Rect, app: &App, c: &CommandState) {
-    let h = 3u16;
-    let area = Rect {
-        x: full.x,
-        y: full.y + full.height.saturating_sub(h),
-        width: full.width,
-        height: h,
-    };
-    f.render_widget(Clear, area);
-    let line = Line::from(vec![
-        Span::styled(" : ", app.theme.help_title),
-        Span::raw(c.buffer.clone()),
-        Span::styled("▏", app.theme.cursor_caret),
-    ]);
-    let bar = Paragraph::new(line)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(app.theme.border),
-        )
-        .style(Style::default().bg(app.theme.popup_bg));
-    f.render_widget(bar, area);
-}
-
-fn render_backlinks_panel(
-    f: &mut ratatui::Frame<'_>,
-    area: Rect,
-    app: &App,
-    backlinks: &[outl_md::index::Backlink],
-) {
-    let mut lines: Vec<Line<'_>> = Vec::new();
-    let mut last_source: Option<String> = None;
-    for bl in backlinks {
-        if last_source.as_deref() != Some(bl.source_slug.as_str()) {
-            let header = match &bl.source_icon {
-                Some(icon) => format!("{icon} {}", bl.source_title),
-                None => bl.source_title.clone(),
-            };
-            lines.push(Line::from(Span::styled(header, app.theme.heading)));
-            last_source = Some(bl.source_slug.clone());
-        }
-        lines.push(Line::from(vec![
-            Span::styled("  • ", app.theme.bullet),
-            Span::raw(truncate_for_snippet(&bl.snippet, 60)),
-        ]));
-    }
-    if lines.is_empty() {
-        lines.push(Line::from(Span::styled("No backlinks yet", app.theme.dim)));
-    }
-    let widget = Paragraph::new(lines)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(app.theme.border)
-                .title(format!("Backlinks · {} ref(s)", backlinks.len())),
-        )
-        .wrap(ratatui::widgets::Wrap { trim: false });
-    f.render_widget(widget, area);
 }
 
 fn render_main(f: &mut ratatui::Frame<'_>, area: Rect, app: &mut App) {
@@ -451,10 +91,26 @@ fn render_main(f: &mut ratatui::Frame<'_>, area: Rect, app: &mut App) {
     );
     f.render_widget(header, outer[0]);
 
-    let (lines, selected_line) = render_outline(&app.page, app);
+    // Build the single scrollable region: outline lines, then the
+    // inline backlinks section. The `─` separator and headers live
+    // inside `backlinks::render_backlinks_inline`.
+    let (mut all_lines, sel_outline) = outline::render_outline(&app.page, app);
+    let outline_len = all_lines.len();
+    let inner_width = outer[1].width.saturating_sub(2);
+    let (bl_lines, sel_bl) = backlinks::render_backlinks_inline(app, inner_width);
+    let bl_offset = all_lines.len();
+    all_lines.extend(bl_lines);
+
     let title = match &app.view {
         View::Journal(_) | View::Page(_) => "Outline",
     };
+
+    // Pick the selected line based on where the focus currently is.
+    let selected_line = match &app.focus {
+        Focus::Outline => sel_outline,
+        Focus::Backlink { .. } => sel_bl.map(|n| n + bl_offset),
+    };
+    let _ = outline_len; // kept for future scroll heuristics
 
     // Viewport math: outer[1] is the outline area (borders included).
     // Subtract 2 for top + bottom border lines to get the actually
@@ -474,7 +130,7 @@ fn render_main(f: &mut ratatui::Frame<'_>, area: Rect, app: &mut App) {
         }
     }
     // Clamp: never scroll past `last_line - viewport_h + 1`.
-    let total = lines.len() as u16;
+    let total = all_lines.len() as u16;
     if total > viewport_h {
         let max_scroll = total - viewport_h;
         if app.scroll_y > max_scroll {
@@ -493,7 +149,7 @@ fn render_main(f: &mut ratatui::Frame<'_>, area: Rect, app: &mut App) {
     } else {
         String::new()
     };
-    let outline = Paragraph::new(lines)
+    let body = Paragraph::new(all_lines)
         .block(
             Block::default()
                 .borders(Borders::ALL)
@@ -506,7 +162,7 @@ fn render_main(f: &mut ratatui::Frame<'_>, area: Rect, app: &mut App) {
     // `selected_line` index. We trade off-screen long lines (rare,
     // and you can horizontal-scroll later) for a correct vertical
     // scroll today.
-    f.render_widget(outline, outer[1]);
+    f.render_widget(body, outer[1]);
 
     let (mode_label, mode_style) = match app.mode {
         Mode::Normal => (" NORMAL ", app.theme.status_normal),
@@ -542,442 +198,4 @@ fn render_main(f: &mut ratatui::Frame<'_>, area: Rect, app: &mut App) {
             .border_style(app.theme.border),
     );
     f.render_widget(footer, outer[2]);
-}
-
-fn render_help_popup(f: &mut ratatui::Frame<'_>, full: Rect, app: &App) {
-    let popup_w = (full.width as f32 * 0.7) as u16;
-    let popup_h = 34u16.min(full.height.saturating_sub(2));
-    let x = (full.width.saturating_sub(popup_w)) / 2;
-    let y = (full.height.saturating_sub(popup_h)) / 2;
-    let area = Rect {
-        x,
-        y,
-        width: popup_w,
-        height: popup_h,
-    };
-    let body = vec![
-        Line::from(Span::styled("NORMAL mode", app.theme.help_title)),
-        Line::from("  i           edit current block"),
-        Line::from("  I           edit, cursor at start of block"),
-        Line::from("  o / O       new block below / above"),
-        Line::from("  Enter       open [[ref]] / #tag / journal under cursor"),
-        Line::from("              (falls back to edit if nothing matches)"),
-        Line::from("  j / k / ↑ ↓ move between blocks"),
-        Line::from("  PgDn/PgUp   move one viewport down/up"),
-        Line::from("  Ctrl+D / U  half-page down/up"),
-        Line::from("  g g / G     first / last block"),
-        Line::from("  h / l / ← → move cursor inside the current block"),
-        Line::from("  w / b       cursor to next / previous word"),
-        Line::from("  0 / $       cursor to start / end of block"),
-        Line::from("  Tab / S-Tab indent / outdent"),
-        Line::from("  K / J       move block up / down (Alt+↑/↓ too)"),
-        Line::from("  dd          delete block"),
-        Line::from("  yy / p / P  yank · paste after · paste before"),
-        Line::from("  Ctrl+Enter  cycle TODO / DONE / none"),
-        Line::from("  u           undo"),
-        Line::from("  Ctrl+R      redo"),
-        Line::from("  Ctrl+S      force save"),
-        Line::from("  Ctrl+L      refresh workspace (re-read from disk)"),
-        Line::from("  t           today's journal"),
-        Line::from("  [ / ]       previous / next journal"),
-        Line::from("  g j         jump to today"),
-        Line::from("  g x         run code block under cursor (also `:run`)"),
-        Line::from("  B           toggle backlinks panel"),
-        Line::from("  ?           toggle this help"),
-        Line::from("  q q         quit (chord — single `q` arms it)"),
-        Line::from(""),
-        Line::from(Span::styled("Overlays", app.theme.help_title)),
-        Line::from("  Ctrl+P      quick switcher (pages + journals)"),
-        Line::from("  /           slash commands (prop, search, run, ...)"),
-        Line::from("  n / N       next / previous search hit"),
-        Line::from("  :           vim-style palette (same registry as /)"),
-        Line::from(""),
-        Line::from(Span::styled("INSERT mode", app.theme.help_title)),
-        Line::from("  Esc         commit"),
-        Line::from("  Enter       commit + new block below"),
-        Line::from("  Ctrl+Enter  cycle TODO / DONE / none (stays in Insert)"),
-        Line::from("  Tab / S-Tab indent / outdent (stays in Insert)"),
-        Line::from("  [[ / #      autocomplete from existing page titles"),
-        Line::from(""),
-        Line::from(Span::styled(
-            format!("theme: {}", app.theme.name),
-            app.theme.dim,
-        )),
-    ];
-    let popup = Paragraph::new(body)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(app.theme.border)
-                .title(Span::styled("Help", app.theme.help_title)),
-        )
-        .style(Style::default().bg(app.theme.popup_bg));
-    f.render_widget(Clear, area);
-    f.render_widget(popup, area);
-}
-
-/// Render the outline into a flat list of `Line`s for ratatui, and
-/// report the visual line index where the *selected* block's bullet
-/// row landed. The caller uses that index to keep the selection
-/// inside the scrolled viewport.
-fn render_outline(p: &ParsedPage, app: &App) -> (Vec<Line<'static>>, Option<usize>) {
-    let mut out = Vec::new();
-    for (k, v) in &p.properties {
-        out.push(Line::from(vec![
-            Span::styled(format!("{k}:: "), app.theme.property_key),
-            Span::styled(v.clone(), app.theme.property_value),
-        ]));
-    }
-    if !p.properties.is_empty() && !p.blocks.is_empty() {
-        out.push(Line::from(""));
-    }
-    let mut cursor = 0usize;
-    let mut selected_line: Option<usize> = None;
-    for block in &p.blocks {
-        render_block(block, 0, &mut cursor, app, &mut out, &mut selected_line);
-    }
-    (out, selected_line)
-}
-
-/// Strip an optional `TODO`/`DONE` prefix off a block's text, returning
-/// both the stripped body and a marker describing what was present.
-pub(crate) fn split_todo_prefix(text: &str) -> (Option<bool>, &str) {
-    if let Some(rest) = text.strip_prefix("TODO ") {
-        return (Some(false), rest);
-    }
-    if let Some(rest) = text.strip_prefix("DONE ") {
-        return (Some(true), rest);
-    }
-    (None, text)
-}
-
-fn render_block(
-    b: &OutlineNode,
-    indent: u32,
-    cursor: &mut usize,
-    app: &App,
-    out: &mut Vec<Line<'static>>,
-    selected_line: &mut Option<usize>,
-) {
-    let is_selected = *cursor == app.selected;
-    // Record the visual line where this block's bullet row begins so
-    // the caller can scroll the viewport to keep it visible.
-    if is_selected && selected_line.is_none() {
-        *selected_line = Some(out.len());
-    }
-    let in_visual_range = app
-        .visual_range()
-        .is_some_and(|(lo, hi)| *cursor >= lo && *cursor <= hi);
-    let editing_here = matches!(&app.mode, Mode::Insert { block_path, .. }
-        if path_for_index(&app.page.blocks, *cursor).as_deref() == Some(block_path.as_slice()));
-
-    let bullet_style = if is_selected || in_visual_range {
-        app.theme.selected_bullet
-    } else {
-        app.theme.bullet
-    };
-
-    // Determine which text and cursor position to render. Three cases:
-    //   1. Editing here       → buffer with caret cursor.
-    //   2. Selected in Normal → block text with block-style cursor.
-    //   3. Anything else      → block text, no cursor, pretty render.
-    let mode = if editing_here {
-        if let Mode::Insert { buffer, .. } = &app.mode {
-            RenderMode::Editing {
-                text: buffer.as_string(),
-                cursor_char: buffer.cursor,
-            }
-        } else {
-            unreachable!("editing_here matched but mode isn't Insert")
-        }
-    } else if is_selected && matches!(app.mode, Mode::Normal) {
-        RenderMode::NormalCursor {
-            text: b.text.clone(),
-            cursor_char: app.cursor_col,
-        }
-    } else {
-        RenderMode::Pretty {
-            text: b.text.clone(),
-        }
-    };
-
-    let has_auto_run = b.properties.iter().any(|(k, _)| k == "auto-run");
-    emit_block_lines(indent, bullet_style, &mode, has_auto_run, app, out);
-
-    for (k, v) in &b.properties {
-        let mut prop_spans: Vec<Span<'_>> = Vec::new();
-        for _ in 0..indent {
-            prop_spans.push(Span::styled("│ ", app.theme.dim));
-        }
-        prop_spans.push(Span::raw("  ".to_string()));
-        prop_spans.push(Span::styled(format!("{k}:: "), app.theme.property_key));
-        prop_spans.push(Span::styled(v.clone(), app.theme.property_value));
-        out.push(Line::from(prop_spans));
-    }
-    *cursor += 1;
-    for child in &b.children {
-        render_block(child, indent + 1, cursor, app, out, selected_line);
-    }
-}
-
-/// Where the cursor sits on a block being rendered, and what style
-/// the renderer should use for it. The UI-agnostic decomposition
-/// lives in [`outl_md::view`]; this enum carries the *TUI-flavored*
-/// detail of "caret vs block cursor".
-pub(crate) enum RenderMode {
-    /// Insert mode — show the live buffer with a thin caret at
-    /// `cursor_char`. Markdown is rendered raw so columns match bytes.
-    Editing { text: String, cursor_char: usize },
-    /// Normal mode on the selected block — show a vim-style block
-    /// cursor on the character under `cursor_char`. Raw render.
-    NormalCursor { text: String, cursor_char: usize },
-    /// Anything else — markdown is rendered prettily; no cursor.
-    Pretty { text: String },
-}
-
-/// Emit one or more ratatui [`Line`]s for a block's text.
-///
-/// Decomposition into visual rows (bullet vs continuation vs code
-/// fence marker vs code fence body) is delegated to
-/// [`outl_md::view::block_to_rows`] so the Tauri GUI and mobile
-/// clients use the same classification. This function is the
-/// TUI-specific mapping: each [`outl_md::view::BlockRow`] becomes a
-/// `Line` of `Span`s using the active theme.
-fn emit_block_lines(
-    indent: u32,
-    bullet_style: Style,
-    mode: &RenderMode,
-    has_auto_run: bool,
-    app: &App,
-    out: &mut Vec<Line<'static>>,
-) {
-    let (text, cursor_char, cursor_style) = match mode {
-        RenderMode::Editing { text, cursor_char } => {
-            (text.as_str(), Some(*cursor_char), Some(CursorStyle::Caret))
-        }
-        RenderMode::NormalCursor { text, cursor_char } => {
-            (text.as_str(), Some(*cursor_char), Some(CursorStyle::Block))
-        }
-        RenderMode::Pretty { text } => (text.as_str(), None, None),
-    };
-    let pretty = matches!(mode, RenderMode::Pretty { .. });
-    let rows = block_to_rows(text, indent, cursor_char);
-
-    // TODO/DONE checkbox decoration only fits on single-line bullets
-    // (multi-line ones would have the icon floating above body text).
-    let single_line_pretty = pretty && rows.len() == 1;
-
-    for row in &rows {
-        let mut spans: Vec<Span<'_>> = Vec::new();
-        for _ in 0..row.indent {
-            spans.push(Span::styled("│ ", app.theme.dim));
-        }
-        match row.kind {
-            BlockRowKind::Bullet => {
-                // Blocks with `auto-run::` get a ⚡ before the bullet
-                // so the user can see at a glance which cells re-run
-                // themselves on page open.
-                if has_auto_run {
-                    spans.push(Span::styled("⚡", app.theme.hint));
-                }
-                spans.push(Span::styled("- ", bullet_style));
-            }
-            BlockRowKind::Continuation
-            | BlockRowKind::CodeFenceMarker
-            | BlockRowKind::CodeFenceBody => {
-                // Indent the continuation rows by the same width
-                // the ⚡ added on the bullet row so columns align.
-                if has_auto_run {
-                    spans.push(Span::raw(" "));
-                }
-                spans.push(Span::raw("  "));
-            }
-        }
-
-        // If the cursor is on this row we always go raw — we want
-        // bytes to line up with what the user typed, regardless of
-        // fence state.
-        if let (Some(col), Some(style)) = (row.cursor_col, cursor_style) {
-            emit_row_with_cursor(row.text, col, style, &app.theme, &mut spans);
-        } else {
-            // A bullet row whose text opens a code fence (`` ```lisp ``)
-            // is *both* a bullet and a fence marker — style the text
-            // dimly so the fence reads visually like the rest of the
-            // code block while keeping the `- ` glyph emitted above.
-            let bullet_is_fence_opener = matches!(row.kind, BlockRowKind::Bullet)
-                && row.text.trim_start().starts_with("```");
-            match row.kind {
-                _ if pretty && bullet_is_fence_opener => {
-                    spans.push(Span::styled(row.text.to_string(), app.theme.dim));
-                }
-                BlockRowKind::CodeFenceMarker if pretty => {
-                    spans.push(Span::styled(row.text.to_string(), app.theme.dim));
-                }
-                BlockRowKind::CodeFenceBody if pretty => {
-                    spans.push(Span::styled(row.text.to_string(), app.theme.code));
-                }
-                BlockRowKind::Bullet if single_line_pretty => {
-                    let (todo_state, body) = split_todo_prefix(row.text);
-                    match todo_state {
-                        Some(false) => {
-                            spans.push(Span::styled("☐ ", app.theme.todo_open));
-                            spans.extend(render_markdown_inline(body, &app.theme, &app.index));
-                        }
-                        Some(true) => {
-                            spans.push(Span::styled("☑ ", app.theme.todo_done));
-                            for sp in render_markdown_inline(body, &app.theme, &app.index) {
-                                spans.push(Span::styled(
-                                    sp.content.into_owned(),
-                                    sp.style.patch(app.theme.todo_done_body),
-                                ));
-                            }
-                        }
-                        None => {
-                            spans.extend(render_markdown_inline(row.text, &app.theme, &app.index))
-                        }
-                    }
-                }
-                _ => spans.extend(render_markdown_inline(row.text, &app.theme, &app.index)),
-            }
-        }
-        out.push(Line::from(spans));
-    }
-}
-
-/// Draw one row with the cursor highlighted at `col` (a char index
-/// into `text`). Splits the row in three: left of cursor, the char
-/// under the cursor (or a thin caret if past-end), right of cursor.
-fn emit_row_with_cursor(
-    text: &str,
-    col: usize,
-    style: CursorStyle,
-    theme: &Theme,
-    spans: &mut Vec<Span<'static>>,
-) {
-    let byte = byte_index_for_char(text, col);
-    let (left, right) = text.split_at(byte);
-    spans.extend(highlight_inline(left, theme));
-    let mut right_chars = right.chars();
-    match (right_chars.next(), style) {
-        (Some(ch), CursorStyle::Caret) => {
-            // Thin caret BEFORE the next char.
-            spans.push(Span::styled("▏", theme.cursor_caret));
-            spans.push(Span::raw(ch.to_string()));
-            let rest: String = right_chars.collect();
-            spans.extend(highlight_inline(&rest, theme));
-        }
-        (Some(ch), CursorStyle::Block) => {
-            // Inverted-color block cursor on the char under it.
-            spans.push(Span::styled(ch.to_string(), theme.cursor_block));
-            let rest: String = right_chars.collect();
-            spans.extend(highlight_inline(&rest, theme));
-        }
-        (None, CursorStyle::Caret) => {
-            spans.push(Span::styled("▏", theme.cursor_caret));
-        }
-        (None, CursorStyle::Block) => {
-            spans.push(Span::styled("▏", theme.cursor_block));
-        }
-    }
-}
-
-/// Cursor visual style. `Caret` is the thin `▏` (Insert mode);
-/// `Block` is the inverted single-char box (Normal mode on the
-/// selected block).
-#[derive(Debug, Clone, Copy)]
-enum CursorStyle {
-    Caret,
-    Block,
-}
-
-/// Render with markdown stripped — bold/italic/code/strike applied as
-/// styles, `[[ref]]` / `#tag` / `[text](url)` shown without their
-/// delimiters. Used when the block is read-only (not selected, not in
-/// Insert mode).
-///
-/// Looks up `[[ref]]` / `#tag` targets in `index` to prepend the
-/// page's `icon::` when one is set. The icon is *display-only* — the
-/// underlying `.md` keeps the plain `[[Title]]` / `#tag` text.
-///
-/// `highlight_inline` (the raw, cursor-bearing render) deliberately
-/// does *not* take this path — adding a non-source glyph would
-/// break column-to-byte alignment for the visible cursor.
-pub(crate) fn render_markdown_inline(
-    text: &str,
-    theme: &Theme,
-    index: &outl_md::index::WorkspaceIndex,
-) -> Vec<Span<'static>> {
-    let mut out = Vec::new();
-    for tok in tokenize(text) {
-        match tok {
-            InlineTok::Plain(s) => out.push(Span::raw(s.to_string())),
-            InlineTok::PageRef { name } => {
-                if let Some(icon) = index.by_title(name).and_then(|p| p.icon.as_deref()) {
-                    out.push(Span::styled(format!("{icon} "), theme.dim));
-                }
-                out.push(Span::styled(name.to_string(), theme.ref_link));
-            }
-            InlineTok::Tag { name } => {
-                if let Some(icon) = index.by_slug(name).and_then(|p| p.icon.as_deref()) {
-                    out.push(Span::styled(format!("{icon} "), theme.dim));
-                }
-                out.push(Span::styled(format!("#{name}"), theme.tag_link));
-            }
-            InlineTok::Bold { inner } => out.push(Span::styled(inner.to_string(), theme.bold)),
-            InlineTok::Italic { inner, .. } => {
-                out.push(Span::styled(inner.to_string(), theme.italic))
-            }
-            InlineTok::Strike { inner } => out.push(Span::styled(inner.to_string(), theme.strike)),
-            InlineTok::Code { inner } => out.push(Span::styled(inner.to_string(), theme.code)),
-            InlineTok::Link { text, .. } => out.push(Span::styled(text.to_string(), theme.md_link)),
-        }
-    }
-    out
-}
-
-/// Render with markdown markers visible (dimmed) and inner text styled.
-/// Used when the block is selected in Normal mode (so the visible cursor
-/// columns match the underlying source bytes) or in Insert mode. The
-/// delimiters themselves use a dim style so the formatting markers
-/// don't distract.
-pub(crate) fn highlight_inline(text: &str, theme: &Theme) -> Vec<Span<'static>> {
-    let mut out = Vec::new();
-    let dim = theme.dim;
-
-    for tok in tokenize(text) {
-        match tok {
-            InlineTok::Plain(s) => out.push(Span::raw(s.to_string())),
-            InlineTok::PageRef { name } => {
-                out.push(Span::styled(format!("[[{name}]]"), theme.ref_link))
-            }
-            InlineTok::Tag { name } => out.push(Span::styled(format!("#{name}"), theme.tag_link)),
-            InlineTok::Bold { inner } => {
-                out.push(Span::styled("**".to_string(), dim));
-                out.push(Span::styled(inner.to_string(), theme.bold));
-                out.push(Span::styled("**".to_string(), dim));
-            }
-            InlineTok::Italic { inner, marker } => {
-                let m = marker.to_string();
-                out.push(Span::styled(m.clone(), dim));
-                out.push(Span::styled(inner.to_string(), theme.italic));
-                out.push(Span::styled(m, dim));
-            }
-            InlineTok::Strike { inner } => {
-                out.push(Span::styled("~~".to_string(), dim));
-                out.push(Span::styled(inner.to_string(), theme.strike));
-                out.push(Span::styled("~~".to_string(), dim));
-            }
-            InlineTok::Code { inner } => {
-                out.push(Span::styled("`".to_string(), dim));
-                out.push(Span::styled(inner.to_string(), theme.code));
-                out.push(Span::styled("`".to_string(), dim));
-            }
-            InlineTok::Link { text, url } => {
-                out.push(Span::styled("[".to_string(), dim));
-                out.push(Span::styled(text.to_string(), theme.md_link));
-                out.push(Span::styled(format!("]({url})"), dim));
-            }
-        }
-    }
-    out
 }

--- a/crates/outl-tui/src/view.rs
+++ b/crates/outl-tui/src/view.rs
@@ -3,11 +3,11 @@
 //! This file is the orchestrator — it composes the panels but delegates
 //! the actual painting to siblings:
 //!
-//! - [`overlays`] — every modal popup (quick switcher, search, slash,
+//! - `overlays` — every modal popup (quick switcher, search, slash,
 //!   command bar, error, help, inline autocomplete).
-//! - [`outline`] — the current page's block tree.
-//! - [`backlinks`] — the inline backlinks section below the outline.
-//! - [`inline`] — span-level markdown (used by `outline` and
+//! - `outline` — the current page's block tree.
+//! - `backlinks` — the inline backlinks section below the outline.
+//! - `inline` — span-level markdown (used by `outline` and
 //!   `backlinks`).
 //!
 //! Only `render_app` is callable from outside the module — the rest is

--- a/crates/outl-tui/src/view/backlinks.rs
+++ b/crates/outl-tui/src/view/backlinks.rs
@@ -1,0 +1,190 @@
+//! Inline backlinks section — rendered *below* the outline, separated
+//! by a full-width `─` rule. Each source page contributes a header
+//! followed by its referencing block (with children) as a mini-outline.
+//!
+//! Selection of a backlink block (`Focus::Backlink { idx, sub_path }`)
+//! highlights the bullet the same way the outline does — same theme
+//! `selected_bullet`, same cursor styles. The TUI scrolls so the
+//! selection stays visible (handled by the caller in `view::render_main`).
+
+use crate::state::{App, EditTarget, Focus, Mode};
+use crate::view::outline::{emit_block_lines, RenderMode};
+use outl_md::index::Backlink;
+use outl_md::parse::OutlineNode;
+use ratatui::text::{Line, Span};
+
+/// Render the inline backlinks section.
+///
+/// Returns `(lines, selected_line)`. `selected_line` is the index in
+/// the returned `Vec<Line>` of the bullet row of the focused backlink
+/// block, or `None` when focus is on the outline. `inner_width` is the
+/// drawable width of the outline panel (i.e. excluding the 2-col
+/// border) so the separator rule spans the full visible width.
+///
+/// Empty result `(vec![], None)` when there are no backlinks for the
+/// current view or the user has toggled the section off via `B`.
+pub(crate) fn render_backlinks_inline(
+    app: &App,
+    inner_width: u16,
+) -> (Vec<Line<'static>>, Option<usize>) {
+    if !app.show_backlinks {
+        return (Vec::new(), None);
+    }
+    let backlinks = app.index.backlinks(&app.current_slug());
+    if backlinks.is_empty() {
+        return (Vec::new(), None);
+    }
+
+    let mut out: Vec<Line<'static>> = Vec::new();
+    let mut selected_line: Option<usize> = None;
+
+    // Full-width rule and section header. The blank line above the
+    // rule isolates the section visually from the outline.
+    out.push(Line::from(""));
+    let rule = "─".repeat(inner_width.max(1) as usize);
+    out.push(Line::from(Span::styled(rule, app.theme.border)));
+    out.push(Line::from(Span::styled(
+        format!(" Backlinks · {} ref(s)", backlinks.len()),
+        app.theme.heading,
+    )));
+    out.push(Line::from(""));
+
+    let mut prev_source: Option<String> = None;
+    for (idx, bl) in backlinks.iter().enumerate() {
+        // Header per source page. Multiple backlinks from the same
+        // page collapse under one header.
+        if prev_source.as_deref() != Some(bl.source_slug.as_str()) {
+            if prev_source.is_some() {
+                out.push(Line::from(""));
+            }
+            let header = match &bl.source_icon {
+                Some(icon) => format!("{icon}  {}", bl.source_title),
+                None => format!("📄  {}", bl.source_title),
+            };
+            out.push(Line::from(Span::styled(header, app.theme.heading)));
+            prev_source = Some(bl.source_slug.clone());
+        }
+
+        // Sub-path inside the source_block that's currently focused,
+        // if any. The mini-outline highlights it the same way the
+        // main outline highlights `app.selected`.
+        let focus_path: Option<&[usize]> = match &app.focus {
+            Focus::Backlink {
+                idx: fidx,
+                sub_path,
+            } if *fidx == idx => Some(sub_path.as_slice()),
+            _ => None,
+        };
+
+        let mut current_path: Vec<usize> = Vec::new();
+        render_backlink_node(
+            bl,
+            &bl.source_block,
+            0,
+            &mut current_path,
+            focus_path,
+            app,
+            &mut out,
+            &mut selected_line,
+        );
+    }
+
+    (out, selected_line)
+}
+
+/// Recursive helper: emit a backlink's source block (and its children)
+/// as a mini-outline. Tracks `current_path` to know when to flag the
+/// focused row, and consults `app.mode` to render an in-place edit
+/// buffer when the cursor sits on the block currently being edited
+/// (cross-page Insert through `EditTarget::SourcePage`).
+#[allow(clippy::too_many_arguments)]
+fn render_backlink_node(
+    bl: &Backlink,
+    node: &OutlineNode,
+    indent: u32,
+    current_path: &mut Vec<usize>,
+    focus_path: Option<&[usize]>,
+    app: &App,
+    out: &mut Vec<Line<'static>>,
+    selected_line: &mut Option<usize>,
+) {
+    let is_focused = focus_path == Some(current_path.as_slice());
+    if is_focused && selected_line.is_none() {
+        *selected_line = Some(out.len());
+    }
+
+    let bullet_style = if is_focused {
+        app.theme.selected_bullet
+    } else {
+        app.theme.bullet
+    };
+
+    // Is this exact block the one the user is editing in place?
+    // `Mode::Insert.block_path` lives in the *source page* coordinate
+    // system; reconstruct the equivalent absolute path here and
+    // compare. When it matches, render the live buffer with a caret
+    // (same UX as outline Insert).
+    let editing_here = is_focused
+        && match &app.mode {
+            Mode::Insert {
+                target: EditTarget::SourcePage { path, .. },
+                block_path,
+                ..
+            } if path == &bl.source_path => {
+                let prefix = &bl.source_block_path;
+                block_path.len() == prefix.len() + current_path.len()
+                    && block_path.starts_with(prefix)
+                    && &block_path[prefix.len()..] == current_path.as_slice()
+            }
+            _ => false,
+        };
+
+    let mode = if editing_here {
+        if let Mode::Insert { buffer, .. } = &app.mode {
+            RenderMode::Editing {
+                text: buffer.as_string(),
+                cursor_char: buffer.cursor,
+            }
+        } else {
+            unreachable!("editing_here matched but mode isn't Insert")
+        }
+    } else if is_focused && matches!(app.mode, Mode::Normal) {
+        RenderMode::NormalCursor {
+            text: node.text.clone(),
+            cursor_char: app.cursor_col,
+        }
+    } else {
+        RenderMode::Pretty {
+            text: node.text.clone(),
+        }
+    };
+
+    let has_auto_run = node.properties.iter().any(|(k, _)| k == "auto-run");
+    emit_block_lines(indent, bullet_style, &mode, has_auto_run, app, out);
+
+    for (k, v) in &node.properties {
+        let mut spans: Vec<Span<'_>> = Vec::new();
+        for _ in 0..indent {
+            spans.push(Span::styled("│ ", app.theme.dim));
+        }
+        spans.push(Span::raw("  ".to_string()));
+        spans.push(Span::styled(format!("{k}:: "), app.theme.property_key));
+        spans.push(Span::styled(v.clone(), app.theme.property_value));
+        out.push(Line::from(spans));
+    }
+
+    for (i, child) in node.children.iter().enumerate() {
+        current_path.push(i);
+        render_backlink_node(
+            bl,
+            child,
+            indent + 1,
+            current_path,
+            focus_path,
+            app,
+            out,
+            selected_line,
+        );
+        current_path.pop();
+    }
+}

--- a/crates/outl-tui/src/view/inline.rs
+++ b/crates/outl-tui/src/view/inline.rs
@@ -1,0 +1,114 @@
+//! Inline (span-level) markdown rendering.
+//!
+//! Two flavours — `render_markdown_inline` strips delimiters and
+//! prepends ref icons (read-only blocks), `highlight_inline` keeps the
+//! markdown source visible with dim delimiters (cursor-bearing blocks
+//! so column-to-byte alignment stays 1:1).
+
+use crate::theme::Theme;
+use outl_md::inline::{tokenize, InlineTok};
+use ratatui::text::Span;
+
+/// Strip an optional `TODO`/`DONE` prefix off a block's text, returning
+/// both the stripped body and a marker describing what was present.
+pub(crate) fn split_todo_prefix(text: &str) -> (Option<bool>, &str) {
+    if let Some(rest) = text.strip_prefix("TODO ") {
+        return (Some(false), rest);
+    }
+    if let Some(rest) = text.strip_prefix("DONE ") {
+        return (Some(true), rest);
+    }
+    (None, text)
+}
+
+/// Render with markdown stripped — bold/italic/code/strike applied as
+/// styles, `[[ref]]` / `#tag` / `[text](url)` shown without their
+/// delimiters. Used when the block is read-only (not selected, not in
+/// Insert mode).
+///
+/// Looks up `[[ref]]` / `#tag` targets in `index` to prepend the
+/// page's `icon::` when one is set. The icon is *display-only* — the
+/// underlying `.md` keeps the plain `[[Title]]` / `#tag` text.
+///
+/// `highlight_inline` (the raw, cursor-bearing render) deliberately
+/// does *not* take this path — adding a non-source glyph would
+/// break column-to-byte alignment for the visible cursor.
+pub(crate) fn render_markdown_inline(
+    text: &str,
+    theme: &Theme,
+    index: &outl_md::index::WorkspaceIndex,
+) -> Vec<Span<'static>> {
+    let mut out = Vec::new();
+    for tok in tokenize(text) {
+        match tok {
+            InlineTok::Plain(s) => out.push(Span::raw(s.to_string())),
+            InlineTok::PageRef { name } => {
+                if let Some(icon) = index.by_title(name).and_then(|p| p.icon.as_deref()) {
+                    out.push(Span::styled(format!("{icon} "), theme.dim));
+                }
+                out.push(Span::styled(name.to_string(), theme.ref_link));
+            }
+            InlineTok::Tag { name } => {
+                if let Some(icon) = index.by_slug(name).and_then(|p| p.icon.as_deref()) {
+                    out.push(Span::styled(format!("{icon} "), theme.dim));
+                }
+                out.push(Span::styled(format!("#{name}"), theme.tag_link));
+            }
+            InlineTok::Bold { inner } => out.push(Span::styled(inner.to_string(), theme.bold)),
+            InlineTok::Italic { inner, .. } => {
+                out.push(Span::styled(inner.to_string(), theme.italic))
+            }
+            InlineTok::Strike { inner } => out.push(Span::styled(inner.to_string(), theme.strike)),
+            InlineTok::Code { inner } => out.push(Span::styled(inner.to_string(), theme.code)),
+            InlineTok::Link { text, .. } => out.push(Span::styled(text.to_string(), theme.md_link)),
+        }
+    }
+    out
+}
+
+/// Render with markdown markers visible (dimmed) and inner text styled.
+/// Used when the block is selected in Normal mode (so the visible cursor
+/// columns match the underlying source bytes) or in Insert mode. The
+/// delimiters themselves use a dim style so the formatting markers
+/// don't distract.
+pub(crate) fn highlight_inline(text: &str, theme: &Theme) -> Vec<Span<'static>> {
+    let mut out = Vec::new();
+    let dim = theme.dim;
+
+    for tok in tokenize(text) {
+        match tok {
+            InlineTok::Plain(s) => out.push(Span::raw(s.to_string())),
+            InlineTok::PageRef { name } => {
+                out.push(Span::styled(format!("[[{name}]]"), theme.ref_link))
+            }
+            InlineTok::Tag { name } => out.push(Span::styled(format!("#{name}"), theme.tag_link)),
+            InlineTok::Bold { inner } => {
+                out.push(Span::styled("**".to_string(), dim));
+                out.push(Span::styled(inner.to_string(), theme.bold));
+                out.push(Span::styled("**".to_string(), dim));
+            }
+            InlineTok::Italic { inner, marker } => {
+                let m = marker.to_string();
+                out.push(Span::styled(m.clone(), dim));
+                out.push(Span::styled(inner.to_string(), theme.italic));
+                out.push(Span::styled(m, dim));
+            }
+            InlineTok::Strike { inner } => {
+                out.push(Span::styled("~~".to_string(), dim));
+                out.push(Span::styled(inner.to_string(), theme.strike));
+                out.push(Span::styled("~~".to_string(), dim));
+            }
+            InlineTok::Code { inner } => {
+                out.push(Span::styled("`".to_string(), dim));
+                out.push(Span::styled(inner.to_string(), theme.code));
+                out.push(Span::styled("`".to_string(), dim));
+            }
+            InlineTok::Link { text, url } => {
+                out.push(Span::styled("[".to_string(), dim));
+                out.push(Span::styled(text.to_string(), theme.md_link));
+                out.push(Span::styled(format!("]({url})"), dim));
+            }
+        }
+    }
+    out
+}

--- a/crates/outl-tui/src/view/outline.rs
+++ b/crates/outl-tui/src/view/outline.rs
@@ -1,0 +1,283 @@
+//! Outline rendering — turn a `ParsedPage` (current view) into a
+//! flat `Vec<Line>` for ratatui, with selection / cursor / TODO
+//! decoration.
+
+use crate::outline_ops::path_for_index;
+use crate::state::{App, Focus, Mode};
+use crate::theme::Theme;
+use crate::view::inline::{highlight_inline, render_markdown_inline, split_todo_prefix};
+use outl_md::inline::byte_index_for_char;
+use outl_md::parse::{OutlineNode, ParsedPage};
+use outl_md::view::{block_to_rows, BlockRowKind};
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+
+/// Render the outline into a flat list of `Line`s for ratatui, and
+/// report the visual line index where the *selected* block's bullet
+/// row landed. The caller uses that index to keep the selection
+/// inside the scrolled viewport.
+pub(crate) fn render_outline(p: &ParsedPage, app: &App) -> (Vec<Line<'static>>, Option<usize>) {
+    let mut out = Vec::new();
+    for (k, v) in &p.properties {
+        out.push(Line::from(vec![
+            Span::styled(format!("{k}:: "), app.theme.property_key),
+            Span::styled(v.clone(), app.theme.property_value),
+        ]));
+    }
+    if !p.properties.is_empty() && !p.blocks.is_empty() {
+        out.push(Line::from(""));
+    }
+    let mut cursor = 0usize;
+    let mut selected_line: Option<usize> = None;
+    for block in &p.blocks {
+        render_block(block, 0, &mut cursor, app, &mut out, &mut selected_line);
+    }
+    (out, selected_line)
+}
+
+pub(crate) fn render_block(
+    b: &OutlineNode,
+    indent: u32,
+    cursor: &mut usize,
+    app: &App,
+    out: &mut Vec<Line<'static>>,
+    selected_line: &mut Option<usize>,
+) {
+    // Outline only owns selection/cursor decoration when focus lives
+    // here. With `Focus::Backlink`, the bullet/caret belong to the
+    // backlinks section — drawing them on the outline too would leave
+    // a "ghost cursor" on the last outline block (the value `selected`
+    // still happens to point at).
+    let focused_on_outline = matches!(app.focus, Focus::Outline);
+    let is_selected = focused_on_outline && *cursor == app.selected;
+    // Record the visual line where this block's bullet row begins so
+    // the caller can scroll the viewport to keep it visible.
+    if is_selected && selected_line.is_none() {
+        *selected_line = Some(out.len());
+    }
+    let in_visual_range = focused_on_outline
+        && app
+            .visual_range()
+            .is_some_and(|(lo, hi)| *cursor >= lo && *cursor <= hi);
+    let editing_here = focused_on_outline
+        && matches!(&app.mode, Mode::Insert { block_path, .. }
+            if path_for_index(&app.page.blocks, *cursor).as_deref() == Some(block_path.as_slice()));
+
+    let bullet_style = if is_selected || in_visual_range {
+        app.theme.selected_bullet
+    } else {
+        app.theme.bullet
+    };
+
+    // Determine which text and cursor position to render. Three cases:
+    //   1. Editing here       → buffer with caret cursor.
+    //   2. Selected in Normal → block text with block-style cursor.
+    //   3. Anything else      → block text, no cursor, pretty render.
+    let mode = if editing_here {
+        if let Mode::Insert { buffer, .. } = &app.mode {
+            RenderMode::Editing {
+                text: buffer.as_string(),
+                cursor_char: buffer.cursor,
+            }
+        } else {
+            unreachable!("editing_here matched but mode isn't Insert")
+        }
+    } else if is_selected && matches!(app.mode, Mode::Normal) {
+        RenderMode::NormalCursor {
+            text: b.text.clone(),
+            cursor_char: app.cursor_col,
+        }
+    } else {
+        RenderMode::Pretty {
+            text: b.text.clone(),
+        }
+    };
+
+    let has_auto_run = b.properties.iter().any(|(k, _)| k == "auto-run");
+    emit_block_lines(indent, bullet_style, &mode, has_auto_run, app, out);
+
+    for (k, v) in &b.properties {
+        let mut prop_spans: Vec<Span<'_>> = Vec::new();
+        for _ in 0..indent {
+            prop_spans.push(Span::styled("│ ", app.theme.dim));
+        }
+        prop_spans.push(Span::raw("  ".to_string()));
+        prop_spans.push(Span::styled(format!("{k}:: "), app.theme.property_key));
+        prop_spans.push(Span::styled(v.clone(), app.theme.property_value));
+        out.push(Line::from(prop_spans));
+    }
+    *cursor += 1;
+    for child in &b.children {
+        render_block(child, indent + 1, cursor, app, out, selected_line);
+    }
+}
+
+/// Where the cursor sits on a block being rendered, and what style
+/// the renderer should use for it. The UI-agnostic decomposition
+/// lives in [`outl_md::view`]; this enum carries the *TUI-flavored*
+/// detail of "caret vs block cursor".
+pub(crate) enum RenderMode {
+    /// Insert mode — show the live buffer with a thin caret at
+    /// `cursor_char`. Markdown is rendered raw so columns match bytes.
+    Editing { text: String, cursor_char: usize },
+    /// Normal mode on the selected block — show a vim-style block
+    /// cursor on the character under `cursor_char`. Raw render.
+    NormalCursor { text: String, cursor_char: usize },
+    /// Anything else — markdown is rendered prettily; no cursor.
+    Pretty { text: String },
+}
+
+/// Emit one or more ratatui [`Line`]s for a block's text.
+///
+/// Decomposition into visual rows (bullet vs continuation vs code
+/// fence marker vs code fence body) is delegated to
+/// [`outl_md::view::block_to_rows`] so the Tauri GUI and mobile
+/// clients use the same classification. This function is the
+/// TUI-specific mapping: each [`outl_md::view::BlockRow`] becomes a
+/// `Line` of `Span`s using the active theme.
+pub(crate) fn emit_block_lines(
+    indent: u32,
+    bullet_style: Style,
+    mode: &RenderMode,
+    has_auto_run: bool,
+    app: &App,
+    out: &mut Vec<Line<'static>>,
+) {
+    let (text, cursor_char, cursor_style) = match mode {
+        RenderMode::Editing { text, cursor_char } => {
+            (text.as_str(), Some(*cursor_char), Some(CursorStyle::Caret))
+        }
+        RenderMode::NormalCursor { text, cursor_char } => {
+            (text.as_str(), Some(*cursor_char), Some(CursorStyle::Block))
+        }
+        RenderMode::Pretty { text } => (text.as_str(), None, None),
+    };
+    let pretty = matches!(mode, RenderMode::Pretty { .. });
+    let rows = block_to_rows(text, indent, cursor_char);
+
+    // TODO/DONE checkbox decoration only fits on single-line bullets
+    // (multi-line ones would have the icon floating above body text).
+    let single_line_pretty = pretty && rows.len() == 1;
+
+    for row in &rows {
+        let mut spans: Vec<Span<'_>> = Vec::new();
+        for _ in 0..row.indent {
+            spans.push(Span::styled("│ ", app.theme.dim));
+        }
+        match row.kind {
+            BlockRowKind::Bullet => {
+                // Blocks with `auto-run::` get a ⚡ before the bullet
+                // so the user can see at a glance which cells re-run
+                // themselves on page open.
+                if has_auto_run {
+                    spans.push(Span::styled("⚡", app.theme.hint));
+                }
+                spans.push(Span::styled("- ", bullet_style));
+            }
+            BlockRowKind::Continuation
+            | BlockRowKind::CodeFenceMarker
+            | BlockRowKind::CodeFenceBody => {
+                // Indent the continuation rows by the same width
+                // the ⚡ added on the bullet row so columns align.
+                if has_auto_run {
+                    spans.push(Span::raw(" "));
+                }
+                spans.push(Span::raw("  "));
+            }
+        }
+
+        // If the cursor is on this row we always go raw — we want
+        // bytes to line up with what the user typed, regardless of
+        // fence state.
+        if let (Some(col), Some(style)) = (row.cursor_col, cursor_style) {
+            emit_row_with_cursor(row.text, col, style, &app.theme, &mut spans);
+        } else {
+            // A bullet row whose text opens a code fence (`` ```lisp ``)
+            // is *both* a bullet and a fence marker — style the text
+            // dimly so the fence reads visually like the rest of the
+            // code block while keeping the `- ` glyph emitted above.
+            let bullet_is_fence_opener = matches!(row.kind, BlockRowKind::Bullet)
+                && row.text.trim_start().starts_with("```");
+            match row.kind {
+                _ if pretty && bullet_is_fence_opener => {
+                    spans.push(Span::styled(row.text.to_string(), app.theme.dim));
+                }
+                BlockRowKind::CodeFenceMarker if pretty => {
+                    spans.push(Span::styled(row.text.to_string(), app.theme.dim));
+                }
+                BlockRowKind::CodeFenceBody if pretty => {
+                    spans.push(Span::styled(row.text.to_string(), app.theme.code));
+                }
+                BlockRowKind::Bullet if single_line_pretty => {
+                    let (todo_state, body) = split_todo_prefix(row.text);
+                    match todo_state {
+                        Some(false) => {
+                            spans.push(Span::styled("☐ ", app.theme.todo_open));
+                            spans.extend(render_markdown_inline(body, &app.theme, &app.index));
+                        }
+                        Some(true) => {
+                            spans.push(Span::styled("☑ ", app.theme.todo_done));
+                            for sp in render_markdown_inline(body, &app.theme, &app.index) {
+                                spans.push(Span::styled(
+                                    sp.content.into_owned(),
+                                    sp.style.patch(app.theme.todo_done_body),
+                                ));
+                            }
+                        }
+                        None => {
+                            spans.extend(render_markdown_inline(row.text, &app.theme, &app.index))
+                        }
+                    }
+                }
+                _ => spans.extend(render_markdown_inline(row.text, &app.theme, &app.index)),
+            }
+        }
+        out.push(Line::from(spans));
+    }
+}
+
+/// Draw one row with the cursor highlighted at `col` (a char index
+/// into `text`). Splits the row in three: left of cursor, the char
+/// under the cursor (or a thin caret if past-end), right of cursor.
+fn emit_row_with_cursor(
+    text: &str,
+    col: usize,
+    style: CursorStyle,
+    theme: &Theme,
+    spans: &mut Vec<Span<'static>>,
+) {
+    let byte = byte_index_for_char(text, col);
+    let (left, right) = text.split_at(byte);
+    spans.extend(highlight_inline(left, theme));
+    let mut right_chars = right.chars();
+    match (right_chars.next(), style) {
+        (Some(ch), CursorStyle::Caret) => {
+            // Thin caret BEFORE the next char.
+            spans.push(Span::styled("▏", theme.cursor_caret));
+            spans.push(Span::raw(ch.to_string()));
+            let rest: String = right_chars.collect();
+            spans.extend(highlight_inline(&rest, theme));
+        }
+        (Some(ch), CursorStyle::Block) => {
+            // Inverted-color block cursor on the char under it.
+            spans.push(Span::styled(ch.to_string(), theme.cursor_block));
+            let rest: String = right_chars.collect();
+            spans.extend(highlight_inline(&rest, theme));
+        }
+        (None, CursorStyle::Caret) => {
+            spans.push(Span::styled("▏", theme.cursor_caret));
+        }
+        (None, CursorStyle::Block) => {
+            spans.push(Span::styled("▏", theme.cursor_block));
+        }
+    }
+}
+
+/// Cursor visual style. `Caret` is the thin `▏` (Insert mode);
+/// `Block` is the inverted single-char box (Normal mode on the
+/// selected block).
+#[derive(Debug, Clone, Copy)]
+enum CursorStyle {
+    Caret,
+    Block,
+}

--- a/crates/outl-tui/src/view/overlays.rs
+++ b/crates/outl-tui/src/view/overlays.rs
@@ -1,0 +1,444 @@
+//! Modal overlays: quick switcher, search, slash menu, command bar,
+//! error popup, help popup, and the inline autocomplete dropdown.
+//!
+//! Each function takes the full frame `Rect` and centers / anchors its
+//! own popup inside. `render_app` in the parent module dispatches based
+//! on `app.overlay`.
+
+use crate::state::{
+    App, AutocompleteKind, AutocompleteState, CommandState, ErrorState, QuickSwitchState,
+    SearchState, SlashState, SwitchKind,
+};
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph};
+
+pub(crate) fn render_autocomplete(
+    f: &mut ratatui::Frame<'_>,
+    full: Rect,
+    app: &App,
+    ac: &AutocompleteState,
+) {
+    let height = (ac.candidates.len() as u16 + 2).min(10);
+    if height < 3 {
+        return;
+    }
+    let width = 36u16.min(full.width.saturating_sub(4));
+    // Bottom-right anchor so it doesn't fight with the outline.
+    let area = Rect {
+        x: full.x + full.width.saturating_sub(width + 2),
+        y: full.y + full.height.saturating_sub(height + 2),
+        width,
+        height,
+    };
+    f.render_widget(Clear, area);
+    let title = match ac.kind {
+        AutocompleteKind::PageRef => format!("[[{}]]", ac.query),
+        AutocompleteKind::Tag => format!("#{}", ac.query),
+        AutocompleteKind::SlashCommand => format!("/{}", ac.query),
+    };
+    let items: Vec<ListItem<'_>> = ac
+        .candidates
+        .iter()
+        .enumerate()
+        .map(|(i, c)| {
+            let style = if i == ac.selected {
+                app.theme.list_selected
+            } else {
+                Style::default()
+            };
+            // Decorate the candidate row according to its kind. For
+            // pages/tags we prepend the page's `icon::` (display-only);
+            // for slash commands we append a dim description so the
+            // popup doubles as in-context help.
+            match ac.kind {
+                AutocompleteKind::PageRef | AutocompleteKind::Tag => {
+                    let icon = match ac.kind {
+                        AutocompleteKind::PageRef => {
+                            app.index.by_title(c).and_then(|p| p.icon.clone())
+                        }
+                        AutocompleteKind::Tag => app.index.by_slug(c).and_then(|p| p.icon.clone()),
+                        _ => None,
+                    };
+                    let label = match icon {
+                        Some(ic) => format!("{ic} {c}"),
+                        None => c.clone(),
+                    };
+                    ListItem::new(Line::from(Span::styled(label, style)))
+                }
+                AutocompleteKind::SlashCommand => {
+                    let cmd = app.command_registry.get(c);
+                    let description = cmd.as_ref().map(|cmd| cmd.description()).unwrap_or("");
+                    let needs_args = cmd.as_ref().map(|cmd| cmd.needs_args()).unwrap_or(false);
+                    let suffix = if needs_args { " …" } else { "" };
+                    ListItem::new(Line::from(vec![
+                        Span::styled(format!("{c}{suffix}  "), style),
+                        Span::styled(description.to_string(), app.theme.dim),
+                    ]))
+                }
+            }
+        })
+        .collect();
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(app.theme.border)
+                .title(Span::styled(title, app.theme.help_title)),
+        )
+        .style(Style::default().bg(app.theme.popup_bg));
+    f.render_widget(list, area);
+}
+
+fn centered_rect(full: Rect, w_pct: u16, h_pct: u16) -> Rect {
+    let w = (full.width as u32 * w_pct as u32 / 100) as u16;
+    let h = (full.height as u32 * h_pct as u32 / 100) as u16;
+    Rect {
+        x: full.x + (full.width.saturating_sub(w)) / 2,
+        y: full.y + (full.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    }
+}
+
+pub(crate) fn render_quick_switch(
+    f: &mut ratatui::Frame<'_>,
+    full: Rect,
+    app: &App,
+    qs: &QuickSwitchState,
+) {
+    let area = centered_rect(full, 60, 60);
+    f.render_widget(Clear, area);
+
+    let outer = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(3)])
+        .split(area);
+
+    let input = Paragraph::new(Line::from(vec![
+        Span::styled(" › ", app.theme.help_title),
+        Span::raw(qs.query.clone()),
+        Span::styled("▏", app.theme.cursor_caret),
+    ]))
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(app.theme.border)
+            .title(Span::styled("Quick Switcher", app.theme.help_title)),
+    )
+    .style(Style::default().bg(app.theme.popup_bg));
+    f.render_widget(input, outer[0]);
+
+    let items: Vec<ListItem<'_>> = qs
+        .candidates
+        .iter()
+        .enumerate()
+        .map(|(i, c)| {
+            let icon = match c.kind {
+                SwitchKind::Page => "📄 ",
+                SwitchKind::Journal => "📅 ",
+            };
+            let style = if i == qs.selected {
+                app.theme.list_selected
+            } else {
+                Style::default()
+            };
+            ListItem::new(Line::from(vec![
+                Span::raw(icon),
+                Span::styled(c.label.clone(), style),
+            ]))
+        })
+        .collect();
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(app.theme.border)
+                .title(format!(
+                    "{} matches  ↑↓ navigate · Enter open · Esc cancel",
+                    qs.candidates.len()
+                )),
+        )
+        .style(Style::default().bg(app.theme.popup_bg));
+    f.render_widget(list, outer[1]);
+}
+
+pub(crate) fn render_search_overlay(
+    f: &mut ratatui::Frame<'_>,
+    full: Rect,
+    app: &App,
+    s: &SearchState,
+) {
+    let area = centered_rect(full, 75, 70);
+    f.render_widget(Clear, area);
+
+    let outer = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(3)])
+        .split(area);
+
+    let input = Paragraph::new(Line::from(vec![
+        Span::styled(" / ", app.theme.help_title),
+        Span::raw(s.query.clone()),
+        Span::styled("▏", app.theme.cursor_caret),
+    ]))
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(app.theme.border)
+            .title(Span::styled("Search", app.theme.help_title)),
+    )
+    .style(Style::default().bg(app.theme.popup_bg));
+    f.render_widget(input, outer[0]);
+
+    let lines: Vec<Line<'_>> = s
+        .hits
+        .iter()
+        .enumerate()
+        .map(|(i, h)| {
+            let style = if i == s.selected {
+                app.theme.list_selected
+            } else {
+                Style::default()
+            };
+            let icon_prefix = h
+                .page_icon
+                .as_deref()
+                .map(|i| format!("{i} "))
+                .unwrap_or_default();
+            Line::from(vec![
+                Span::styled(format!(" {icon_prefix}{} · ", h.page_label), app.theme.dim),
+                Span::styled(h.snippet.clone(), style),
+            ])
+        })
+        .collect();
+    let list = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(app.theme.border)
+                .title(format!(
+                    "{} hits  ↑↓ navigate · Enter jump · Esc cancel",
+                    s.hits.len()
+                )),
+        )
+        .style(Style::default().bg(app.theme.popup_bg))
+        .wrap(ratatui::widgets::Wrap { trim: false });
+    f.render_widget(list, outer[1]);
+}
+
+pub(crate) fn render_slash_overlay(
+    f: &mut ratatui::Frame<'_>,
+    full: Rect,
+    app: &App,
+    s: &SlashState,
+) {
+    let area = centered_rect(full, 60, 60);
+    f.render_widget(Clear, area);
+
+    let outer = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(3)])
+        .split(area);
+
+    let input = Paragraph::new(Line::from(vec![
+        Span::styled(" / ", app.theme.help_title),
+        Span::raw(s.query.clone()),
+        Span::styled("▏", app.theme.cursor_caret),
+    ]))
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(app.theme.border)
+            .title(Span::styled("Commands", app.theme.help_title)),
+    )
+    .style(Style::default().bg(app.theme.popup_bg));
+    f.render_widget(input, outer[0]);
+
+    let items: Vec<ListItem<'_>> = s
+        .candidates
+        .iter()
+        .enumerate()
+        .map(|(i, c)| {
+            let style = if i == s.selected {
+                app.theme.list_selected
+            } else {
+                Style::default()
+            };
+            // Two-column-ish: name on the left, description dimmed
+            // on the right. The `…` glyph hints at "this one asks
+            // for args next".
+            let suffix = if c.needs_args { " …" } else { "" };
+            ListItem::new(Line::from(vec![
+                Span::styled(format!(" {}{suffix}  ", c.name), style),
+                Span::styled(c.description.to_string(), app.theme.dim),
+            ]))
+        })
+        .collect();
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(app.theme.border)
+                .title(format!(
+                    "{} commands  ↑↓ navigate · Enter run · Esc cancel",
+                    s.candidates.len()
+                )),
+        )
+        .style(Style::default().bg(app.theme.popup_bg));
+    f.render_widget(list, outer[1]);
+}
+
+pub(crate) fn render_error_overlay(
+    f: &mut ratatui::Frame<'_>,
+    full: Rect,
+    app: &App,
+    err: &ErrorState,
+) {
+    // Auto-size: pick 80% of the viewport, capped so a tiny body
+    // doesn't draw a giant empty modal.
+    let body_lines = err.body.lines().count().max(1) as u16;
+    let popup_w = (full.width as f32 * 0.8) as u16;
+    let popup_h = (body_lines + 4).min((full.height as f32 * 0.7) as u16);
+    let x = (full.width.saturating_sub(popup_w)) / 2;
+    let y = (full.height.saturating_sub(popup_h)) / 2;
+    let area = Rect {
+        x,
+        y,
+        width: popup_w,
+        height: popup_h,
+    };
+    f.render_widget(Clear, area);
+
+    let lines: Vec<Line<'_>> = err
+        .body
+        .lines()
+        .map(|l| Line::from(Span::raw(l.to_string())))
+        .collect();
+
+    let title = format!(" ✕ {} · press any key to dismiss ", err.title);
+    let widget = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(app.theme.status_message)
+                .title(Span::styled(title, app.theme.status_message)),
+        )
+        .style(Style::default().bg(app.theme.popup_bg))
+        .wrap(ratatui::widgets::Wrap { trim: false });
+    f.render_widget(widget, area);
+}
+
+pub(crate) fn render_command_bar(
+    f: &mut ratatui::Frame<'_>,
+    full: Rect,
+    app: &App,
+    c: &CommandState,
+) {
+    let h = 3u16;
+    let area = Rect {
+        x: full.x,
+        y: full.y + full.height.saturating_sub(h),
+        width: full.width,
+        height: h,
+    };
+    f.render_widget(Clear, area);
+    let line = Line::from(vec![
+        Span::styled(" : ", app.theme.help_title),
+        Span::raw(c.buffer.clone()),
+        Span::styled("▏", app.theme.cursor_caret),
+    ]);
+    let bar = Paragraph::new(line)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(app.theme.border),
+        )
+        .style(Style::default().bg(app.theme.popup_bg));
+    f.render_widget(bar, area);
+}
+
+pub(crate) fn render_help_popup(f: &mut ratatui::Frame<'_>, full: Rect, app: &App) {
+    let popup_w = (full.width as f32 * 0.7) as u16;
+    let popup_h = 34u16.min(full.height.saturating_sub(2));
+    let x = (full.width.saturating_sub(popup_w)) / 2;
+    let y = (full.height.saturating_sub(popup_h)) / 2;
+    let area = Rect {
+        x,
+        y,
+        width: popup_w,
+        height: popup_h,
+    };
+    let body = vec![
+        Line::from(Span::styled("NORMAL mode", app.theme.help_title)),
+        Line::from("  i           edit current block"),
+        Line::from("  I           edit, cursor at start of block"),
+        Line::from("  o / O       new block below / above"),
+        Line::from("  Enter       open [[ref]] / #tag / journal under cursor"),
+        Line::from("              (falls back to edit if nothing matches)"),
+        Line::from("  j / k / ↑ ↓ move between blocks"),
+        Line::from("  PgDn/PgUp   move one viewport down/up"),
+        Line::from("  Ctrl+D / U  half-page down/up"),
+        Line::from("  g g / G     first / last block"),
+        Line::from("  h / l / ← → move cursor inside the current block"),
+        Line::from("  w / b       cursor to next / previous word"),
+        Line::from("  0 / $       cursor to start / end of block"),
+        Line::from("  Tab / S-Tab indent / outdent"),
+        Line::from("  K / J       move block up / down (Alt+↑/↓ too)"),
+        Line::from("  dd          delete block"),
+        Line::from("  yy / p / P  yank · paste after · paste before"),
+        Line::from("  Ctrl+T      cycle TODO / DONE / none (Ctrl+Enter on kitty-proto terminals)"),
+        Line::from("  u           undo"),
+        Line::from("  Ctrl+R      redo"),
+        Line::from("  Ctrl+S      force save"),
+        Line::from("  Ctrl+L      refresh workspace (re-read from disk)"),
+        Line::from("  t           today's journal"),
+        Line::from("  [ / ]       previous / next journal"),
+        Line::from("  g j         jump to today"),
+        Line::from("  g x         run code block under cursor (also `:run`)"),
+        Line::from("  B           toggle inline backlinks section"),
+        Line::from("  ?           toggle this help"),
+        Line::from("  q q         quit (chord — single `q` arms it)"),
+        Line::from(""),
+        Line::from(Span::styled("Overlays", app.theme.help_title)),
+        Line::from("  Ctrl+P      quick switcher (pages + journals)"),
+        Line::from("  /           slash commands (prop, search, run, ...)"),
+        Line::from("  n / N       next / previous search hit"),
+        Line::from("  :           vim-style palette (same registry as /)"),
+        Line::from(""),
+        Line::from(Span::styled("INSERT mode", app.theme.help_title)),
+        Line::from("  Esc         commit"),
+        Line::from("  Enter       commit + new block below"),
+        Line::from("  Ctrl+T      cycle TODO / DONE / none (stays in Insert; Ctrl+Enter on kitty-proto terminals)"),
+        Line::from("  Tab / S-Tab indent / outdent (stays in Insert)"),
+        Line::from("  [[ / #      autocomplete from existing page titles"),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Date inserters (Insert mode, via /)",
+            app.theme.help_title,
+        )),
+        Line::from("  /date-today       [[YYYY-MM-DD]]  (also /dt, /dtm, /dy)"),
+        Line::from("  /date-next-monday next Monday's journal ref (and one per weekday)"),
+        Line::from("  /date +3d         offset or absolute: +Nd, -Nw, +Nm, YYYY-MM-DD"),
+        Line::from("  /time-now         HH:MM, plain (no brackets)"),
+        Line::from("  /datetime-now     [[YYYY-MM-DD]] HH:MM  (alias /stamp)"),
+        Line::from("  /iso-date-today   YYYY-MM-DD, no brackets (for `due::` etc)"),
+        Line::from("  /week-num         #YYYY-Www  (ISO week as a tag)"),
+        Line::from(""),
+        Line::from(Span::styled(
+            format!("theme: {}", app.theme.name),
+            app.theme.dim,
+        )),
+    ];
+    let popup = Paragraph::new(body)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(app.theme.border)
+                .title(Span::styled("Help", app.theme.help_title)),
+        )
+        .style(Style::default().bg(app.theme.popup_bg));
+    f.render_widget(Clear, area);
+    f.render_widget(popup, area);
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -70,8 +70,9 @@ Or, if you `cd ~/notes`, just `outl` works — no subcommand means
 | Jump to today | `t` |
 | Yesterday / tomorrow | `[` / `]` |
 | Find any page or journal | `Ctrl+P` (fuzzy switcher) |
-| Search the whole workspace | `/` |
-| Run a command | `:` then `theme dracula`, `open Foo`, `q`, etc. |
+| Run a command | `/` (Notion-style menu) or `:` (vim palette) |
+| Search the whole workspace | `/search` (alias `/s`) |
+| Insert today's date as `[[link]]` | `/date-today` (in Insert mode) |
 | Quit | `q` or `Ctrl+C` |
 
 Pages you reference but haven't created yet are *real* the moment you

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -37,16 +37,16 @@ characters insert themselves — every key is a command.
 | `Tab` / `Shift-Tab` | Indent / outdent the current block |
 | `K` / `J` (or `Alt+↑/↓`) | Move block up / down |
 | `dd` | Delete the current block (chord) |
-| `Ctrl+Enter` | Cycle the block's TODO / DONE / none prefix |
+| `Ctrl+Enter` / `Ctrl+T` | Cycle the block's TODO / DONE / none prefix (`Ctrl+T` is the portable fallback for tmux / Terminal.app, which collapse `Ctrl+Enter` into plain `Enter`) |
 | `u` / `Ctrl+R` | Undo / redo |
 | `V` | Enter Visual mode (multi-block select) |
 | `t` / `Home` | Today's journal |
 | `[` / `]` | Previous / next journal |
 | `g j` | Jump to today (chord) |
 | `Ctrl+P` | Quick switcher (fuzzy page/journal pick) |
-| `/` | Workspace-wide search |
-| `:` | Command palette |
-| `B` | Toggle the backlinks panel |
+| `/` | Slash command menu (Notion-style, fuzzy filter) |
+| `:` | Command palette (vim-style) |
+| `B` | Toggle the inline backlinks section below the outline |
 | `?` | Toggle this help popup |
 | `q q` / `Ctrl+C` | Quit — `q` alone arms a chord, second `q` confirms |
 
@@ -61,7 +61,7 @@ Text input goes into the buffer. Esc commits (writes back to the
 | `Enter` | Commit + new block below (soft newline inside open code fence — see below) |
 | `Alt+Enter` / `Ctrl+J` | Soft newline (stays in same block) — portable across terminals |
 | `Shift+Enter` | Soft newline — only on terminals that speak the kitty keyboard protocol |
-| `Ctrl+Enter` | Cycle the block's TODO / DONE / none (stays in Insert) |
+| `Ctrl+Enter` / `Ctrl+T` | Cycle the block's TODO / DONE / none (stays in Insert; `Ctrl+T` works on terminals that collapse `Ctrl+Enter`) |
 | `Tab` / `Shift-Tab` | Indent / outdent (stays in Insert) |
 | `Backspace` on empty | Delete block, move to previous |
 | `Left` at column 0 | Spill into the previous block (cursor at end) |
@@ -123,39 +123,117 @@ keystream while open; `Esc` always closes them.
 Fuzzy search across page titles, slugs, and journal dates. Today's
 date is always present even if the journal file doesn't exist yet.
 
-### Search (`/`)
+### Slash menu (`/`) and Command palette (`:`)
 
-Workspace-wide block search using the same fuzzy matcher. Hits show
-the source page label + a snippet of the block; `Enter` jumps to it.
+Two surfaces over the **same** command registry — pick whichever
+matches your muscle memory:
 
-### Command palette (`:`)
-
-Vim-style command bar. Supported commands:
-
-| Command | Action |
-|---------|--------|
-| `:q` / `:quit` | Quit |
-| `:w` / `:write` / `:save` | Force re-save current page |
-| `:open <name>` / `:o <name>` | Open page by name |
-| `:new <name>` / `:n <name>` | Create page (or open if exists) |
-| `:theme <name>` | Swap the active theme (see `outl theme list`) |
-| `:today` | Jump to today's journal |
-| `:help` / `:h` | Open the help popup |
+- **`/`** (Normal mode) opens a Notion-style filterable list. Each
+  entry shows its name + description. Inside Insert mode, typing `/`
+  triggers inline autocomplete with the same list — pick a command
+  with `Tab`/`Enter` without leaving the buffer.
+- **`:`** is the vim command line. Same registry, same args,
+  same aliases — `/q` and `:q` are interchangeable.
 
 Unknown commands surface in the status line as `unknown command:
-:<line>`.
+<name>`.
+
+#### Workspace / navigation
+
+| Command | Aliases | Action |
+|---------|---------|--------|
+| `open <name>` | `o`, `new`, `n` | Open (or create) page by name |
+| `today` | — | Jump to today's journal |
+| `search` | `s`, `find` | Workspace-wide block search |
+| `quit` | `q`, `exit` | Close the TUI |
+| `write` | `w`, `save` | Force-save current page |
+| `refresh` | `r`, `reload` | Re-read workspace from disk |
+| `theme <preset>` | — | Swap the active theme |
+| `help` | `h` | Toggle help popup |
+
+#### Properties
+
+| Command | Aliases | Action |
+|---------|---------|--------|
+| `prop-block <key> <value>` | `prop` | Set property on current block (empty value deletes) |
+| `prop-page <key> <value>` | — | Set page-level property (`title::`, `icon::`, …) |
+
+#### Code execution
+
+| Command | Aliases | Action |
+|---------|---------|--------|
+| `run` | `x`, `execute` | Run the code block under the cursor |
+
+#### Date & time inserters
+
+These write text **at the cursor** (Insert mode only). They skip the
+auto-commit step the other commands do, so your in-flight edit stays
+alive while the text lands.
+
+| Command | Aliases | Inserts |
+|---------|---------|---------|
+| `date-today` | `dt` | `[[YYYY-MM-DD]]` (today) |
+| `date-tomorrow` | `dtm` | `[[YYYY-MM-DD]]` (today + 1) |
+| `date-yesterday` | `dy` | `[[YYYY-MM-DD]]` (today − 1) |
+| `date-next-week` | `dnw` | `[[YYYY-MM-DD]]` (today + 7) |
+| `date-last-week` | `dlw` | `[[YYYY-MM-DD]]` (today − 7) |
+| `date-next-monday` | `dnmon` | next Monday's journal ref |
+| `date-next-tuesday` | `dntue` | next Tuesday's journal ref |
+| `date-next-wednesday` | `dnwed` | next Wednesday's journal ref |
+| `date-next-thursday` | `dnthu` | next Thursday's journal ref |
+| `date-next-friday` | `dnfri` | next Friday's journal ref |
+| `date-next-saturday` | `dnsat` | next Saturday's journal ref |
+| `date-next-sunday` | `dnsun` | next Sunday's journal ref |
+| `date <arg>` | — | flexible — see below |
+| `iso-date-today` | `isod` | `YYYY-MM-DD` (no brackets, for `due::` etc) |
+| `iso-date-tomorrow` | `isodtm` | `YYYY-MM-DD` |
+| `iso-date-yesterday` | `isody` | `YYYY-MM-DD` |
+| `time-now` | `now`, `tn` | `HH:MM` (no brackets, plain time) |
+| `datetime-now` | `dtn`, `stamp` | `[[YYYY-MM-DD]] HH:MM` (journal ref + time) |
+| `week-num` | `wn`, `week` | `#YYYY-Www` (ISO week as a tag) |
+
+##### `/date <arg>`
+
+| Input | Resolves to |
+|-------|-------------|
+| `/date +3d` | today + 3 days |
+| `/date -2w` | today − 2 weeks |
+| `/date +1m` | today + 1 month (Jan 31 + 1m → Feb 28/29 — clamped to last day of month) |
+| `/date 5d` | bare `Nd`/`Nw`/`Nm` is treated as positive |
+| `/date 2026-06-15` | absolute ISO date |
+
+Garbage input (`/date nope`, `/date +3x`, invalid date) shows
+`usage: date +Nd | -Nw | +Nm | YYYY-MM-DD` on the status line.
+
+> **Weekday math:** `date-next-<weekday>` always jumps to the **next**
+> occurrence of that weekday, strictly in the future. Running it on
+> the same weekday adds 7 days, not 0 — `date-next-monday` on a Monday
+> means "next Monday."
+>
+> **ISO week year:** `week-num` uses `%G-W%V` (ISO 8601), not `%Y-W%V`.
+> The ISO year can differ from the calendar year on a few days around
+> year boundaries — e.g. 2025-12-31 (Wednesday) belongs to ISO week
+> `2026-W01`, not `2025-W01`.
 
 ## Panels
 
 ```
-┌─outl · default-dark ────────────────────────────────────┬─Backlinks────┐
-│ Journal · Sunday, 2026-05-24                            │ Project X    │
-├─────────────────────────────────────────────────────────┤   • led by … │
-│ - first block                                           │              │
-│ - second block with [[Avelino]] and #tag                │ Ideas        │
-│   - nested                                              │   • saw …    │
-│                                                         │              │
-├──┌NORMAL─┐ i edit  o new  K/J move … ───────────────────┴──────────────┤
+┌─outl · default-dark ───────────────────────────────────────────────────┐
+│ Page · Avelino                                                         │
+├────────────────────────────────────────────────────────────────────────┤
+│ - I am the author                                                      │
+│ - some other note                                                      │
+│ ───────────────────────────────────────────────────────────────────────│
+│  Backlinks · 2 ref(s)                                                  │
+│                                                                        │
+│ 📄  Project X                                                          │
+│ - led by [[Avelino]]                                                   │
+│   - milestone A                                                        │
+│   - milestone B                                                        │
+│                                                                        │
+│ 📅  2026-05-24                                                         │
+│ - meeting with [[Avelino]] about Q4                                    │
+├──┌NORMAL─┐ i edit  o new  K/J move …  ⇇ 2 backlinks ───────────────────┤
 │  └───────┘                                                             │
 └────────────────────────────────────────────────────────────────────────┘
 ```
@@ -163,9 +241,15 @@ Unknown commands surface in the status line as `unknown command:
 - **Outline** — the current view (journal or named page). Markdown
   renders inline (bold/italic/code/strike); the selected/editing block
   is shown raw so cursor columns align with source bytes.
-- **Backlinks** — every block in any other page that contains
-  `[[this]]` or `#this`. Toggle with `B`. Self-references are
-  excluded.
+- **Backlinks (inline)** — rendered below the outline, separated by a
+  full-width `─` rule. Every block in any other page that contains
+  `[[this]]` or `#this` shows up with its children, grouped by source
+  page. `j`/`k` navigation crosses the separator transparently: from
+  the last outline block, `j` lands you on the first backlink; `k`
+  from the first backlink walks back into the outline. Toggle the
+  section with `B`. Self-references are excluded. Press `i` / `Enter`
+  on a backlink to jump to its source page positioned on the
+  referencing block (in-place editing lands in a follow-up).
 - **Status / hint** — mode badge, contextual key reminder, backlink
   count, status messages.
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -202,13 +202,13 @@ things:
 
 - **`Ctrl+P`** — quick switcher. Fuzzy match by title or filename.
   Type `dist` and `distsys` jumps to the top.
-- **`/`** — workspace-wide search. Type a fragment of any block.
-  Hits show page label + snippet; Enter jumps you to the block.
-  After the popup closes, `n` and `N` walk through the rest of the
-  matches.
-- **`:`** — command palette. `:open Avelino` opens by title.
-  `:today` jumps to today's journal. `:theme nord` swaps the theme.
-  `:q` quits.
+- **`/`** — slash command menu. Notion-style filterable list of every
+  registered command. Type `/search` and `Enter` for workspace-wide
+  block search; after the search popup closes, `n` and `N` walk
+  through the rest of the matches.
+- **`:`** — command palette (vim-style). Same registry as `/`, same
+  aliases. `:open Avelino` opens by title, `:today` jumps to today's
+  journal, `:theme nord` swaps the theme, `:q` quits.
 
 Try them. Press `?` if you forget a key — the help popup lists
 everything.
@@ -226,15 +226,48 @@ A few things that compound:
 - **`yy`** — yank the current block (and its subtree). `p` pastes
   after, `P` pastes before. Works in Visual mode too: press `V`,
   extend with `j`/`k`, then `y`.
-- **`Ctrl+Enter`** — cycle the block's TODO/DONE/none prefix. In
-  Insert mode it cycles inline without moving your cursor relative
-  to the text.
+- **`Ctrl+Enter`** (or **`Ctrl+T`** as a portable fallback) — cycle
+  the block's TODO/DONE/none prefix. In Insert mode it cycles inline
+  without moving your cursor relative to the text. Use `Ctrl+T` on
+  terminals/multiplexers (tmux, Terminal.app) that collapse
+  `Ctrl+Enter` into plain `Enter`.
 - **`Ctrl+L`** — re-read the workspace from disk. Useful when
   another editor changed a `.md` behind your back.
 - **`Ctrl+S`** — force save. (Edits auto-save on every commit, but
   this is for muscle memory.)
 
 You're now using outl roughly the way it's meant to be used.
+
+---
+
+## Day 8 — Date & time inserters
+
+Journal-first means a lot of cross-linking between days. Typing
+`[[2026-05-26]]` by hand gets old fast, so outl ships slash commands
+for it.
+
+In Insert mode, type `/`, filter, pick:
+
+- **`/date-today`** → `[[2026-05-26]]` (also `/dt`)
+- **`/date-tomorrow`** → `[[2026-05-27]]` (also `/dtm`)
+- **`/date-yesterday`** → `[[2026-05-25]]` (also `/dy`)
+- **`/date-next-monday`** → next Monday's journal ref (also `/dnmon`,
+  and one per weekday: `dntue`, `dnwed`, `dnthu`, `dnfri`, `dnsat`,
+  `dnsun`)
+- **`/date-next-week`** / **`/date-last-week`** → today ±7 days
+  (`/dnw`, `/dlw`)
+- **`/date +3d`** / **`/date -2w`** / **`/date +1m`** /
+  **`/date 2026-06-15`** → flexible offset or absolute
+- **`/time-now`** → `14:32` (plain text, no brackets — for "I started
+  at" notes)
+- **`/datetime-now`** → `[[2026-05-26]] 14:32` (stamp this moment)
+- **`/iso-date-today`** → `2026-05-26` without brackets, for property
+  values like `due:: 2026-05-26`
+- **`/week-num`** → `#2026-W21` (ISO week as a tag — clusters weekly
+  notes via the tag index)
+
+All of these write at the cursor without committing your in-flight
+edit — type away.
 
 ---
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
- Backlinks viram parte do fluxo: aparecem **inline** abaixo da outline (sem painel lateral), separados por linha `─` full-width, agrupados por source page, e são **editáveis no lugar** — `i`/`Esc`/`Ctrl+T`/`o`/`Tab`/`dd`/`K`/`J` operam direto no `.md` source.
- **Cold start agora aparece em ~16ms** em vez de até 750ms. Não era o scan que era lento — era o `event::poll` segurando a main thread. Adaptive poll resolve.
- Index maintenance trocou full re-scan por **patch incremental** por save. Edição independe do tamanho do workspace.
- Bump geral de deps (rusqlite 0.39, comrak 0.52, yrs 0.26, bincode 2, toml 1.1, thiserror 2) + Rust 1.95.
- Workspace version → `0.2.0`.

## Highlights

**Backlinks**
- `Focus::{Outline, Backlink{idx, sub_path}}` em `state.rs` modela onde o cursor mora. `j`/`k` cruzam a fronteira transparente.
- `EditTarget::{CurrentPage, SourcePage{path, page}}` em `Mode::Insert` roteia o commit pro `.md` certo.
- `apply_to_backlink_source` em `actions/block.rs` centraliza o padrão "read source → mutate AST → optimistic index refresh → save no rebuild".
- `WorkspaceIndex::refresh_backlinks_from_source` patcha o `source_block` em memória — UI atualiza **no frame seguinte**.

**Perf**
- `WorkspaceIndex::patch_page(path, &page)`: re-indexa **uma página** (drop dos backlinks com `source_slug == X`, re-tokeniza, refresh title/icon). Substitui `spawn_index_rebuild` em todo save path. `O(blocks_da_pagina)` em vez de `O(workspace)`.
- `App::has_pending_index()` + `POLL_INTERVAL_PENDING_INDEX = 16ms` no event loop. `spawn_index_rebuild` sobrevive só em `App::new` (cold start) e `Ctrl+L` (refresh manual).

**Refactor**
- `view.rs` (995L) → `view.rs` (orquestrador, ~200L) + `view/{inline,outline,overlays,backlinks}.rs`. Cada um abaixo de 450L.

**Bug fixes que vieram junto**
- Cursor fantasma na última linha da outline quando o foco já tava no backlink (`render_block` agora gate por `Focus::Outline`).
- Cursor pulando pro fim ao entrar Insert. Agora preserva `app.cursor_col` (vim `i`); `I` ainda vai pro `0`.