### PR TITLE
feat(tui): ratatui UI/UX overhaul — chrome, sidebar, help, toasts, pin

### DIFF
--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -1,6 +1,6 @@
 ---
-description: Roda fmt + clippy + test do workspace inteiro. Use antes de reportar done.
-allowed-tools: Bash(cargo fmt:*), Bash(cargo clippy:*), Bash(cargo test:*), Bash(cargo build:*)
+description: Roda fmt + clippy + test + doc do workspace inteiro. Use antes de reportar done.
+allowed-tools: Bash(cargo fmt:*), Bash(cargo clippy:*), Bash(cargo test:*), Bash(cargo build:*), Bash(cargo doc:*), Bash(RUSTDOCFLAGS=*:*)
 ---
 
 Rode em sequência e reporte resultado de cada etapa:
@@ -8,6 +8,9 @@ Rode em sequência e reporte resultado de cada etapa:
 1. `cargo fmt --all -- --check` — formato
 2. `cargo clippy --workspace --all-targets -- -D warnings` — lints
 3. `cargo test --workspace --all-targets` — testes
+4. `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — docs
+   (CI roda isso; quebra em links de intra-doc pra items privados, p.ex.
+   ``[`Foo`]`` onde `Foo` é `pub(crate)`. Drop os brackets: `` `Foo` ``.)
 
 Se algum falhar, **pare** e mostre a saída exata. Não tente corrigir automaticamente — só relate.
 
@@ -17,6 +20,7 @@ Formato de saída:
 fmt:     PASS | FAIL (N arquivos)
 clippy:  PASS | FAIL (N warnings)
 test:    PASS | FAIL (N falhas)
+doc:     PASS | FAIL (N warnings)
 
 [detalhes da falha, se houver]
 ```

--- a/.claude/hooks/rust-quality.sh
+++ b/.claude/hooks/rust-quality.sh
@@ -69,4 +69,37 @@ if [ "$clippy_status" -ne 0 ]; then
   exit 2
 fi
 
+# Run rustdoc with -D warnings — CI gates on this, so catch
+# intra-doc-link-to-private-item issues (and friends) before
+# pushing. Only triggers when the edited file looks like it
+# might carry doc comments (mod.rs, lib.rs, or any file with
+# `//!` block docs).
+case "$file_path" in
+  */mod.rs|*/lib.rs)
+    doc_check=1
+    ;;
+  *)
+    if grep -q '^//!' "$file_path" 2>/dev/null; then
+      doc_check=1
+    else
+      doc_check=0
+    fi
+    ;;
+esac
+
+if [ "$doc_check" = "1" ]; then
+  doc_output=$(
+    cd "${CLAUDE_PROJECT_DIR}" 2>/dev/null || cd .
+    RUSTDOCFLAGS="-D warnings" cargo doc -p "$crate_dir" --no-deps --quiet 2>&1
+  )
+  doc_status=$?
+  if [ "$doc_status" -ne 0 ]; then
+    # Most common cause: `[\`Foo\`]` intra-doc link where Foo is
+    # pub(crate) / pub(super) / mod (no pub). Drop brackets.
+    printf 'cargo doc emitted warnings in crate %s after edit of %s:\n%s\n' \
+      "$crate_dir" "$file_path" "$doc_output" >&2
+    exit 2
+  fi
+fi
+
 exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,10 +82,29 @@ cargo build --workspace
 cargo test --workspace
 cargo clippy --workspace --all-targets -- -D warnings
 cargo fmt --all -- --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
 ```
 
 Or just `/check`. The PostToolUse hook in `.claude/settings.json` runs fmt +
 clippy on the touched crate automatically after each `Edit`/`Write`.
+
+**`cargo doc` is part of CI** (`.github/workflows/ci.yml` — `docs` job, with
+`RUSTDOCFLAGS=-D warnings`). It breaks the PR on:
+
+- **Intra-doc links to private items.** A doc comment that writes
+  ``[`Foo`]`` or ``[`crate::path::Foo`]`` where `Foo` is `pub(crate)` /
+  `pub(super)` / `mod` (no `pub`) fails with
+  `rustdoc::private_intra_doc_links`. The workspace is mostly `pub(crate)`,
+  so **almost every internal type triggers this**. Mitigation: drop the
+  square brackets and use backticks only (`` `Foo` ``) — same readability,
+  no link, no warning.
+- **Broken/missing doc references.** `[`Foo`]` where `Foo` doesn't exist.
+- **Code blocks in doc comments that don't compile** (rare for us; we
+  rarely put rust code in module docs).
+
+Run `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` before
+reporting "done" on any patch that adds or changes module-level doc
+comments (`//!` blocks) — `/check` does not include this today.
 
 ### Specialized agents
 

--- a/crates/outl-md/src/index.rs
+++ b/crates/outl-md/src/index.rs
@@ -35,6 +35,10 @@ pub struct PageEntry {
     pub icon: Option<String>,
     /// Whether the file lives in `journals/`.
     pub is_journal: bool,
+    /// `pinned:: true` page-level property. Surfaces that ship a
+    /// sidebar (TUI, future Tauri) list pinned pages prominently so
+    /// frequently-touched notes are a single click away.
+    pub pinned: bool,
 }
 
 /// One backlink — a block in another page that references this slug.
@@ -137,6 +141,10 @@ impl WorkspaceIndex {
                     .find(|(k, _)| k == "icon")
                     .map(|(_, v)| v.trim().to_string())
                     .filter(|s| !s.is_empty());
+                let pinned = parsed
+                    .properties
+                    .iter()
+                    .any(|(k, v)| k == "pinned" && is_truthy(v));
 
                 idx.pages.insert(
                     slug.to_string(),
@@ -146,6 +154,7 @@ impl WorkspaceIndex {
                         title: title.clone(),
                         icon,
                         is_journal,
+                        pinned,
                     },
                 );
                 idx.title_to_slug.insert(title.clone(), slug.to_string());
@@ -237,6 +246,10 @@ impl WorkspaceIndex {
             .find(|(k, _)| k == "icon")
             .map(|(_, v)| v.trim().to_string())
             .filter(|s| !s.is_empty());
+        let pinned = page
+            .properties
+            .iter()
+            .any(|(k, v)| k == "pinned" && is_truthy(v));
 
         // Drop every backlink that used to come from this page —
         // we'll re-emit the fresh set below.
@@ -256,6 +269,7 @@ impl WorkspaceIndex {
             title: title.clone(),
             icon,
             is_journal,
+            pinned,
         };
         self.pages.insert(slug.clone(), entry.clone());
         self.title_to_slug.insert(title, slug);
@@ -375,6 +389,17 @@ fn walk_node<'a>(blocks: &'a [OutlineNode], path: &[usize]) -> Option<&'a Outlin
         current = &n.children;
     }
     node
+}
+
+/// Loose truthy check for boolean-ish property values (`pinned::`,
+/// `archived::`, etc). Accepts `true`, `yes`, `1`, `on` (case
+/// insensitive). Empty string is treated as falsy so a stray
+/// `pinned:: ` doesn't flip a page into the pinned list.
+fn is_truthy(v: &str) -> bool {
+    matches!(
+        v.trim().to_ascii_lowercase().as_str(),
+        "true" | "yes" | "1" | "on"
+    )
 }
 
 fn collect_backlinks_recursive(

--- a/crates/outl-tui/CLAUDE.md
+++ b/crates/outl-tui/CLAUDE.md
@@ -173,4 +173,9 @@ src/
 1. `cargo fmt`
 2. `cargo clippy -p outl-tui --all-targets -- -D warnings`
 3. `cargo test -p outl-tui` (lib + bin + e2e tests)
-4. Manual smoke in a real terminal: `outl init /tmp/x && outl --path /tmp/x`
+4. **`RUSTDOCFLAGS="-D warnings" cargo doc -p outl-tui --no-deps`** —
+   CI runs this and it catches things `clippy` won't. Most common bite:
+   ``[`SomeType`]`` in a `//!` module doc where the type is `pub(crate)`
+   triggers `rustdoc::private_intra_doc_links`. Drop the brackets, keep
+   the backticks: `` `SomeType` ``.
+5. Manual smoke in a real terminal: `outl init /tmp/x && outl --path /tmp/x`

--- a/crates/outl-tui/src/actions/block.rs
+++ b/crates/outl-tui/src/actions/block.rs
@@ -696,6 +696,46 @@ impl App {
         self.save();
     }
 
+    /// Toggle the `pinned:: true` page-level property. Wired to the
+    /// `gp` chord in Normal mode and to the `/pin` slash command;
+    /// commits straight to disk (no insert-mode buffer to worry
+    /// about) and toasts the new state so the user can confirm
+    /// without reading the file.
+    ///
+    /// Refuses to act on Journal pages — pinning a journal would be
+    /// semantically weird (today's note auto-rotates) and would
+    /// silently dilute the sidebar's `Pinned` list with
+    /// date-shaped junk.
+    pub(crate) fn toggle_pinned(&mut self) {
+        if matches!(self.view, crate::state::View::Journal(_)) {
+            self.toast(crate::state::ToastKind::Warning, "can't pin a journal page");
+            return;
+        }
+        self.snapshot_for_undo();
+        let was_pinned = self.page.properties.iter().any(|(k, v)| {
+            k == "pinned"
+                && matches!(
+                    v.trim().to_ascii_lowercase().as_str(),
+                    "true" | "yes" | "1" | "on"
+                )
+        });
+        if was_pinned {
+            self.page.properties.retain(|(k, _)| k != "pinned");
+            self.save();
+            self.toast(crate::state::ToastKind::Info, "unpinned");
+        } else {
+            // Drop any existing falsy `pinned::` value first so the
+            // toggle doesn't leave two `pinned::` lines stacked at
+            // the top of the file.
+            self.page.properties.retain(|(k, _)| k != "pinned");
+            self.page
+                .properties
+                .push(("pinned".to_string(), "true".to_string()));
+            self.save();
+            self.toast(crate::state::ToastKind::Success, "pinned");
+        }
+    }
+
     pub(crate) fn toggle_todo(&mut self) {
         match self.focus.clone() {
             Focus::Outline => {

--- a/crates/outl-tui/src/actions/lifecycle.rs
+++ b/crates/outl-tui/src/actions/lifecycle.rs
@@ -42,6 +42,8 @@ impl App {
             page_list: Vec::new(),
             mode: Mode::Normal,
             show_help: false,
+            help_tab: 0,
+            help_scroll: 0,
             pending_chord: None,
             status: String::new(),
             overlay: None,
@@ -51,10 +53,16 @@ impl App {
             index: WorkspaceIndex::default(),
             index_rx: None,
             show_backlinks: true,
+            show_sidebar: false,
+            sidebar_focus: None,
+            sidebar_cursor: 0,
+            recent_paths: Vec::new(),
+            toasts: Vec::new(),
             focus: Focus::Outline,
             scroll_y: 0,
             viewport_height: 0,
             last_mtime: None,
+            last_saved_at: None,
             undo: Vec::new(),
             redo: Vec::new(),
             theme,
@@ -221,6 +229,26 @@ impl App {
         // Snapshot the file's mtime so the polling loop can tell when
         // an *external* edit lands (vs. our own save).
         self.last_mtime = file_mtime(&path);
+        // Anchor the header's freshness chip ("⟳ 2s ago") to the load
+        // instant: from the user's perspective, what's on screen *is*
+        // what's on disk at this moment.
+        self.last_saved_at = Some(std::time::Instant::now());
+        self.touch_recent(&path);
+    }
+
+    /// Move `path` to the front of the recent-paths LRU. Used by
+    /// `load_current_no_autorun` so any view switch (journal, page,
+    /// switch-overlay open) keeps the sidebar's `Recent` list in
+    /// sync with what the user actually touched.
+    ///
+    /// Capped at 20 entries — anything past that drops off the back,
+    /// which is enough for a session's worth of context without
+    /// turning into infinite scroll.
+    pub(crate) fn touch_recent(&mut self, path: &Path) {
+        const RECENT_MAX: usize = 20;
+        self.recent_paths.retain(|p| p != path);
+        self.recent_paths.insert(0, path.to_path_buf());
+        self.recent_paths.truncate(RECENT_MAX);
     }
 
     /// Detect that the current `.md` was edited by another process
@@ -250,9 +278,13 @@ impl App {
         }
 
         if matches!(self.mode, Mode::Insert { .. }) {
-            self.status = format!(
-                "external edit detected ({}) — finish your edit, then Ctrl+L to reload",
-                path.file_name().and_then(|s| s.to_str()).unwrap_or("file")
+            let fname = path.file_name().and_then(|s| s.to_str()).unwrap_or("file");
+            // Toast the warning instead of the status line: this is a
+            // conflict the user needs to acknowledge, but the footer
+            // hint is more useful for the chord prompt next to it.
+            self.toast(
+                crate::state::ToastKind::Warning,
+                format!("external edit on {fname} — Ctrl+L to reload"),
             );
             // Don't update last_mtime — we'll keep warning until the
             // user explicitly resolves it.
@@ -266,7 +298,7 @@ impl App {
         // didn't change.)
         let cur_path = self.current_path();
         self.index.patch_page(&cur_path, &self.page);
-        self.status = "reloaded from disk".into();
+        self.toast(crate::state::ToastKind::Info, "reloaded from disk");
         true
     }
 
@@ -326,7 +358,7 @@ impl App {
         let path = self.current_path();
         let md = render(&self.page);
         if let Err(e) = outl_md::write_atomic(&path, md.as_bytes()) {
-            self.status = format!("save failed: {e}");
+            self.toast(crate::state::ToastKind::Error, format!("save failed: {e}"));
             return;
         }
         match reconcile_md(
@@ -336,7 +368,10 @@ impl App {
             Some(&self.orphans_log),
         ) {
             Ok(_) => self.status.clear(),
-            Err(e) => self.status = format!("reconcile failed: {e}"),
+            Err(e) => self.toast(
+                crate::state::ToastKind::Error,
+                format!("reconcile failed: {e}"),
+            ),
         }
         self.flat_len = flat_count(&self.page.blocks);
         if self.flat_len == 0 {
@@ -354,6 +389,7 @@ impl App {
         // Update mtime AFTER the write so the polling loop doesn't
         // mistake our own save for an external edit.
         self.last_mtime = file_mtime(&path);
+        self.last_saved_at = Some(std::time::Instant::now());
     }
 }
 

--- a/crates/outl-tui/src/actions/mod.rs
+++ b/crates/outl-tui/src/actions/mod.rs
@@ -25,6 +25,8 @@ pub(crate) mod history;
 pub(crate) mod lifecycle;
 pub(crate) mod nav;
 pub(crate) mod overlay;
+pub(crate) mod sidebar;
+pub(crate) mod toast;
 pub(crate) mod visual;
 pub(crate) mod yank;
 

--- a/crates/outl-tui/src/actions/nav.rs
+++ b/crates/outl-tui/src/actions/nav.rs
@@ -26,6 +26,7 @@ impl App {
         }
     }
 
+    #[allow(dead_code)] // header now uses chrome::breadcrumb; kept for future reuse
     pub(crate) fn current_title(&self) -> String {
         let mode_tag = match self.mode {
             Mode::Normal => "NORMAL",

--- a/crates/outl-tui/src/actions/overlay.rs
+++ b/crates/outl-tui/src/actions/overlay.rs
@@ -103,6 +103,7 @@ impl App {
             query: String::new(),
             candidates,
             selected: 0,
+            preview_cache: std::cell::RefCell::new(None),
         }));
     }
 

--- a/crates/outl-tui/src/actions/sidebar.rs
+++ b/crates/outl-tui/src/actions/sidebar.rs
@@ -1,0 +1,198 @@
+//! Sidebar navigation: open/close, focus moves, item activation.
+//!
+//! The renderer in `view::sidebar` is read-only — it derives lists
+//! from `app.index` and `app.recent_paths`. This module owns the
+//! *behavior*: which section has focus, where the cursor sits inside
+//! it, and what happens on `Enter`.
+//!
+//! Public surface called from `input.rs`:
+//! - [`App::sidebar_open_focused`]  — `\` while closed
+//! - [`App::sidebar_close`]         — `\` while open (any focus)
+//! - [`App::sidebar_blur`]          — `Esc` to return focus to the outline
+//! - [`App::sidebar_cycle_section`] — `Tab` / `Shift-Tab`
+//! - [`App::sidebar_move`]          — `j`/`k` inside the focused section
+//! - [`App::sidebar_activate`]      — `Enter` on the focused item
+//!
+//! Calendar focus is intentionally **stubbed for now**: the section
+//! takes focus and the user can `Tab` through it, but `Enter` does
+//! nothing. Day-by-day navigation needs its own cursor state (which
+//! date is highlighted) — a follow-up patch.
+
+use crate::state::{App, SidebarSection, View};
+use anyhow::Result;
+use chrono::NaiveDate;
+use std::path::PathBuf;
+
+impl App {
+    /// `\` while the sidebar is closed: open it and drop focus onto
+    /// the first non-empty section.
+    ///
+    /// Pinned wins by default (the user explicitly curated those).
+    /// If Pinned is empty, fall back to Recent so `Enter` still does
+    /// something useful. If both are empty, focus Calendar — the
+    /// user at least gets a visual cue that the sidebar exists.
+    pub(crate) fn sidebar_open_focused(&mut self) {
+        self.show_sidebar = true;
+        let initial = if self.pinned_slugs_sorted().is_empty() {
+            if self.recent_paths.is_empty() {
+                SidebarSection::Calendar
+            } else {
+                SidebarSection::Recent
+            }
+        } else {
+            SidebarSection::Pinned
+        };
+        self.sidebar_focus = Some(initial);
+        self.sidebar_cursor = 0;
+    }
+
+    /// `\` while the sidebar is open: hide it and drop focus.
+    pub(crate) fn sidebar_close(&mut self) {
+        self.show_sidebar = false;
+        self.sidebar_focus = None;
+        self.sidebar_cursor = 0;
+    }
+
+    /// `Esc` inside a focused sidebar: keep the sidebar visible but
+    /// hand the keyboard back to the outline. The cursor remembers
+    /// its position so Tab can re-enter the same item.
+    pub(crate) fn sidebar_blur(&mut self) {
+        self.sidebar_focus = None;
+    }
+
+    /// `Tab` / `Shift-Tab` inside the sidebar: rotate through the
+    /// three sections. Resets the cursor to 0 so the new section
+    /// starts at its first item — coming back to a previous section
+    /// with a stale cursor was confusing in early prototypes.
+    pub(crate) fn sidebar_cycle_section(&mut self, forward: bool) {
+        let Some(cur) = self.sidebar_focus else {
+            return;
+        };
+        let order = [
+            SidebarSection::Pinned,
+            SidebarSection::Recent,
+            SidebarSection::Calendar,
+        ];
+        let idx = order.iter().position(|s| *s == cur).unwrap_or(0);
+        let next = if forward {
+            (idx + 1) % order.len()
+        } else {
+            (idx + order.len() - 1) % order.len()
+        };
+        self.sidebar_focus = Some(order[next]);
+        self.sidebar_cursor = 0;
+    }
+
+    /// `j` / `k` inside a focused section: advance or retreat by
+    /// `delta`. Clamps at both ends (no wrap-around) so the user
+    /// always knows when they're at a boundary.
+    pub(crate) fn sidebar_move(&mut self, delta: i32) {
+        let Some(section) = self.sidebar_focus else {
+            return;
+        };
+        let count = self.sidebar_item_count(section);
+        if count == 0 {
+            self.sidebar_cursor = 0;
+            return;
+        }
+        let max = count - 1;
+        let cur = self.sidebar_cursor as i32;
+        let new = (cur + delta).max(0).min(max as i32) as usize;
+        self.sidebar_cursor = new;
+    }
+
+    /// `Enter` on the focused sidebar item: open the page (or
+    /// journal) it points at. No-op for Calendar until that section
+    /// gains its own day cursor.
+    pub(crate) fn sidebar_activate(&mut self) -> Result<()> {
+        let Some(section) = self.sidebar_focus else {
+            return Ok(());
+        };
+        match section {
+            SidebarSection::Pinned => {
+                let pinned = self.pinned_slugs_sorted();
+                if let Some(slug) = pinned.get(self.sidebar_cursor) {
+                    self.open_slug(slug)?;
+                }
+            }
+            SidebarSection::Recent => {
+                if let Some(path) = self.recent_paths.get(self.sidebar_cursor).cloned() {
+                    self.open_path(path)?;
+                }
+            }
+            SidebarSection::Calendar => {
+                // No-op until calendar grows its own date cursor.
+            }
+        }
+        Ok(())
+    }
+
+    /// Pinned slugs in the same alphabetical order the renderer
+    /// uses. Mirroring the sort here means index N in the action
+    /// layer matches row N on screen — no drift between what the
+    /// user sees and what `Enter` opens.
+    pub(crate) fn pinned_slugs_sorted(&self) -> Vec<String> {
+        let mut v: Vec<(String, String)> = self
+            .index
+            .pages()
+            .filter(|p| p.pinned)
+            .map(|p| (p.slug.clone(), p.title.clone()))
+            .collect();
+        v.sort_by_key(|(_, t)| t.to_lowercase());
+        v.into_iter().map(|(s, _)| s).collect()
+    }
+
+    fn sidebar_item_count(&self, section: SidebarSection) -> usize {
+        match section {
+            SidebarSection::Pinned => self.pinned_slugs_sorted().len(),
+            SidebarSection::Recent => self.recent_paths.len().min(20),
+            SidebarSection::Calendar => 0, // navigated as a single block for now
+        }
+    }
+
+    /// Open a page or journal by slug. Journals live under
+    /// `journals/`, pages under `pages/`; the index knows the
+    /// difference via `PageEntry.is_journal`.
+    fn open_slug(&mut self, slug: &str) -> Result<()> {
+        let Some(entry) = self.index.by_slug(slug).cloned() else {
+            return Ok(());
+        };
+        if entry.is_journal {
+            if let Ok(date) = NaiveDate::parse_from_str(&entry.slug, "%Y-%m-%d") {
+                self.view = View::Journal(date);
+                self.selected = 0;
+                self.cursor_col = 0;
+                self.ensure_view_file_exists()?;
+                self.load_current();
+                return Ok(());
+            }
+        }
+        self.open_path(entry.path.clone())
+    }
+
+    /// Switch the view to an arbitrary `.md` path. Treats the file
+    /// as a Page (not a Journal) — recent paths come from anywhere
+    /// the user touched, but the journal branch is taken via the
+    /// `open_slug` route above so we don't mistake a page in
+    /// `journals/` for a date.
+    pub(crate) fn open_path(&mut self, path: PathBuf) -> Result<()> {
+        // Detect journal-shaped filenames (`YYYY-MM-DD.md`) and route
+        // through the journal view so navigation (`[`, `]`, `t`) stays
+        // consistent with how the user opened it.
+        if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+            if let Ok(date) = NaiveDate::parse_from_str(stem, "%Y-%m-%d") {
+                self.view = View::Journal(date);
+                self.selected = 0;
+                self.cursor_col = 0;
+                self.ensure_view_file_exists()?;
+                self.load_current();
+                return Ok(());
+            }
+        }
+        self.view = View::Page(path);
+        self.selected = 0;
+        self.cursor_col = 0;
+        self.load_current();
+        Ok(())
+    }
+}

--- a/crates/outl-tui/src/actions/toast.rs
+++ b/crates/outl-tui/src/actions/toast.rs
@@ -1,0 +1,68 @@
+//! Transient bottom-right notifications.
+//!
+//! Toasts are the "I want to see what happened" UI: a quick visual
+//! confirmation for save, reload, undo, etc, without stealing the
+//! footer's `status` line (which is reserved for chord prompts and
+//! sticky warnings).
+//!
+//! API surface is small on purpose:
+//! - [`App::toast`] — push a new notification with a kind + message.
+//!   Default lifetime ~2.5 seconds.
+//! - [`App::prune_toasts`] — called by the event loop each tick to
+//!   evict expired entries so the stack doesn't grow unbounded.
+
+use crate::state::{App, Toast, ToastKind};
+use std::time::{Duration, Instant};
+
+/// Default time a toast stays visible before the event loop sweeps
+/// it out. Long enough to read a 4-word message; short enough that
+/// stacking three save toasts doesn't drown out a real warning.
+const TOAST_DEFAULT_LIFETIME_MS: u64 = 2_500;
+
+/// Cap on how many toasts can coexist on screen at once. Anything
+/// past this drops off the bottom of the stack — the newest is
+/// always visible.
+const TOAST_STACK_CAP: usize = 4;
+
+impl App {
+    /// Push a new toast with the default lifetime. Use the typed
+    /// `kind` to drive the icon + color; the renderer maps semantics
+    /// to colors consistently.
+    pub(crate) fn toast(&mut self, kind: ToastKind, message: impl Into<String>) {
+        self.toast_for(kind, message, TOAST_DEFAULT_LIFETIME_MS);
+    }
+
+    /// Same as [`Self::toast`] but with a caller-supplied lifetime.
+    /// Useful when the message needs a beat extra ("compiled in 4.2s,
+    /// running…") or, conversely, should flash and disappear.
+    pub(crate) fn toast_for(
+        &mut self,
+        kind: ToastKind,
+        message: impl Into<String>,
+        lifetime_ms: u64,
+    ) {
+        let toast = Toast {
+            message: message.into(),
+            kind,
+            until: Instant::now() + Duration::from_millis(lifetime_ms),
+        };
+        self.toasts.push(toast);
+        // Evict the oldest from the front so the stack is bounded.
+        // `remove(0)` is O(n) but `n` is tiny (≤ TOAST_STACK_CAP).
+        while self.toasts.len() > TOAST_STACK_CAP {
+            self.toasts.remove(0);
+        }
+    }
+
+    /// Sweep expired toasts. Called from the event loop on every
+    /// tick (after `event::poll` returns, before draw). Returns the
+    /// number removed so the caller can decide whether to force a
+    /// redraw — the toast region looks wrong when an entry stays
+    /// frozen past its expiry.
+    pub(crate) fn prune_toasts(&mut self) -> usize {
+        let now = Instant::now();
+        let before = self.toasts.len();
+        self.toasts.retain(|t| t.until > now);
+        before - self.toasts.len()
+    }
+}

--- a/crates/outl-tui/src/commands/builtins/dates.rs
+++ b/crates/outl-tui/src/commands/builtins/dates.rs
@@ -1,64 +1,19 @@
-// Each struct here is self-documenting (one `impl SlashCommand` block
-// each, name + description on the trait methods). The struct itself
-// is just a zero-sized handle.
-#![allow(missing_docs)]
-
-//! Built-in slash / palette commands.
+//! Date / time / week-tag insert commands.
 //!
-//! Each command is a small struct implementing `SlashCommand`.
-//! Adding a new one is ~20 lines + one call in `register_all`.
-//!
-//! Convention:
-//!
-//! - `name()` is lowercase, single word.
-//! - `description()` is one short sentence in present-tense English.
-//! - Args-less commands (`needs_args = false`) usually toggle UI or
-//!   navigate. They run immediately from `/` without a second prompt.
-//! - Arg-taking commands explain expected format in `description`.
+//! Sixteen single-purpose commands that all share the same shape: in
+//! Insert mode they paste a formatted timestamp at the cursor; in
+//! Normal mode they refuse politely with a status hint. Grouped here
+//! because they share helpers (`insert_or_warn`, `journal_link_offset`,
+//! `time_text`, …) and the seven `date-next-<weekday>` siblings come
+//! from a single macro.
 
 use anyhow::Result;
 use chrono::{Datelike, Duration, Local, Months, NaiveDate, Weekday};
 
-use super::{CommandRegistry, SlashCommand};
+use super::super::SlashCommand;
 use crate::state::{App, Mode};
-use crate::theme;
 
-/// Hook for [`CommandRegistry::with_builtins`].
-pub(super) fn register_all(reg: &mut CommandRegistry) {
-    reg.register(PropBlockCommand);
-    reg.register(PropPageCommand);
-    reg.register(SearchCommand);
-    reg.register(RunCommand);
-    reg.register(ThemeCommand);
-    reg.register(TodayCommand);
-    reg.register(RefreshCommand);
-    reg.register(WriteCommand);
-    reg.register(HelpCommand);
-    reg.register(QuitCommand);
-    reg.register(OpenCommand);
-    // Date / time inserters (Insert mode only — slash dispatcher
-    // skips `commit_insert` for these because they need the buffer
-    // alive at the cursor).
-    reg.register(DateTodayCommand);
-    reg.register(DateTomorrowCommand);
-    reg.register(DateYesterdayCommand);
-    reg.register(DateNextWeekCommand);
-    reg.register(DateLastWeekCommand);
-    reg.register(DateNextMondayCommand);
-    reg.register(DateNextTuesdayCommand);
-    reg.register(DateNextWednesdayCommand);
-    reg.register(DateNextThursdayCommand);
-    reg.register(DateNextFridayCommand);
-    reg.register(DateNextSaturdayCommand);
-    reg.register(DateNextSundayCommand);
-    reg.register(DateCommand);
-    reg.register(IsoDateTodayCommand);
-    reg.register(IsoDateTomorrowCommand);
-    reg.register(IsoDateYesterdayCommand);
-    reg.register(TimeNowCommand);
-    reg.register(DateTimeNowCommand);
-    reg.register(WeekNumCommand);
-}
+// ─── helpers ──────────────────────────────────────────────────────────
 
 /// Insert `text` at the cursor if we're in Insert mode; otherwise
 /// surface a status message — date commands only make sense while
@@ -169,277 +124,7 @@ fn parse_date_arg(arg: &str, today: NaiveDate) -> Option<NaiveDate> {
     }
 }
 
-// ---------------------------------------------------------------------------
-// prop-block — add or update a property on the current block
-// ---------------------------------------------------------------------------
-
-pub struct PropBlockCommand;
-impl SlashCommand for PropBlockCommand {
-    fn name(&self) -> &'static str {
-        "prop-block"
-    }
-    fn description(&self) -> &'static str {
-        "Set a property on the current block — `prop-block <key> <value>` (empty value deletes)"
-    }
-    fn needs_args(&self) -> bool {
-        true
-    }
-    fn aliases(&self) -> &'static [&'static str] {
-        // `prop` defaults to the block scope — that's the common case.
-        &["prop"]
-    }
-    fn execute(&self, app: &mut App, args: &str) -> Result<bool> {
-        let (key, value) = args.split_once(' ').unwrap_or((args, ""));
-        let key = key.trim();
-        let value = value.trim();
-        if key.is_empty() {
-            app.status = "usage: prop-block <key> <value>".into();
-            return Ok(false);
-        }
-        app.set_property_on_current_block(key, value);
-        Ok(false)
-    }
-}
-
-// ---------------------------------------------------------------------------
-// prop-page — add or update a property at page level
-// ---------------------------------------------------------------------------
-
-pub struct PropPageCommand;
-impl SlashCommand for PropPageCommand {
-    fn name(&self) -> &'static str {
-        "prop-page"
-    }
-    fn description(&self) -> &'static str {
-        "Set a property on the page itself (`title::`, `icon::`, …) — `prop-page <key> <value>`"
-    }
-    fn needs_args(&self) -> bool {
-        true
-    }
-    fn execute(&self, app: &mut App, args: &str) -> Result<bool> {
-        let (key, value) = args.split_once(' ').unwrap_or((args, ""));
-        let key = key.trim();
-        let value = value.trim();
-        if key.is_empty() {
-            app.status = "usage: prop-page <key> <value>".into();
-            return Ok(false);
-        }
-        app.set_property_on_page(key, value);
-        Ok(false)
-    }
-}
-
-// ---------------------------------------------------------------------------
-// search — workspace-wide block search
-// ---------------------------------------------------------------------------
-
-pub struct SearchCommand;
-impl SlashCommand for SearchCommand {
-    fn name(&self) -> &'static str {
-        "search"
-    }
-    fn description(&self) -> &'static str {
-        "Open the workspace search overlay"
-    }
-    fn aliases(&self) -> &'static [&'static str] {
-        &["s", "find"]
-    }
-    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
-        app.open_search();
-        Ok(false)
-    }
-}
-
-// ---------------------------------------------------------------------------
-// run — execute the code block under the cursor
-// ---------------------------------------------------------------------------
-
-pub struct RunCommand;
-impl SlashCommand for RunCommand {
-    fn name(&self) -> &'static str {
-        "run"
-    }
-    fn description(&self) -> &'static str {
-        "Run the code block under the cursor through outl-exec"
-    }
-    fn aliases(&self) -> &'static [&'static str] {
-        &["x", "execute"]
-    }
-    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
-        app.run_current_block();
-        Ok(false)
-    }
-}
-
-// ---------------------------------------------------------------------------
-// theme — switch palette at runtime
-// ---------------------------------------------------------------------------
-
-pub struct ThemeCommand;
-impl SlashCommand for ThemeCommand {
-    fn name(&self) -> &'static str {
-        "theme"
-    }
-    fn description(&self) -> &'static str {
-        "Switch the active theme — `theme <preset>`"
-    }
-    fn needs_args(&self) -> bool {
-        true
-    }
-    fn execute(&self, app: &mut App, args: &str) -> Result<bool> {
-        if args.is_empty() {
-            app.status = "usage: theme <preset>".into();
-            return Ok(false);
-        }
-        if let Some(t) = theme::by_name(args) {
-            let name = t.name;
-            app.theme = t;
-            app.status = format!("theme: {name}");
-        } else {
-            app.status = format!("unknown theme: {args}");
-        }
-        Ok(false)
-    }
-}
-
-// ---------------------------------------------------------------------------
-// today — jump to today's journal
-// ---------------------------------------------------------------------------
-
-pub struct TodayCommand;
-impl SlashCommand for TodayCommand {
-    fn name(&self) -> &'static str {
-        "today"
-    }
-    fn description(&self) -> &'static str {
-        "Jump to today's journal"
-    }
-    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
-        app.go_today()?;
-        Ok(false)
-    }
-}
-
-// ---------------------------------------------------------------------------
-// refresh — re-read the workspace from disk
-// ---------------------------------------------------------------------------
-
-pub struct RefreshCommand;
-impl SlashCommand for RefreshCommand {
-    fn name(&self) -> &'static str {
-        "refresh"
-    }
-    fn description(&self) -> &'static str {
-        "Re-read the workspace from disk (rebuilds index)"
-    }
-    fn aliases(&self) -> &'static [&'static str] {
-        &["reload", "r"]
-    }
-    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
-        app.refresh_workspace();
-        app.status = "refreshed".into();
-        Ok(false)
-    }
-}
-
-// ---------------------------------------------------------------------------
-// write — force-save the current page
-// ---------------------------------------------------------------------------
-
-pub struct WriteCommand;
-impl SlashCommand for WriteCommand {
-    fn name(&self) -> &'static str {
-        "write"
-    }
-    fn description(&self) -> &'static str {
-        "Save the current page to disk"
-    }
-    fn aliases(&self) -> &'static [&'static str] {
-        &["w", "save"]
-    }
-    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
-        app.save();
-        app.status = "saved".into();
-        Ok(false)
-    }
-}
-
-// ---------------------------------------------------------------------------
-// help — toggle the help popup
-// ---------------------------------------------------------------------------
-
-pub struct HelpCommand;
-impl SlashCommand for HelpCommand {
-    fn name(&self) -> &'static str {
-        "help"
-    }
-    fn description(&self) -> &'static str {
-        "Toggle the help popup"
-    }
-    fn aliases(&self) -> &'static [&'static str] {
-        &["h"]
-    }
-    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
-        app.show_help = true;
-        Ok(false)
-    }
-}
-
-// ---------------------------------------------------------------------------
-// quit — close the TUI
-// ---------------------------------------------------------------------------
-
-pub struct QuitCommand;
-impl SlashCommand for QuitCommand {
-    fn name(&self) -> &'static str {
-        "quit"
-    }
-    fn description(&self) -> &'static str {
-        "Close the TUI (commits any pending Insert first)"
-    }
-    fn aliases(&self) -> &'static [&'static str] {
-        &["q", "exit"]
-    }
-    fn execute(&self, _app: &mut App, _args: &str) -> Result<bool> {
-        Ok(true)
-    }
-}
-
-// ---------------------------------------------------------------------------
-// open — open (or create) a page by title
-// ---------------------------------------------------------------------------
-
-pub struct OpenCommand;
-impl SlashCommand for OpenCommand {
-    fn name(&self) -> &'static str {
-        "open"
-    }
-    fn description(&self) -> &'static str {
-        "Open (or create) a page by name — `open <name>`"
-    }
-    fn needs_args(&self) -> bool {
-        true
-    }
-    fn aliases(&self) -> &'static [&'static str] {
-        &["o", "new", "n"]
-    }
-    fn execute(&self, app: &mut App, args: &str) -> Result<bool> {
-        if args.is_empty() {
-            app.status = "usage: open <page name>".into();
-            return Ok(false);
-        }
-        app.open_page_by_name(args)?;
-        Ok(false)
-    }
-}
-
-// ---------------------------------------------------------------------------
-// date-today / date-tomorrow / date-yesterday — insert a journal ref
-// ---------------------------------------------------------------------------
-//
-// All three insert `[[YYYY-MM-DD]]` at the cursor. ISO format matches
-// outl's journal slug, so the inserted ref is also a live link to that
-// day's journal — clickable from the rendered view.
+// ─── date-today / tomorrow / yesterday ────────────────────────────────
 
 pub struct DateTodayCommand;
 impl SlashCommand for DateTodayCommand {
@@ -501,9 +186,7 @@ impl SlashCommand for DateYesterdayCommand {
     }
 }
 
-// ---------------------------------------------------------------------------
-// time-now — plain `HH:MM`, no brackets (it's not a journal ref)
-// ---------------------------------------------------------------------------
+// ─── time-now / datetime-now ──────────────────────────────────────────
 
 pub struct TimeNowCommand;
 impl SlashCommand for TimeNowCommand {
@@ -525,10 +208,6 @@ impl SlashCommand for TimeNowCommand {
     }
 }
 
-// ---------------------------------------------------------------------------
-// datetime-now — `[[YYYY-MM-DD]] HH:MM`, the "timestamp this moment" marker
-// ---------------------------------------------------------------------------
-
 pub struct DateTimeNowCommand;
 impl SlashCommand for DateTimeNowCommand {
     fn name(&self) -> &'static str {
@@ -549,9 +228,7 @@ impl SlashCommand for DateTimeNowCommand {
     }
 }
 
-// ---------------------------------------------------------------------------
-// date-next-week / date-last-week — same weekday, ±7 days
-// ---------------------------------------------------------------------------
+// ─── date-next-week / date-last-week ──────────────────────────────────
 
 pub struct DateNextWeekCommand;
 impl SlashCommand for DateNextWeekCommand {
@@ -593,12 +270,8 @@ impl SlashCommand for DateLastWeekCommand {
     }
 }
 
-// ---------------------------------------------------------------------------
-// date-next-<weekday> — next occurrence of that weekday (skips today)
-// ---------------------------------------------------------------------------
-//
-// Seven small structs share one body via a macro because the only
-// thing that varies is the name string and the `Weekday` value.
+// ─── date-next-<weekday> ──────────────────────────────────────────────
+// Seven sibling commands share one body via a macro.
 macro_rules! next_weekday_command {
     ($struct_name:ident, $name:literal, $weekday:expr, $label:literal, $aliases:expr) => {
         pub struct $struct_name;
@@ -675,9 +348,7 @@ next_weekday_command!(
     &["dnsun"]
 );
 
-// ---------------------------------------------------------------------------
-// date — flexible: `/date +3d`, `/date -2w`, `/date +1m`, `/date 2026-06-15`
-// ---------------------------------------------------------------------------
+// ─── date (flexible offset / absolute) ────────────────────────────────
 
 pub struct DateCommand;
 impl SlashCommand for DateCommand {
@@ -708,12 +379,7 @@ impl SlashCommand for DateCommand {
     }
 }
 
-// ---------------------------------------------------------------------------
-// iso-date-{today,tomorrow,yesterday} — plain `YYYY-MM-DD` (no brackets)
-// ---------------------------------------------------------------------------
-//
-// Useful for property values like `due:: 2026-05-26` where you don't
-// want the auto-link semantics of `[[...]]`.
+// ─── iso-date-{today,tomorrow,yesterday} ──────────────────────────────
 
 pub struct IsoDateTodayCommand;
 impl SlashCommand for IsoDateTodayCommand {
@@ -775,13 +441,10 @@ impl SlashCommand for IsoDateYesterdayCommand {
     }
 }
 
-// ---------------------------------------------------------------------------
-// week-num — `#YYYY-Www` tag for the current ISO week
-// ---------------------------------------------------------------------------
-//
+// ─── week-num (`#YYYY-Www`) ───────────────────────────────────────────
 // Inserted as a `#tag` (not `[[ref]]`) so it routes through the
-// existing tag indexing — weekly notes show up in backlinks for
-// the tag page if it exists.
+// existing tag indexing — weekly notes show up in backlinks for the
+// tag page if it exists.
 
 pub struct WeekNumCommand;
 impl SlashCommand for WeekNumCommand {
@@ -803,6 +466,8 @@ impl SlashCommand for WeekNumCommand {
         Ok(false)
     }
 }
+
+// ─── tests ────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
@@ -880,15 +545,6 @@ mod tests {
         assert!(IsoDateTomorrowCommand.inserts_inline());
         assert!(IsoDateYesterdayCommand.inserts_inline());
         assert!(WeekNumCommand.inserts_inline());
-    }
-
-    /// Sanity: existing non-inline commands keep the default `false`,
-    /// so we don't accidentally break the commit-then-dispatch flow.
-    #[test]
-    fn non_date_commands_stay_non_inline() {
-        assert!(!TodayCommand.inserts_inline());
-        assert!(!OpenCommand.inserts_inline());
-        assert!(!SearchCommand.inserts_inline());
     }
 
     #[test]
@@ -1007,5 +663,19 @@ mod tests {
         // differs from `%Y` (calendar year) here. Confirms we used %G.
         let last_of_year = NaiveDate::from_ymd_opt(2025, 12, 31).unwrap();
         assert_eq!(week_tag(last_of_year), "#2026-W01");
+    }
+
+    // -- non-date commands kept lean -----------------------------------------
+
+    #[test]
+    fn non_date_commands_stay_non_inline() {
+        // Sentinel — anything not in this module should keep its
+        // default `inserts_inline == false`. We re-assert here so
+        // a refactor that flips the default doesn't slip through.
+        use super::super::exec::SearchCommand;
+        use super::super::workspace::{OpenCommand, TodayCommand};
+        assert!(!TodayCommand.inserts_inline());
+        assert!(!OpenCommand.inserts_inline());
+        assert!(!SearchCommand.inserts_inline());
     }
 }

--- a/crates/outl-tui/src/commands/builtins/exec.rs
+++ b/crates/outl-tui/src/commands/builtins/exec.rs
@@ -1,0 +1,84 @@
+//! Execution-flavored builtins: search, run a code block, swap theme.
+//!
+//! These three live together because they each trigger a "side
+//! effect that's not an AST edit" — opening an overlay, invoking
+//! `outl-exec`, or hot-swapping the palette.
+
+use anyhow::Result;
+
+use super::super::SlashCommand;
+use crate::state::App;
+use crate::theme;
+
+// ---------------------------------------------------------------------------
+// search — workspace-wide block search
+// ---------------------------------------------------------------------------
+
+pub struct SearchCommand;
+impl SlashCommand for SearchCommand {
+    fn name(&self) -> &'static str {
+        "search"
+    }
+    fn description(&self) -> &'static str {
+        "Open the workspace search overlay"
+    }
+    fn aliases(&self) -> &'static [&'static str] {
+        &["s", "find"]
+    }
+    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
+        app.open_search();
+        Ok(false)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// run — execute the code block under the cursor
+// ---------------------------------------------------------------------------
+
+pub struct RunCommand;
+impl SlashCommand for RunCommand {
+    fn name(&self) -> &'static str {
+        "run"
+    }
+    fn description(&self) -> &'static str {
+        "Run the code block under the cursor through outl-exec"
+    }
+    fn aliases(&self) -> &'static [&'static str] {
+        &["x", "execute"]
+    }
+    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
+        app.run_current_block();
+        Ok(false)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// theme — switch palette at runtime
+// ---------------------------------------------------------------------------
+
+pub struct ThemeCommand;
+impl SlashCommand for ThemeCommand {
+    fn name(&self) -> &'static str {
+        "theme"
+    }
+    fn description(&self) -> &'static str {
+        "Switch the active theme — `theme <preset>`"
+    }
+    fn needs_args(&self) -> bool {
+        true
+    }
+    fn execute(&self, app: &mut App, args: &str) -> Result<bool> {
+        if args.is_empty() {
+            app.status = "usage: theme <preset>".into();
+            return Ok(false);
+        }
+        if let Some(t) = theme::by_name(args) {
+            let name = t.name;
+            app.theme = t;
+            app.status = format!("theme: {name}");
+        } else {
+            app.status = format!("unknown theme: {args}");
+        }
+        Ok(false)
+    }
+}

--- a/crates/outl-tui/src/commands/builtins/mod.rs
+++ b/crates/outl-tui/src/commands/builtins/mod.rs
@@ -1,0 +1,89 @@
+//! Built-in slash / palette commands.
+//!
+//! Each command is a small struct implementing
+//! [`crate::commands::SlashCommand`]. They're grouped into sibling
+//! modules by concern so this file stays a glance-able index:
+//!
+//! - [`page`] — block / page property mutations, including `pin`
+//! - [`workspace`] — navigation, save, reload, help, quit, open
+//! - [`exec`] — search overlay, code-block runner, theme swap
+//! - [`dates`] — date / time / ISO / week-tag inserters
+//!
+//! Adding a new command:
+//!
+//! 1. Drop the `pub struct FooCommand;` + `impl SlashCommand for FooCommand` in the
+//!    appropriate sibling (or create a new sibling if it's a fresh concern).
+//! 2. Register it below in [`register_all`].
+//!
+//! Convention:
+//!
+//! - `name()` is lowercase, single word.
+//! - `description()` is one short sentence in present-tense English.
+//! - Args-less commands (`needs_args = false`) usually toggle UI or
+//!   navigate. They run immediately from `/` without a second prompt.
+//! - Arg-taking commands explain expected format in `description`.
+#![allow(missing_docs)]
+
+mod dates;
+mod exec;
+mod page;
+mod workspace;
+
+use super::CommandRegistry;
+
+use dates::{
+    DateCommand, DateLastWeekCommand, DateNextFridayCommand, DateNextMondayCommand,
+    DateNextSaturdayCommand, DateNextSundayCommand, DateNextThursdayCommand,
+    DateNextTuesdayCommand, DateNextWednesdayCommand, DateNextWeekCommand, DateTimeNowCommand,
+    DateTodayCommand, DateTomorrowCommand, DateYesterdayCommand, IsoDateTodayCommand,
+    IsoDateTomorrowCommand, IsoDateYesterdayCommand, TimeNowCommand, WeekNumCommand,
+};
+use exec::{RunCommand, SearchCommand, ThemeCommand};
+use page::{PinCommand, PropBlockCommand, PropPageCommand};
+use workspace::{
+    HelpCommand, OpenCommand, QuitCommand, RefreshCommand, TodayCommand, WriteCommand,
+};
+
+/// Hook for [`super::CommandRegistry::with_builtins`].
+pub(super) fn register_all(reg: &mut CommandRegistry) {
+    // page — properties and the pinned toggle
+    reg.register(PropBlockCommand);
+    reg.register(PropPageCommand);
+    reg.register(PinCommand);
+
+    // workspace — chrome verbs
+    reg.register(TodayCommand);
+    reg.register(RefreshCommand);
+    reg.register(WriteCommand);
+    reg.register(HelpCommand);
+    reg.register(QuitCommand);
+    reg.register(OpenCommand);
+
+    // exec — side-effecting actions
+    reg.register(SearchCommand);
+    reg.register(RunCommand);
+    reg.register(ThemeCommand);
+
+    // dates — Insert-mode inserters. The slash dispatcher uses
+    // `inserts_inline()` (set true in each command) to skip
+    // `commit_insert()` and write straight into the live buffer.
+    reg.register(DateTodayCommand);
+    reg.register(DateTomorrowCommand);
+    reg.register(DateYesterdayCommand);
+    reg.register(DateNextWeekCommand);
+    reg.register(DateLastWeekCommand);
+    reg.register(DateNextMondayCommand);
+    reg.register(DateNextTuesdayCommand);
+    reg.register(DateNextWednesdayCommand);
+    reg.register(DateNextThursdayCommand);
+    reg.register(DateNextFridayCommand);
+    reg.register(DateNextSaturdayCommand);
+    reg.register(DateNextSundayCommand);
+    reg.register(DateCommand);
+    reg.register(IsoDateTodayCommand);
+    reg.register(IsoDateTomorrowCommand);
+    reg.register(IsoDateYesterdayCommand);
+    reg.register(TimeNowCommand);
+    reg.register(DateTimeNowCommand);
+    reg.register(WeekNumCommand);
+}

--- a/crates/outl-tui/src/commands/builtins/mod.rs
+++ b/crates/outl-tui/src/commands/builtins/mod.rs
@@ -1,19 +1,19 @@
 //! Built-in slash / palette commands.
 //!
-//! Each command is a small struct implementing
-//! [`crate::commands::SlashCommand`]. They're grouped into sibling
-//! modules by concern so this file stays a glance-able index:
+//! Each command is a small struct implementing the `SlashCommand`
+//! trait from the parent `commands` module. They're grouped into
+//! sibling modules by concern so this file stays a glance-able index:
 //!
-//! - [`page`] — block / page property mutations, including `pin`
-//! - [`workspace`] — navigation, save, reload, help, quit, open
-//! - [`exec`] — search overlay, code-block runner, theme swap
-//! - [`dates`] — date / time / ISO / week-tag inserters
+//! - `page` — block / page property mutations, including `pin`
+//! - `workspace` — navigation, save, reload, help, quit, open
+//! - `exec` — search overlay, code-block runner, theme swap
+//! - `dates` — date / time / ISO / week-tag inserters
 //!
 //! Adding a new command:
 //!
 //! 1. Drop the `pub struct FooCommand;` + `impl SlashCommand for FooCommand` in the
 //!    appropriate sibling (or create a new sibling if it's a fresh concern).
-//! 2. Register it below in [`register_all`].
+//! 2. Register it below in `register_all`.
 //!
 //! Convention:
 //!
@@ -44,7 +44,7 @@ use workspace::{
     HelpCommand, OpenCommand, QuitCommand, RefreshCommand, TodayCommand, WriteCommand,
 };
 
-/// Hook for [`super::CommandRegistry::with_builtins`].
+/// Hook for `super::CommandRegistry::with_builtins`.
 pub(super) fn register_all(reg: &mut CommandRegistry) {
     // page — properties and the pinned toggle
     reg.register(PropBlockCommand);

--- a/crates/outl-tui/src/commands/builtins/page.rs
+++ b/crates/outl-tui/src/commands/builtins/page.rs
@@ -82,7 +82,12 @@ impl SlashCommand for PinCommand {
         "Toggle pinned:: on the current page (shows in sidebar Pinned)"
     }
     fn aliases(&self) -> &'static [&'static str] {
-        &["unpin", "pinned"]
+        // `pinned` is a synonym — it reads naturally in the palette
+        // ("/pinned" → "is this pinned? toggle it"). We intentionally
+        // do NOT alias `unpin`: a command named `unpin` that *toggles*
+        // would silently pin an unpinned page, which is surprising.
+        // Users wanting the explicit verb get `/pin` either way.
+        &["pinned"]
     }
     fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
         app.toggle_pinned();

--- a/crates/outl-tui/src/commands/builtins/page.rs
+++ b/crates/outl-tui/src/commands/builtins/page.rs
@@ -1,0 +1,91 @@
+//! Page-scoped builtins: property edits and the `pin` toggle.
+//!
+//! These commands operate on either the current block or the page's
+//! top-level properties. They live together because they share the
+//! "mutate AST → save → reconcile" code path through `App`.
+
+use anyhow::Result;
+
+use super::super::SlashCommand;
+use crate::state::App;
+
+// ---------------------------------------------------------------------------
+// prop-block — add or update a property on the current block
+// ---------------------------------------------------------------------------
+
+pub struct PropBlockCommand;
+impl SlashCommand for PropBlockCommand {
+    fn name(&self) -> &'static str {
+        "prop-block"
+    }
+    fn description(&self) -> &'static str {
+        "Set a property on the current block — `prop-block <key> <value>` (empty value deletes)"
+    }
+    fn needs_args(&self) -> bool {
+        true
+    }
+    fn aliases(&self) -> &'static [&'static str] {
+        // `prop` defaults to the block scope — that's the common case.
+        &["prop"]
+    }
+    fn execute(&self, app: &mut App, args: &str) -> Result<bool> {
+        let (key, value) = args.split_once(' ').unwrap_or((args, ""));
+        let key = key.trim();
+        let value = value.trim();
+        if key.is_empty() {
+            app.status = "usage: prop-block <key> <value>".into();
+            return Ok(false);
+        }
+        app.set_property_on_current_block(key, value);
+        Ok(false)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// prop-page — add or update a property at page level
+// ---------------------------------------------------------------------------
+
+pub struct PropPageCommand;
+impl SlashCommand for PropPageCommand {
+    fn name(&self) -> &'static str {
+        "prop-page"
+    }
+    fn description(&self) -> &'static str {
+        "Set a property on the page itself (`title::`, `icon::`, …) — `prop-page <key> <value>`"
+    }
+    fn needs_args(&self) -> bool {
+        true
+    }
+    fn execute(&self, app: &mut App, args: &str) -> Result<bool> {
+        let (key, value) = args.split_once(' ').unwrap_or((args, ""));
+        let key = key.trim();
+        let value = value.trim();
+        if key.is_empty() {
+            app.status = "usage: prop-page <key> <value>".into();
+            return Ok(false);
+        }
+        app.set_property_on_page(key, value);
+        Ok(false)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// pin — toggle the `pinned::` page property
+// ---------------------------------------------------------------------------
+
+pub struct PinCommand;
+impl SlashCommand for PinCommand {
+    fn name(&self) -> &'static str {
+        "pin"
+    }
+    fn description(&self) -> &'static str {
+        "Toggle pinned:: on the current page (shows in sidebar Pinned)"
+    }
+    fn aliases(&self) -> &'static [&'static str] {
+        &["unpin", "pinned"]
+    }
+    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
+        app.toggle_pinned();
+        Ok(false)
+    }
+}

--- a/crates/outl-tui/src/commands/builtins/workspace.rs
+++ b/crates/outl-tui/src/commands/builtins/workspace.rs
@@ -7,7 +7,7 @@
 use anyhow::Result;
 
 use super::super::SlashCommand;
-use crate::state::App;
+use crate::state::{App, ToastKind};
 
 // ---------------------------------------------------------------------------
 // today — jump to today's journal
@@ -44,7 +44,7 @@ impl SlashCommand for RefreshCommand {
     }
     fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
         app.refresh_workspace();
-        app.status = "refreshed".into();
+        app.toast(ToastKind::Info, "refreshed");
         Ok(false)
     }
 }
@@ -66,7 +66,7 @@ impl SlashCommand for WriteCommand {
     }
     fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
         app.save();
-        app.status = "saved".into();
+        app.toast(ToastKind::Success, "saved");
         Ok(false)
     }
 }
@@ -87,7 +87,12 @@ impl SlashCommand for HelpCommand {
         &["h"]
     }
     fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
-        app.show_help = true;
+        // Genuine toggle so /help on an open popup closes it — matches
+        // the description and matches the `?` keybinding's behavior.
+        app.show_help = !app.show_help;
+        if !app.show_help {
+            app.help_scroll = 0;
+        }
         Ok(false)
     }
 }

--- a/crates/outl-tui/src/commands/builtins/workspace.rs
+++ b/crates/outl-tui/src/commands/builtins/workspace.rs
@@ -1,0 +1,141 @@
+//! Workspace / chrome commands: navigation, save, reload, help, quit.
+//!
+//! Anything that doesn't insert text and doesn't touch a single
+//! block's properties — these are the "I want to do something with
+//! the *editor*" verbs.
+
+use anyhow::Result;
+
+use super::super::SlashCommand;
+use crate::state::App;
+
+// ---------------------------------------------------------------------------
+// today — jump to today's journal
+// ---------------------------------------------------------------------------
+
+pub struct TodayCommand;
+impl SlashCommand for TodayCommand {
+    fn name(&self) -> &'static str {
+        "today"
+    }
+    fn description(&self) -> &'static str {
+        "Jump to today's journal"
+    }
+    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
+        app.go_today()?;
+        Ok(false)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// refresh — re-read the workspace from disk
+// ---------------------------------------------------------------------------
+
+pub struct RefreshCommand;
+impl SlashCommand for RefreshCommand {
+    fn name(&self) -> &'static str {
+        "refresh"
+    }
+    fn description(&self) -> &'static str {
+        "Re-read the workspace from disk (rebuilds index)"
+    }
+    fn aliases(&self) -> &'static [&'static str] {
+        &["reload", "r"]
+    }
+    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
+        app.refresh_workspace();
+        app.status = "refreshed".into();
+        Ok(false)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// write — force-save the current page
+// ---------------------------------------------------------------------------
+
+pub struct WriteCommand;
+impl SlashCommand for WriteCommand {
+    fn name(&self) -> &'static str {
+        "write"
+    }
+    fn description(&self) -> &'static str {
+        "Save the current page to disk"
+    }
+    fn aliases(&self) -> &'static [&'static str] {
+        &["w", "save"]
+    }
+    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
+        app.save();
+        app.status = "saved".into();
+        Ok(false)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// help — toggle the help popup
+// ---------------------------------------------------------------------------
+
+pub struct HelpCommand;
+impl SlashCommand for HelpCommand {
+    fn name(&self) -> &'static str {
+        "help"
+    }
+    fn description(&self) -> &'static str {
+        "Toggle the help popup"
+    }
+    fn aliases(&self) -> &'static [&'static str] {
+        &["h"]
+    }
+    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
+        app.show_help = true;
+        Ok(false)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// quit — close the TUI
+// ---------------------------------------------------------------------------
+
+pub struct QuitCommand;
+impl SlashCommand for QuitCommand {
+    fn name(&self) -> &'static str {
+        "quit"
+    }
+    fn description(&self) -> &'static str {
+        "Close the TUI (commits any pending Insert first)"
+    }
+    fn aliases(&self) -> &'static [&'static str] {
+        &["q", "exit"]
+    }
+    fn execute(&self, _app: &mut App, _args: &str) -> Result<bool> {
+        Ok(true)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// open — open (or create) a page by title
+// ---------------------------------------------------------------------------
+
+pub struct OpenCommand;
+impl SlashCommand for OpenCommand {
+    fn name(&self) -> &'static str {
+        "open"
+    }
+    fn description(&self) -> &'static str {
+        "Open (or create) a page by name — `open <name>`"
+    }
+    fn needs_args(&self) -> bool {
+        true
+    }
+    fn aliases(&self) -> &'static [&'static str] {
+        &["o", "new", "n"]
+    }
+    fn execute(&self, app: &mut App, args: &str) -> Result<bool> {
+        if args.is_empty() {
+            app.status = "usage: open <page name>".into();
+            return Ok(false);
+        }
+        app.open_page_by_name(args)?;
+        Ok(false)
+    }
+}

--- a/crates/outl-tui/src/input.rs
+++ b/crates/outl-tui/src/input.rs
@@ -227,6 +227,104 @@ fn run_command(app: &mut App, line: &str) -> Result<bool> {
 }
 
 pub(crate) fn handle_normal_key(app: &mut App, key: KeyEvent) -> Result<bool> {
+    // Help popup owns the keyboard exclusively while open. Any key
+    // that isn't a tab switch / scroll / close is *swallowed* — we
+    // don't want `j` to move the outline behind the popup while the
+    // user thinks they're scrolling help.
+    if app.show_help {
+        match key.code {
+            KeyCode::Char('h') | KeyCode::Left => {
+                if app.help_tab == 0 {
+                    app.help_tab = crate::view::HELP_TABS.len() - 1;
+                } else {
+                    app.help_tab -= 1;
+                }
+                app.help_scroll = 0; // new tab → top
+            }
+            KeyCode::Char('l') | KeyCode::Right | KeyCode::Tab => {
+                app.help_tab = (app.help_tab + 1) % crate::view::HELP_TABS.len();
+                app.help_scroll = 0;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                app.help_scroll = app.help_scroll.saturating_add(1);
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                app.help_scroll = app.help_scroll.saturating_sub(1);
+            }
+            KeyCode::PageDown => {
+                app.help_scroll = app.help_scroll.saturating_add(10);
+            }
+            KeyCode::PageUp => {
+                app.help_scroll = app.help_scroll.saturating_sub(10);
+            }
+            KeyCode::Char('g') | KeyCode::Home => {
+                app.help_scroll = 0;
+            }
+            KeyCode::Char('G') | KeyCode::End => {
+                // Big number — the renderer clamps against the
+                // actual body length when it draws, so we don't need
+                // to know the count here.
+                app.help_scroll = u16::MAX / 2;
+            }
+            KeyCode::Char('?') | KeyCode::Esc | KeyCode::Char('q') => {
+                app.show_help = false;
+                app.help_scroll = 0;
+            }
+            _ => {
+                // Swallow every other key. The popup has focus; the
+                // outline behind it must not react.
+            }
+        }
+        return Ok(false);
+    }
+
+    // Sidebar intercept: while focus is inside the sidebar, j/k
+    // navigate the focused section, Tab cycles sections, Enter opens
+    // the item, Esc returns focus to the outline (sidebar stays
+    // visible). `\` always closes the sidebar entirely, handled
+    // further down in the Normal handler.
+    if app.sidebar_focus.is_some() {
+        match key.code {
+            KeyCode::Char('j') | KeyCode::Down => {
+                app.sidebar_move(1);
+                return Ok(false);
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                app.sidebar_move(-1);
+                return Ok(false);
+            }
+            KeyCode::Char('g') => {
+                app.sidebar_cursor = 0;
+                return Ok(false);
+            }
+            KeyCode::Char('G') => {
+                app.sidebar_move(i32::MAX / 2);
+                return Ok(false);
+            }
+            KeyCode::Tab => {
+                app.sidebar_cycle_section(true);
+                return Ok(false);
+            }
+            KeyCode::BackTab => {
+                app.sidebar_cycle_section(false);
+                return Ok(false);
+            }
+            KeyCode::Enter => {
+                app.sidebar_activate()?;
+                return Ok(false);
+            }
+            KeyCode::Esc => {
+                app.sidebar_blur();
+                return Ok(false);
+            }
+            KeyCode::Char('\\') => {
+                app.sidebar_close();
+                return Ok(false);
+            }
+            _ => {}
+        }
+    }
+
     // Chord handling: a previous 'd' / 'g' / 'y' is pending.
     if let Some(pending) = app.pending_chord.take() {
         match (pending, key.code) {
@@ -247,6 +345,15 @@ pub(crate) fn handle_normal_key(app: &mut App, key: KeyEvent) -> Result<bool> {
             ('g', KeyCode::Char('g')) => {
                 // `gg` = jump to the first block (vim convention).
                 app.move_selection(i32::MIN / 2);
+                return Ok(false);
+            }
+            ('g', KeyCode::Char('p')) => {
+                // `gp` = toggle the `pinned::` page property.
+                // Mnemonic: "go pin". Chose a chord (not bare `P`)
+                // because `P` is already paste-before in Normal
+                // mode — overloading it would surprise yanker
+                // muscle memory.
+                app.toggle_pinned();
                 return Ok(false);
             }
             ('y', KeyCode::Char('y')) => {
@@ -367,6 +474,18 @@ pub(crate) fn handle_normal_key(app: &mut App, key: KeyEvent) -> Result<bool> {
         KeyCode::Char('N') => app.search_prev()?,
         // Toggle backlinks panel.
         KeyCode::Char('B') => app.show_backlinks = !app.show_backlinks,
+        // Toggle the left sidebar (mini-calendar, pinned, recent).
+        // Default off — `\` opts in. Opening jumps focus straight to
+        // the first non-empty section (Pinned by default), so the
+        // user can immediately `j/k` through items and `Enter` to
+        // open — no extra Tab to "enter" the sidebar.
+        KeyCode::Char('\\') => {
+            if app.show_sidebar {
+                app.sidebar_close();
+            } else {
+                app.sidebar_open_focused();
+            }
+        }
         // Enter Visual mode (vim-style: V selects entire blocks).
         KeyCode::Char('V') => app.enter_visual(),
         _ => {}

--- a/crates/outl-tui/src/outline_ops.rs
+++ b/crates/outl-tui/src/outline_ops.rs
@@ -20,6 +20,34 @@ pub fn flat_count(blocks: &[OutlineNode]) -> usize {
     blocks.iter().map(|b| 1 + flat_count(&b.children)).sum()
 }
 
+/// TODO/DONE counters: `(done, total)`. A block is counted when its
+/// trimmed text starts with `TODO ` or `DONE `; `DONE` counts toward
+/// `done` and toward `total`.
+///
+/// The header chip in the TUI uses this for the `●● 3/7` indicator,
+/// so the count walks the whole tree (nested children included).
+pub fn count_todos(blocks: &[OutlineNode]) -> (usize, usize) {
+    let mut done = 0usize;
+    let mut total = 0usize;
+    walk_todos(blocks, &mut done, &mut total);
+    (done, total)
+}
+
+fn walk_todos(blocks: &[OutlineNode], done: &mut usize, total: &mut usize) {
+    for b in blocks {
+        let t = b.text.trim_start();
+        if let Some(rest) = t.strip_prefix("TODO ") {
+            let _ = rest;
+            *total += 1;
+        } else if let Some(rest) = t.strip_prefix("DONE ") {
+            let _ = rest;
+            *total += 1;
+            *done += 1;
+        }
+        walk_todos(&b.children, done, total);
+    }
+}
+
 /// Return the path of indices to reach the block at `target_index`
 /// in DFS preorder. `None` if the index is out of range.
 pub fn path_for_index(blocks: &[OutlineNode], target: usize) -> Option<Vec<usize>> {

--- a/crates/outl-tui/src/runtime.rs
+++ b/crates/outl-tui/src/runtime.rs
@@ -212,6 +212,9 @@ fn event_loop(
         // Pick up the background index build if it finished since the
         // last frame. Non-blocking; costs ~one channel try_recv.
         app.poll_index_updates();
+        // Sweep expired toasts so they don't linger on screen past
+        // their lifetime. Cheap O(n) over the small toast stack.
+        app.prune_toasts();
 
         terminal.draw(|f| render_app(f, &mut app)).context("draw")?;
         // Wait for a keystroke for up to POLL_INTERVAL. If nothing
@@ -254,7 +257,8 @@ fn event_loop(
         // Universal: if the help popup is up, intercept the obvious
         // "close it" keys before they reach any mode-specific handler.
         // The popup is a `bool` flag (not an `Overlay`) so the overlay
-        // close path doesn't catch it.
+        // close path doesn't catch it. Also resets `help_scroll` so
+        // reopening starts from the top instead of a stale offset.
         if app.show_help
             && matches!(
                 key.code,
@@ -262,6 +266,7 @@ fn event_loop(
             )
         {
             app.show_help = false;
+            app.help_scroll = 0;
             continue;
         }
 
@@ -272,7 +277,7 @@ fn event_loop(
             } else {
                 app.save();
             }
-            app.status = "saved".into();
+            app.toast(crate::state::ToastKind::Success, "saved");
             continue;
         }
 

--- a/crates/outl-tui/src/state.rs
+++ b/crates/outl-tui/src/state.rs
@@ -231,6 +231,15 @@ pub(crate) struct QuickSwitchState {
     pub(crate) query: String,
     pub(crate) candidates: Vec<SwitchCandidate>,
     pub(crate) selected: usize,
+    /// One-slot cache for the preview pane so the renderer doesn't
+    /// re-read the highlighted page from disk on every frame. Keyed
+    /// by the candidate's `key` (slug or ISO date); the renderer
+    /// invalidates whenever the cached key doesn't match the
+    /// currently selected candidate. `RefCell` because the
+    /// `render_app` path holds `QuickSwitchState` by shared
+    /// reference — interior mutability lets us refresh the slot
+    /// without rippling `&mut` through every view function.
+    pub(crate) preview_cache: std::cell::RefCell<Option<(String, String)>>,
 }
 
 /// One search hit — a single block matching the query.
@@ -396,7 +405,7 @@ pub(crate) struct App {
     /// LRU of recently-opened paths. Newest first; bounded to a small
     /// window so the sidebar's `Recent` section stays scannable.
     /// In-memory only for now — persisting to `.outl/state.toml` is on
-    /// the roadmap (Fase 2 stretch).
+    /// the roadmap (Phase 2 stretch).
     pub(crate) recent_paths: Vec<PathBuf>,
 
     /// Stack of transient notifications shown in the bottom-right

--- a/crates/outl-tui/src/state.rs
+++ b/crates/outl-tui/src/state.rs
@@ -18,7 +18,7 @@ use outl_exec::RuntimeRegistry;
 use outl_md::index::WorkspaceIndex;
 use outl_md::parse::{OutlineNode, ParsedPage};
 use std::path::PathBuf;
-use std::time::SystemTime;
+use std::time::{Instant, SystemTime};
 
 pub(crate) const HELP_HINT_NORMAL: &str =
     "i edit  o new  h/l cursor  Enter open ref  K/J move  C-T TODO  u undo  ? help  q";

--- a/crates/outl-tui/src/state.rs
+++ b/crates/outl-tui/src/state.rs
@@ -84,6 +84,41 @@ pub(crate) enum View {
     Page(PathBuf),
 }
 
+/// Visual severity of a toast notification. Drives the icon and the
+/// color the renderer applies — semantic, not free-form, so a
+/// production-mode bug ("status was overwritten before the user could
+/// read it") shows up consistently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToastKind {
+    Success,
+    Info,
+    Warning,
+    Error,
+}
+
+/// One stacked notification rendered in the bottom-right corner.
+///
+/// Toasts are *additive*: pushing a new one doesn't clobber the
+/// previous one's text the way `status` does. The renderer stacks
+/// them above the footer until each one's `until` instant has
+/// passed, then the event loop sweeps the expired ones out.
+#[derive(Debug, Clone)]
+pub(crate) struct Toast {
+    pub(crate) message: String,
+    pub(crate) kind: ToastKind,
+    pub(crate) until: std::time::Instant,
+}
+
+/// Which section of the sidebar the user is browsing when focus is on
+/// the sidebar. The three sections are stacked vertically; Tab cycles
+/// forward, Shift-Tab backward.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SidebarSection {
+    Calendar,
+    Pinned,
+    Recent,
+}
+
 /// Where the cursor lives — inside the current page's outline (default)
 /// or inside the inline backlinks section below it.
 ///
@@ -292,6 +327,16 @@ pub(crate) struct App {
 
     pub(crate) mode: Mode,
     pub(crate) show_help: bool,
+    /// Selected help tab when `show_help` is true. `h/l` cycle
+    /// horizontally between sections (Normal / Insert / Visual /
+    /// Overlays / Dates) — splits the wall-of-text help into
+    /// glance-able panes.
+    pub(crate) help_tab: usize,
+    /// Vertical scroll offset inside the active help tab. `j/k` and
+    /// `↓/↑/PgUp/PgDn/g/G` drive this while the popup is open.
+    /// Resets to 0 whenever the user switches tabs so the new tab's
+    /// content starts from the top, not at a stale offset.
+    pub(crate) help_scroll: u16,
     pub(crate) pending_chord: Option<char>,
     pub(crate) status: String,
 
@@ -332,6 +377,35 @@ pub(crate) struct App {
     /// Toggled with `B`. Default `true` so users discover the feature.
     pub(crate) show_backlinks: bool,
 
+    /// Whether the left sidebar (mini-calendar + pinned + recent) is
+    /// visible. Default `false` so first-time users land on the
+    /// classic single-pane layout — the toggle (`\`) opt-ins those who
+    /// want it. Persisted across the session in memory only.
+    pub(crate) show_sidebar: bool,
+
+    /// Sidebar focus state. Tracks which section the user is browsing
+    /// when the sidebar has focus (vs. the outline). `None` means the
+    /// outline owns the keyboard; `Some(_)` means the next `j/k/Enter`
+    /// goes to the sidebar list.
+    pub(crate) sidebar_focus: Option<SidebarSection>,
+
+    /// Sidebar cursor inside the currently focused section (0-based).
+    /// Only meaningful when `sidebar_focus.is_some()`.
+    pub(crate) sidebar_cursor: usize,
+
+    /// LRU of recently-opened paths. Newest first; bounded to a small
+    /// window so the sidebar's `Recent` section stays scannable.
+    /// In-memory only for now — persisting to `.outl/state.toml` is on
+    /// the roadmap (Fase 2 stretch).
+    pub(crate) recent_paths: Vec<PathBuf>,
+
+    /// Stack of transient notifications shown in the bottom-right
+    /// corner. Each one carries its own expiry; the event loop sweeps
+    /// the expired ones out so they don't accumulate. Independent
+    /// from `status`, which still drives the single-line footer
+    /// message (e.g. chord prompts).
+    pub(crate) toasts: Vec<Toast>,
+
     /// Where the cursor lives — outline (default) or inside the inline
     /// backlinks section. Reset to `Focus::Outline` whenever the view
     /// changes (page open, journal navigation, etc).
@@ -351,6 +425,12 @@ pub(crate) struct App {
     /// and `save`; consulted by the polling loop so external edits
     /// (e.g. `nvim` saving the same `.md`) are picked up automatically.
     pub(crate) last_mtime: Option<SystemTime>,
+
+    /// Wall-clock instant of the last successful save (or initial
+    /// load). The header renders `⟳ {N}s ago` against this so the user
+    /// has a glanceable freshness indicator. `None` means "never saved
+    /// in this session" — the header chip is hidden in that case.
+    pub(crate) last_saved_at: Option<Instant>,
 
     /// Snapshots of the page AST taken before each structural mutation.
     /// `u` pops back one step; `Ctrl+R` re-pushes. Bounded — see

--- a/crates/outl-tui/src/view.rs
+++ b/crates/outl-tui/src/view.rs
@@ -14,22 +14,28 @@
 //! `pub(crate)` for cross-file reuse inside `view/`.
 
 mod backlinks;
+mod chrome;
 mod inline;
 mod outline;
 mod overlays;
+mod sidebar;
+mod toasts;
 
-use crate::state::{
-    App, Focus, Mode, Overlay, View, HELP_HINT_INSERT, HELP_HINT_NORMAL, HELP_HINT_VISUAL,
-};
+use crate::state::{App, Focus, Overlay, View};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
-use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::widgets::{
+    Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
+};
 
 // Inline-rendering helpers used by tests in `app.rs` — keep them
 // reachable via `crate::view::…` for backwards compat with the
 // pre-split layout.
 #[cfg(test)]
 pub(crate) use inline::{highlight_inline, render_markdown_inline, split_todo_prefix};
+
+// Re-export the help-tabs constant so `input` can compute the tab
+// count without needing the whole `overlays` module visible.
+pub(crate) use overlays::HELP_TABS;
 
 pub(crate) fn render_app(f: &mut ratatui::Frame<'_>, app: &mut App) {
     let area = f.area();
@@ -52,6 +58,11 @@ pub(crate) fn render_app(f: &mut ratatui::Frame<'_>, app: &mut App) {
     if app.show_help {
         overlays::render_help_popup(f, area, app);
     }
+
+    // Toasts render last so they sit visually on top of every other
+    // surface (even open overlays). They're harmless decoration —
+    // never block input, never own focus.
+    toasts::render_toasts(f, area, app);
 }
 
 fn render_main(f: &mut ratatui::Frame<'_>, area: Rect, app: &mut App) {
@@ -64,39 +75,31 @@ fn render_main(f: &mut ratatui::Frame<'_>, area: Rect, app: &mut App) {
         ])
         .split(area);
 
-    // Header: page title on the left, workspace/index info on the right.
-    let workspace_label = app
-        .workspace_root
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("workspace")
-        .to_string();
-    let stats = format!(
-        "  ws:{workspace_label}  pages:{}  blocks:{}",
-        app.index.page_count(),
-        app.flat_len
-    );
-    let header = Paragraph::new(Line::from(vec![
-        Span::styled(app.current_title(), app.theme.heading),
-        Span::styled(stats, app.theme.dim),
-    ]))
-    .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_style(app.theme.border)
-            .title(Span::styled(
-                format!(" outl · {} ", app.theme.name),
-                app.theme.hint,
-            )),
-    );
-    f.render_widget(header, outer[0]);
+    chrome::render_header(f, outer[0], app);
+
+    // Optional left sidebar: splits the middle row horizontally when
+    // toggled on (`\` in Normal mode). Default off keeps the classic
+    // single-pane layout intact for users who never opt in.
+    let body_area = if app.show_sidebar {
+        let cols = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Length(sidebar::SIDEBAR_WIDTH),
+                Constraint::Min(20),
+            ])
+            .split(outer[1]);
+        sidebar::render_sidebar(f, cols[0], app);
+        cols[1]
+    } else {
+        outer[1]
+    };
 
     // Build the single scrollable region: outline lines, then the
     // inline backlinks section. The `─` separator and headers live
     // inside `backlinks::render_backlinks_inline`.
     let (mut all_lines, sel_outline) = outline::render_outline(&app.page, app);
     let outline_len = all_lines.len();
-    let inner_width = outer[1].width.saturating_sub(2);
+    let inner_width = body_area.width.saturating_sub(2);
     let (bl_lines, sel_bl) = backlinks::render_backlinks_inline(app, inner_width);
     let bl_offset = all_lines.len();
     all_lines.extend(bl_lines);
@@ -112,10 +115,10 @@ fn render_main(f: &mut ratatui::Frame<'_>, area: Rect, app: &mut App) {
     };
     let _ = outline_len; // kept for future scroll heuristics
 
-    // Viewport math: outer[1] is the outline area (borders included).
+    // Viewport math: body_area is the outline area (borders included).
     // Subtract 2 for top + bottom border lines to get the actually
     // drawable region.
-    let viewport_h = outer[1].height.saturating_sub(2);
+    let viewport_h = body_area.height.saturating_sub(2);
     app.viewport_height = viewport_h;
 
     // Auto-scroll: keep the selection visible. If it scrolled off the
@@ -140,21 +143,12 @@ fn render_main(f: &mut ratatui::Frame<'_>, area: Rect, app: &mut App) {
         app.scroll_y = 0;
     }
 
-    let scroll_indicator = if total > viewport_h && viewport_h > 0 {
-        format!(
-            " ({}/{})",
-            app.scroll_y + 1,
-            total.saturating_sub(viewport_h) + 1
-        )
-    } else {
-        String::new()
-    };
     let body = Paragraph::new(all_lines)
         .block(
             Block::default()
                 .borders(Borders::ALL)
                 .border_style(app.theme.border)
-                .title(format!("{title}{scroll_indicator}")),
+                .title(title.to_string()),
         )
         .scroll((app.scroll_y, 0));
     // NB: no `.wrap(...)`. Wrap turns one logical line into N visual
@@ -162,40 +156,25 @@ fn render_main(f: &mut ratatui::Frame<'_>, area: Rect, app: &mut App) {
     // `selected_line` index. We trade off-screen long lines (rare,
     // and you can horizontal-scroll later) for a correct vertical
     // scroll today.
-    f.render_widget(body, outer[1]);
+    f.render_widget(body, body_area);
 
-    let (mode_label, mode_style) = match app.mode {
-        Mode::Normal => (" NORMAL ", app.theme.status_normal),
-        Mode::Insert { .. } => (" INSERT ", app.theme.status_insert),
-        Mode::Visual { .. } => (" VISUAL ", app.theme.status_visual),
-    };
-    let hint = match app.mode {
-        Mode::Insert { .. } => HELP_HINT_INSERT,
-        Mode::Visual { .. } => HELP_HINT_VISUAL,
-        Mode::Normal => HELP_HINT_NORMAL,
-    };
-    // Backlink count for this view (when it matters).
-    let bl_count = app.index.backlinks(&app.current_slug()).len();
-    let bl_label = if bl_count == 0 {
-        String::new()
-    } else {
-        format!(
-            "  ⇇ {bl_count} backlink{}",
-            if bl_count == 1 { "" } else { "s" }
-        )
-    };
-    let footer = Paragraph::new(Line::from(vec![
-        Span::styled(mode_label, mode_style),
-        Span::raw("  "),
-        Span::styled(hint, app.theme.hint),
-        Span::styled(bl_label, app.theme.dim),
-        Span::raw("  "),
-        Span::styled(&app.status, app.theme.status_message),
-    ]))
-    .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_style(app.theme.border),
-    );
-    f.render_widget(footer, outer[2]);
+    // Vertical scrollbar on the right border. Only meaningful when the
+    // body actually overflows the viewport; the widget renders nothing
+    // when `content_length <= viewport_height`, but we skip the call
+    // entirely to keep the body title pristine on short pages.
+    if total > viewport_h && viewport_h > 0 {
+        let mut sb_state = ScrollbarState::new(total as usize)
+            .viewport_content_length(viewport_h as usize)
+            .position(app.scroll_y as usize);
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(Some("▲"))
+            .end_symbol(Some("▼"))
+            .track_symbol(Some("│"))
+            .thumb_symbol("█")
+            .style(app.theme.dim)
+            .thumb_style(app.theme.heading);
+        f.render_stateful_widget(scrollbar, body_area, &mut sb_state);
+    }
+
+    chrome::render_footer(f, outer[2], app);
 }

--- a/crates/outl-tui/src/view/chrome.rs
+++ b/crates/outl-tui/src/view/chrome.rs
@@ -1,0 +1,313 @@
+//! Top header + bottom footer — the "chrome" around the main outline.
+//!
+//! Split out from `view.rs` so the orchestrator stays small and the
+//! semantics of each segment (breadcrumb, chips, powerline footer) get
+//! room to breathe without leaking into outline / overlay rendering.
+//!
+//! Two public entry points: [`render_header`] paints the top bar,
+//! [`render_footer`] paints the powerline at the bottom. Both consume
+//! the `Rect` the orchestrator already laid out — no layout decisions
+//! here.
+
+use crate::outline_ops::count_todos;
+use crate::state::{App, Mode, View, HELP_HINT_INSERT, HELP_HINT_NORMAL, HELP_HINT_VISUAL};
+use chrono::Local;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+/// Header (top, 3 lines): breadcrumb on the left, status chips on the
+/// right. Splits the row in half so chips never overlap the title even
+/// when one side is long.
+pub(crate) fn render_header(f: &mut ratatui::Frame<'_>, area: Rect, app: &App) {
+    // Frame block first — chips and breadcrumb both draw *inside* the
+    // bordered area, so we render the outer block as a single widget
+    // and then split the inner Rect for content.
+    let frame = Block::default()
+        .borders(Borders::ALL)
+        .border_style(app.theme.border)
+        .title(Span::styled(
+            format!(" outl · {} ", app.theme.name),
+            app.theme.hint,
+        ));
+    let inner = frame.inner(area);
+    f.render_widget(frame, area);
+
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Min(20), Constraint::Length(chips_width(app))])
+        .split(inner);
+
+    f.render_widget(Paragraph::new(breadcrumb(app)), cols[0]);
+    f.render_widget(
+        Paragraph::new(chips(app)).alignment(ratatui::layout::Alignment::Right),
+        cols[1],
+    );
+}
+
+/// Footer (bottom, 3 lines): powerline-style segmented status bar.
+/// Each segment carries its own bg/fg so the user can scan the bar
+/// for mode + workspace + clock + save state at a glance.
+pub(crate) fn render_footer(f: &mut ratatui::Frame<'_>, area: Rect, app: &App) {
+    let frame = Block::default()
+        .borders(Borders::ALL)
+        .border_style(app.theme.border);
+    let inner = frame.inner(area);
+    f.render_widget(frame, area);
+
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Min(20),
+            Constraint::Length(right_segments_width(app)),
+        ])
+        .split(inner);
+
+    f.render_widget(Paragraph::new(left_segments(app)), cols[0]);
+    f.render_widget(
+        Paragraph::new(right_segments(app)).alignment(ratatui::layout::Alignment::Right),
+        cols[1],
+    );
+}
+
+// ─── header ───────────────────────────────────────────────────────────
+
+fn breadcrumb(app: &App) -> Line<'static> {
+    let workspace_label = app
+        .workspace_root
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("workspace")
+        .to_string();
+
+    let (icon, title) = view_icon_and_title(app);
+    let sep = Span::styled(" ▸ ", app.theme.dim);
+
+    let mut spans: Vec<Span<'static>> = vec![
+        Span::styled(" outl", app.theme.heading.add_modifier(Modifier::BOLD)),
+        sep.clone(),
+        Span::styled(workspace_label, app.theme.hint),
+        sep,
+    ];
+    if let Some(ic) = icon {
+        spans.push(Span::raw(format!("{ic} ")));
+    }
+    spans.push(Span::styled(title, app.theme.heading));
+    Line::from(spans)
+}
+
+/// Pick the icon + title for the current view. Falls back to the slug
+/// when the workspace index hasn't indexed the page yet (race on cold
+/// start).
+fn view_icon_and_title(app: &App) -> (Option<String>, String) {
+    match &app.view {
+        View::Journal(date) => (
+            Some("📅".to_string()),
+            format!("Journal · {}", date.format("%A, %Y-%m-%d")),
+        ),
+        View::Page(p) => {
+            let stem = p.file_stem().and_then(|s| s.to_str()).unwrap_or("?");
+            let entry = app.index.by_slug(stem);
+            let title = entry
+                .map(|e| e.title.clone())
+                .unwrap_or_else(|| stem.to_string());
+            let icon = entry.and_then(|e| e.icon.clone());
+            (icon, title)
+        }
+    }
+}
+
+/// Right-aligned status chips: index throbber · TODOs · unsaved · freshness.
+///
+/// Each chip is a `Span` with its own bg. Order matters — most
+/// important first (rightmost in raw token order, since we then
+/// right-align the whole line).
+fn chips(app: &App) -> Line<'static> {
+    let mut spans: Vec<Span<'static>> = Vec::new();
+
+    // Background index rebuild indicator. Animates against a 100 ms
+    // tick derived from the system clock so the spinner moves even
+    // when no key is pressed — the event loop redraws on the same
+    // poll cadence.
+    if app.has_pending_index() {
+        let frame = throbber_frame();
+        spans.push(Span::styled(
+            format!(" {frame} indexing "),
+            Style::default()
+                .bg(Color::DarkGray)
+                .fg(Color::LightCyan)
+                .add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::raw(" "));
+    }
+
+    let (done, total) = count_todos(&app.page.blocks);
+    if total > 0 {
+        let chip_style = if done == total {
+            Style::default()
+                .bg(Color::DarkGray)
+                .fg(Color::LightGreen)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+                .bg(Color::DarkGray)
+                .fg(Color::LightYellow)
+                .add_modifier(Modifier::BOLD)
+        };
+        spans.push(Span::styled(format!(" ☑ {done}/{total} "), chip_style));
+        spans.push(Span::raw(" "));
+    }
+
+    if matches!(app.mode, Mode::Insert { .. }) {
+        spans.push(Span::styled(
+            " ● editing ",
+            Style::default()
+                .bg(Color::DarkGray)
+                .fg(Color::LightMagenta)
+                .add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::raw(" "));
+    }
+
+    if let Some(at) = app.last_saved_at {
+        let secs = at.elapsed().as_secs();
+        let label = format_age(secs);
+        spans.push(Span::styled(
+            format!(" ⟳ {label} "),
+            Style::default().bg(Color::DarkGray).fg(Color::Gray),
+        ));
+        spans.push(Span::raw(" "));
+    }
+
+    Line::from(spans)
+}
+
+/// Tight upper bound on the chips line width so the layout split
+/// doesn't truncate it. We over-estimate by 4 chars to keep the
+/// breadcrumb side from squeezing on a wide chip set.
+fn chips_width(app: &App) -> u16 {
+    let mut w: u16 = 0;
+    if app.has_pending_index() {
+        w += 13;
+    }
+    let (_, total) = count_todos(&app.page.blocks);
+    if total > 0 {
+        w += 14;
+    }
+    if matches!(app.mode, Mode::Insert { .. }) {
+        w += 12;
+    }
+    if app.last_saved_at.is_some() {
+        w += 14;
+    }
+    w.min(70)
+}
+
+/// Pick a Braille spinner frame from the system clock. 10 frames at
+/// 100 ms each = one full rotation per second. Works without holding
+/// any tick counter in `App` — the render path is called frequently
+/// enough (every poll + every keypress) that the user sees motion.
+fn throbber_frame() -> char {
+    const FRAMES: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+    let millis = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    FRAMES[((millis / 100) as usize) % FRAMES.len()]
+}
+
+fn format_age(secs: u64) -> String {
+    match secs {
+        0..=2 => "just now".to_string(),
+        s @ 3..=59 => format!("{s}s ago"),
+        s @ 60..=3599 => format!("{}m ago", s / 60),
+        s => format!("{}h ago", s / 3600),
+    }
+}
+
+// ─── footer ───────────────────────────────────────────────────────────
+
+fn left_segments(app: &App) -> Line<'static> {
+    let (mode_label, mode_style) = match app.mode {
+        Mode::Normal => (" NORMAL ", app.theme.status_normal),
+        Mode::Insert { .. } => (" INSERT ", app.theme.status_insert),
+        Mode::Visual { .. } => (" VISUAL ", app.theme.status_visual),
+    };
+
+    let workspace_label = app
+        .workspace_root
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("workspace")
+        .to_string();
+
+    let mut spans: Vec<Span<'static>> = vec![
+        Span::styled(mode_label, mode_style.add_modifier(Modifier::BOLD)),
+        // Powerline-style "arrow" between segments: a solid char on
+        // the previous bg followed by spaces on the next. Works on
+        // any terminal without nerd-font.
+        Span::styled(" ", Style::default().bg(Color::DarkGray)),
+        Span::styled(
+            format!(" ◌ {workspace_label} "),
+            Style::default().bg(Color::DarkGray).fg(Color::Gray),
+        ),
+        Span::raw(" "),
+    ];
+
+    // Backlink count — kept in the footer (was already here pre-refactor).
+    let bl_count = app.index.backlinks(&app.current_slug()).len();
+    if bl_count > 0 {
+        spans.push(Span::styled(
+            format!(
+                " ⇇ {bl_count} backlink{} ",
+                if bl_count == 1 { "" } else { "s" }
+            ),
+            Style::default().bg(Color::DarkGray).fg(Color::LightCyan),
+        ));
+        spans.push(Span::raw(" "));
+    }
+
+    let hint = match app.mode {
+        Mode::Insert { .. } => HELP_HINT_INSERT,
+        Mode::Visual { .. } => HELP_HINT_VISUAL,
+        Mode::Normal => HELP_HINT_NORMAL,
+    };
+    spans.push(Span::styled(hint, app.theme.hint));
+
+    // Transient status message ("saved", "reconcile failed: …"). When
+    // empty, no extra padding.
+    if !app.status.is_empty() {
+        spans.push(Span::raw("  "));
+        spans.push(Span::styled(app.status.clone(), app.theme.status_message));
+    }
+
+    Line::from(spans)
+}
+
+fn right_segments(app: &App) -> Line<'static> {
+    let now = Local::now().format("%H:%M").to_string();
+    let saved = match app.last_saved_at {
+        Some(_) if app.status.is_empty() => " 💾 saved ",
+        Some(_) => " 💾 ",
+        None => " ○ ",
+    };
+    Line::from(vec![
+        Span::styled(
+            format!(" 🕐 {now} "),
+            Style::default().bg(Color::DarkGray).fg(Color::Gray),
+        ),
+        Span::raw(" "),
+        Span::styled(
+            saved,
+            Style::default().bg(Color::DarkGray).fg(Color::LightGreen),
+        ),
+        Span::raw(" "),
+        Span::styled(" ? help ", app.theme.hint),
+    ])
+}
+
+fn right_segments_width(_app: &App) -> u16 {
+    // 🕐 HH:MM (10) + saved (10) + help (8) + padding ≈ 32
+    34
+}

--- a/crates/outl-tui/src/view/overlays.rs
+++ b/crates/outl-tui/src/view/overlays.rs
@@ -12,7 +12,7 @@ use crate::state::{
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Tabs};
 
 pub(crate) fn render_autocomplete(
     f: &mut ratatui::Frame<'_>,
@@ -108,7 +108,9 @@ pub(crate) fn render_quick_switch(
     app: &App,
     qs: &QuickSwitchState,
 ) {
-    let area = centered_rect(full, 60, 60);
+    // Wider overlay (80%) so the preview pane has room to show real
+    // outline context, not 5-char truncations.
+    let area = centered_rect(full, 80, 70);
     f.render_widget(Clear, area);
 
     let outer = Layout::default()
@@ -129,6 +131,15 @@ pub(crate) fn render_quick_switch(
     )
     .style(Style::default().bg(app.theme.popup_bg));
     f.render_widget(input, outer[0]);
+
+    // Telescope-style split: list on the left, preview on the right.
+    // The preview re-reads the highlighted page from disk per frame —
+    // cheap for a single page, and avoids leaking a page cache into
+    // App state for a feature that's open for ~5 seconds at a time.
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+        .split(outer[1]);
 
     let items: Vec<ListItem<'_>> = qs
         .candidates
@@ -155,13 +166,101 @@ pub(crate) fn render_quick_switch(
             Block::default()
                 .borders(Borders::ALL)
                 .border_style(app.theme.border)
-                .title(format!(
-                    "{} matches  ↑↓ navigate · Enter open · Esc cancel",
-                    qs.candidates.len()
-                )),
+                .title(format!("{} matches  ↑↓ Enter Esc", qs.candidates.len())),
         )
         .style(Style::default().bg(app.theme.popup_bg));
-    f.render_widget(list, outer[1]);
+    f.render_widget(list, cols[0]);
+
+    render_preview_pane(f, cols[1], app, qs);
+}
+
+/// Right-hand preview pane for the quick switcher. Shows the first
+/// ~N blocks of the highlighted candidate, or a placeholder when the
+/// candidate isn't indexed yet (cold-start race) / has no body.
+fn render_preview_pane(f: &mut ratatui::Frame<'_>, area: Rect, app: &App, qs: &QuickSwitchState) {
+    let Some(candidate) = qs.candidates.get(qs.selected) else {
+        let empty = Paragraph::new(Line::from(Span::styled(
+            "  (type to search)",
+            app.theme.dim,
+        )))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(app.theme.border)
+                .title(Span::styled(" preview ", app.theme.help_title)),
+        )
+        .style(Style::default().bg(app.theme.popup_bg));
+        f.render_widget(empty, area);
+        return;
+    };
+
+    let path = app.index.by_slug(&candidate.key).map(|e| e.path.clone());
+    let body_lines: Vec<Line<'static>> = match path.as_deref() {
+        Some(p) => match std::fs::read_to_string(p) {
+            Ok(text) => preview_lines(&text, area.height.saturating_sub(2) as usize, app),
+            Err(_) => vec![Line::from(Span::styled(
+                "  (couldn't read file)",
+                app.theme.dim,
+            ))],
+        },
+        None => vec![Line::from(Span::styled(
+            "  (not yet indexed)",
+            app.theme.dim,
+        ))],
+    };
+
+    let title_prefix = match candidate.kind {
+        SwitchKind::Page => "📄 ",
+        SwitchKind::Journal => "📅 ",
+    };
+    let preview = Paragraph::new(body_lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(app.theme.border)
+                .title(Span::styled(
+                    format!(" {title_prefix}{} ", candidate.label),
+                    app.theme.help_title,
+                )),
+        )
+        .style(Style::default().bg(app.theme.popup_bg))
+        .wrap(ratatui::widgets::Wrap { trim: false });
+    f.render_widget(preview, area);
+}
+
+/// Cheap markdown → preview lines. Doesn't reuse the outline renderer
+/// (we don't want cursors, TODO checkboxes, etc.) — just enough to
+/// give the user a sense of what they're about to open.
+fn preview_lines(text: &str, max: usize, app: &App) -> Vec<Line<'static>> {
+    let mut out: Vec<Line<'static>> = Vec::new();
+    for line in text.lines() {
+        if out.len() >= max {
+            break;
+        }
+        let trimmed_start = line.trim_start();
+        if trimmed_start.is_empty() {
+            out.push(Line::raw(""));
+            continue;
+        }
+        if let Some(rest) = trimmed_start.strip_prefix("- ") {
+            let indent_chars = line.len() - trimmed_start.len();
+            let indent = " ".repeat(indent_chars);
+            out.push(Line::from(vec![
+                Span::raw(indent),
+                Span::styled("• ", app.theme.bullet),
+                Span::raw(rest.to_string()),
+            ]));
+        } else if trimmed_start.contains("::") {
+            // property line — show dimmer to de-emphasize.
+            out.push(Line::from(Span::styled(line.to_string(), app.theme.dim)));
+        } else {
+            out.push(Line::raw(line.to_string()));
+        }
+    }
+    if out.is_empty() {
+        out.push(Line::from(Span::styled("  (empty page)", app.theme.dim)));
+    }
+    out
 }
 
 pub(crate) fn render_search_overlay(
@@ -234,7 +333,7 @@ pub(crate) fn render_slash_overlay(
     app: &App,
     s: &SlashState,
 ) {
-    let area = centered_rect(full, 60, 60);
+    let area = centered_rect(full, 65, 65);
     f.render_widget(Clear, area);
 
     let outer = Layout::default()
@@ -251,43 +350,132 @@ pub(crate) fn render_slash_overlay(
         Block::default()
             .borders(Borders::ALL)
             .border_style(app.theme.border)
-            .title(Span::styled("Commands", app.theme.help_title)),
+            .title(Span::styled(" Command palette ", app.theme.help_title)),
     )
     .style(Style::default().bg(app.theme.popup_bg));
     f.render_widget(input, outer[0]);
 
-    let items: Vec<ListItem<'_>> = s
-        .candidates
-        .iter()
-        .enumerate()
-        .map(|(i, c)| {
-            let style = if i == s.selected {
+    // Group candidates by category, then render section headers
+    // inline. We need the original index (into `s.candidates`) to
+    // keep the highlight in sync with the selection, so we walk the
+    // list once and stash `(original_index, command, category)`
+    // tuples bucketed by category.
+    let mut buckets: Vec<(&str, Vec<(usize, &crate::state::SlashCommand)>)> = Vec::new();
+    for (i, c) in s.candidates.iter().enumerate() {
+        let cat = category_for(c.name);
+        // Insert preserving the canonical category order rather than
+        // first-seen, so the palette layout is stable as the user
+        // types and the candidate set shifts.
+        if let Some(b) = buckets.iter_mut().find(|(k, _)| *k == cat) {
+            b.1.push((i, c));
+        } else {
+            buckets.push((cat, vec![(i, c)]));
+        }
+    }
+    buckets.sort_by_key(|(k, _)| category_order(k));
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    for (cat, items) in &buckets {
+        lines.push(Line::from(Span::styled(
+            format!(" {} {} ", category_icon(cat), cat),
+            app.theme.help_title,
+        )));
+        for (orig_idx, c) in items {
+            let style = if *orig_idx == s.selected {
                 app.theme.list_selected
             } else {
                 Style::default()
             };
-            // Two-column-ish: name on the left, description dimmed
-            // on the right. The `…` glyph hints at "this one asks
-            // for args next".
             let suffix = if c.needs_args { " …" } else { "" };
-            ListItem::new(Line::from(vec![
-                Span::styled(format!(" {}{suffix}  ", c.name), style),
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("   {}  {}{suffix}  ", command_icon(c.name), c.name),
+                    style,
+                ),
                 Span::styled(c.description.to_string(), app.theme.dim),
-            ]))
-        })
-        .collect();
-    let list = List::new(items)
+            ]));
+        }
+        lines.push(Line::raw(""));
+    }
+
+    let list = Paragraph::new(lines)
         .block(
             Block::default()
                 .borders(Borders::ALL)
                 .border_style(app.theme.border)
-                .title(format!(
-                    "{} commands  ↑↓ navigate · Enter run · Esc cancel",
-                    s.candidates.len()
-                )),
+                .title(format!(" {} commands · ↑↓ Enter Esc ", s.candidates.len())),
         )
         .style(Style::default().bg(app.theme.popup_bg));
     f.render_widget(list, outer[1]);
+}
+
+/// Bucket a command name into a coarse category. Names follow loose
+/// prefix conventions (`date-*`, `time-*`, `iso-*`, `week-*`, …) so
+/// we can group without each command having to declare its category.
+fn category_for(name: &str) -> &'static str {
+    let n = name;
+    if n.starts_with("date")
+        || n.starts_with("time")
+        || n.starts_with("iso")
+        || n.starts_with("week")
+        || n == "stamp"
+        || n == "dt"
+        || n == "dtm"
+        || n == "dy"
+    {
+        "Dates & time"
+    } else if n == "search" || n == "find" {
+        "Search"
+    } else if n == "theme" || n == "set" || n == "config" {
+        "Settings"
+    } else if n == "open" || n == "switch" || n == "quit" || n == "q" {
+        "Navigation"
+    } else {
+        "Actions"
+    }
+}
+
+/// Canonical sort order — Actions first (most common), Dates last
+/// (long list, scrolls off).
+fn category_order(cat: &str) -> u8 {
+    match cat {
+        "Actions" => 0,
+        "Navigation" => 1,
+        "Search" => 2,
+        "Settings" => 3,
+        "Dates & time" => 4,
+        _ => 5,
+    }
+}
+
+fn category_icon(cat: &str) -> &'static str {
+    match cat {
+        "Actions" => "⚡",
+        "Navigation" => "↪",
+        "Search" => "🔎",
+        "Settings" => "⚙",
+        "Dates & time" => "📅",
+        _ => "•",
+    }
+}
+
+/// Per-command leading glyph. Falls back to a dot for anything we
+/// haven't curated.
+fn command_icon(name: &str) -> &'static str {
+    match name {
+        "run" => "▶",
+        "prop" => "≡",
+        "search" | "find" => "🔎",
+        "theme" => "🎨",
+        "open" | "switch" => "↪",
+        "quit" | "q" => "✕",
+        n if n.starts_with("date") || n == "dt" || n == "dy" || n == "dtm" => "📅",
+        n if n.starts_with("time") => "🕐",
+        n if n.starts_with("iso") => "🔢",
+        n if n.starts_with("week") => "📆",
+        "stamp" => "🕒",
+        _ => "·",
+    }
 }
 
 pub(crate) fn render_error_overlay(
@@ -359,9 +547,15 @@ pub(crate) fn render_command_bar(
     f.render_widget(bar, area);
 }
 
+/// Tab titles for the help popup, in the order they appear. The
+/// `App.help_tab` index points into this slice (saturating, so an
+/// out-of-range value clamps to the last tab).
+pub(crate) const HELP_TABS: &[&str] =
+    &["Normal", "Insert", "Visual", "Sidebar", "Overlays", "Dates"];
+
 pub(crate) fn render_help_popup(f: &mut ratatui::Frame<'_>, full: Rect, app: &App) {
     let popup_w = (full.width as f32 * 0.7) as u16;
-    let popup_h = 34u16.min(full.height.saturating_sub(2));
+    let popup_h = 28u16.min(full.height.saturating_sub(2));
     let x = (full.width.saturating_sub(popup_w)) / 2;
     let y = (full.height.saturating_sub(popup_h)) / 2;
     let area = Rect {
@@ -370,75 +564,194 @@ pub(crate) fn render_help_popup(f: &mut ratatui::Frame<'_>, full: Rect, app: &Ap
         width: popup_w,
         height: popup_h,
     };
-    let body = vec![
-        Line::from(Span::styled("NORMAL mode", app.theme.help_title)),
-        Line::from("  i           edit current block"),
-        Line::from("  I           edit, cursor at start of block"),
-        Line::from("  o / O       new block below / above"),
-        Line::from("  Enter       open [[ref]] / #tag / journal under cursor"),
-        Line::from("              (falls back to edit if nothing matches)"),
-        Line::from("  j / k / ↑ ↓ move between blocks"),
-        Line::from("  PgDn/PgUp   move one viewport down/up"),
-        Line::from("  Ctrl+D / U  half-page down/up"),
-        Line::from("  g g / G     first / last block"),
-        Line::from("  h / l / ← → move cursor inside the current block"),
-        Line::from("  w / b       cursor to next / previous word"),
-        Line::from("  0 / $       cursor to start / end of block"),
-        Line::from("  Tab / S-Tab indent / outdent"),
-        Line::from("  K / J       move block up / down (Alt+↑/↓ too)"),
-        Line::from("  dd          delete block"),
-        Line::from("  yy / p / P  yank · paste after · paste before"),
-        Line::from("  Ctrl+T      cycle TODO / DONE / none (Ctrl+Enter on kitty-proto terminals)"),
-        Line::from("  u           undo"),
-        Line::from("  Ctrl+R      redo"),
-        Line::from("  Ctrl+S      force save"),
-        Line::from("  Ctrl+L      refresh workspace (re-read from disk)"),
-        Line::from("  t           today's journal"),
-        Line::from("  [ / ]       previous / next journal"),
-        Line::from("  g j         jump to today"),
-        Line::from("  g x         run code block under cursor (also `:run`)"),
-        Line::from("  B           toggle inline backlinks section"),
-        Line::from("  ?           toggle this help"),
-        Line::from("  q q         quit (chord — single `q` arms it)"),
-        Line::from(""),
-        Line::from(Span::styled("Overlays", app.theme.help_title)),
-        Line::from("  Ctrl+P      quick switcher (pages + journals)"),
-        Line::from("  /           slash commands (prop, search, run, ...)"),
-        Line::from("  n / N       next / previous search hit"),
-        Line::from("  :           vim-style palette (same registry as /)"),
-        Line::from(""),
-        Line::from(Span::styled("INSERT mode", app.theme.help_title)),
-        Line::from("  Esc         commit"),
-        Line::from("  Enter       commit + new block below"),
-        Line::from("  Ctrl+T      cycle TODO / DONE / none (stays in Insert; Ctrl+Enter on kitty-proto terminals)"),
-        Line::from("  Tab / S-Tab indent / outdent (stays in Insert)"),
-        Line::from("  [[ / #      autocomplete from existing page titles"),
-        Line::from(""),
-        Line::from(Span::styled(
-            "Date inserters (Insert mode, via /)",
-            app.theme.help_title,
-        )),
-        Line::from("  /date-today       [[YYYY-MM-DD]]  (also /dt, /dtm, /dy)"),
-        Line::from("  /date-next-monday next Monday's journal ref (and one per weekday)"),
-        Line::from("  /date +3d         offset or absolute: +Nd, -Nw, +Nm, YYYY-MM-DD"),
-        Line::from("  /time-now         HH:MM, plain (no brackets)"),
-        Line::from("  /datetime-now     [[YYYY-MM-DD]] HH:MM  (alias /stamp)"),
-        Line::from("  /iso-date-today   YYYY-MM-DD, no brackets (for `due::` etc)"),
-        Line::from("  /week-num         #YYYY-Www  (ISO week as a tag)"),
-        Line::from(""),
-        Line::from(Span::styled(
-            format!("theme: {}", app.theme.name),
-            app.theme.dim,
-        )),
-    ];
+    f.render_widget(Clear, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(3)])
+        .split(area);
+
+    let tab = app.help_tab.min(HELP_TABS.len() - 1);
+    let tabs = Tabs::new(
+        HELP_TABS
+            .iter()
+            .map(|t| Line::from(format!(" {t} ")))
+            .collect::<Vec<_>>(),
+    )
+    .select(tab)
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(app.theme.border)
+            .title(Span::styled(
+                " Help · h/l tabs · j/k scroll · PgUp/PgDn page · g/G top/end · ? close ",
+                app.theme.help_title,
+            )),
+    )
+    .style(
+        Style::default().bg(app.theme.popup_bg).fg(app
+            .theme
+            .dim
+            .fg
+            .unwrap_or(ratatui::style::Color::Gray)),
+    )
+    .highlight_style(app.theme.list_selected)
+    .divider(Span::styled("│", app.theme.dim));
+    f.render_widget(tabs, chunks[0]);
+
+    let body = help_tab_body(tab, app);
+    let body_len = body.len() as u16;
+    // Inner height = block area minus the 2 border rows.
+    let inner_h = chunks[1].height.saturating_sub(2);
+    // Clamp the requested scroll against the actual body so `G` /
+    // PgDn don't park the user past the end of the content.
+    let max_scroll = body_len.saturating_sub(inner_h);
+    let scroll = app.help_scroll.min(max_scroll);
+
+    // Title carries a scroll indicator when the content overflows —
+    // gives the user a visual cue that there's more below / above.
+    let title = if body_len > inner_h {
+        format!(" {} · ↕ {}/{} ", HELP_TABS[tab], scroll + 1, max_scroll + 1)
+    } else {
+        format!(" {} ", HELP_TABS[tab])
+    };
     let popup = Paragraph::new(body)
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_style(app.theme.border)
-                .title(Span::styled("Help", app.theme.help_title)),
+                // Highlight the border so it reads as "this owns focus"
+                // — the dim outline border behind would otherwise
+                // suggest the popup is informational.
+                .border_style(app.theme.heading)
+                .title(Span::styled(title, app.theme.help_title)),
         )
-        .style(Style::default().bg(app.theme.popup_bg));
-    f.render_widget(Clear, area);
-    f.render_widget(popup, area);
+        .style(Style::default().bg(app.theme.popup_bg))
+        .scroll((scroll, 0))
+        .wrap(ratatui::widgets::Wrap { trim: false });
+    f.render_widget(popup, chunks[1]);
+}
+
+fn help_tab_body(tab: usize, app: &App) -> Vec<Line<'static>> {
+    match HELP_TABS.get(tab).copied().unwrap_or("Normal") {
+        "Normal" => vec![
+            Line::from(Span::styled("Editing", app.theme.help_title)),
+            Line::from("  i           edit current block"),
+            Line::from("  I           edit, cursor at start of block"),
+            Line::from("  o / O       new block below / above"),
+            Line::from("  Tab / S-Tab indent / outdent"),
+            Line::from("  K / J       move block up / down (Alt+↑/↓ too)"),
+            Line::from("  dd          delete block"),
+            Line::from("  yy / p / P  yank · paste after · paste before"),
+            Line::from("  Ctrl+T      cycle TODO / DONE / none"),
+            Line::from("  u / Ctrl+R  undo / redo"),
+            Line::from("  g p         toggle pinned:: on this page (chord)"),
+            Line::from(""),
+            Line::from(Span::styled("Navigation", app.theme.help_title)),
+            Line::from("  j/k ↑↓      move between blocks"),
+            Line::from("  PgDn/PgUp   one viewport"),
+            Line::from("  Ctrl+D / U  half-page"),
+            Line::from("  g g / G     first / last block"),
+            Line::from("  h/l ←→      cursor inside the current block"),
+            Line::from("  w / b       next / previous word"),
+            Line::from("  0 / $       start / end of block"),
+            Line::from("  Enter       open [[ref]] / #tag / journal under cursor"),
+            Line::from(""),
+            Line::from(Span::styled("Journal & workspace", app.theme.help_title)),
+            Line::from("  t           today's journal"),
+            Line::from("  [ / ]       previous / next journal"),
+            Line::from("  g j         jump to today"),
+            Line::from("  g x         run code block under cursor (also `:run`)"),
+            Line::from("  Ctrl+S      force save"),
+            Line::from("  Ctrl+L      reload workspace from disk"),
+            Line::from("  B           toggle inline backlinks"),
+            Line::from("  \\           toggle left sidebar (opens with focus on Pinned)"),
+            Line::from("  q q         quit (chord)"),
+        ],
+        "Insert" => vec![
+            Line::from(Span::styled("Commit / cancel", app.theme.help_title)),
+            Line::from("  Esc         commit (write buffer → AST → disk)"),
+            Line::from("  Enter       commit + new block below"),
+            Line::from(""),
+            Line::from(Span::styled(
+                "Block ops (stay in Insert)",
+                app.theme.help_title,
+            )),
+            Line::from("  Tab / S-Tab indent / outdent"),
+            Line::from("  Ctrl+T      cycle TODO / DONE / none"),
+            Line::from(""),
+            Line::from(Span::styled("Text editing", app.theme.help_title)),
+            Line::from("  chars       insert at cursor"),
+            Line::from("  Backspace   delete previous (deletes block if empty)"),
+            Line::from("  arrows/home/end   move cursor"),
+            Line::from("  ( [ {       auto-pair with matching close"),
+            Line::from(""),
+            Line::from(Span::styled("Autocomplete", app.theme.help_title)),
+            Line::from("  [[          page-ref picker"),
+            Line::from("  #           tag picker"),
+            Line::from("  /           slash command picker"),
+        ],
+        "Visual" => vec![
+            Line::from(Span::styled("Selection", app.theme.help_title)),
+            Line::from("  V           enter Visual (Normal mode)"),
+            Line::from("  j / k       extend selection"),
+            Line::from("  Esc         cancel"),
+            Line::from(""),
+            Line::from(Span::styled("Batch ops on the range", app.theme.help_title)),
+            Line::from("  d / x       delete selected blocks"),
+            Line::from("  y           yank selected blocks"),
+            Line::from("  Tab / S-Tab indent / outdent the range"),
+        ],
+        "Sidebar" => vec![
+            Line::from(Span::styled("Open / close", app.theme.help_title)),
+            Line::from("  \\           toggle sidebar (opens with focus on Pinned)"),
+            Line::from("  Esc         return focus to the outline (sidebar stays open)"),
+            Line::from(""),
+            Line::from(Span::styled("Inside the sidebar", app.theme.help_title)),
+            Line::from("  j / k ↑↓    move between items in the focused section"),
+            Line::from("  g / G       first / last item"),
+            Line::from("  Tab / S-Tab cycle sections (Pinned → Recent → Calendar)"),
+            Line::from("  Enter       open the highlighted page or journal"),
+            Line::from(""),
+            Line::from(Span::styled("Sections", app.theme.help_title)),
+            Line::from("  📅 Calendar  current month — journals marked with ●"),
+            Line::from("  ⭐ Pinned    pages with `pinned:: true` property"),
+            Line::from("              (toggle with `gp` chord in Normal, or `/pin`)"),
+            Line::from("  🕘 Recent    pages opened this session (LRU, cap 20)"),
+        ],
+        "Overlays" => vec![
+            Line::from(Span::styled("Open", app.theme.help_title)),
+            Line::from("  Ctrl+P      quick switcher (pages + journals, with preview)"),
+            Line::from("  /           slash command menu (Notion-style)"),
+            Line::from("  :           vim-style palette (same registry as /)"),
+            Line::from("  ?           toggle this help"),
+            Line::from(""),
+            Line::from(Span::styled("Inside an overlay", app.theme.help_title)),
+            Line::from("  ↑↓ j k      navigate candidates"),
+            Line::from("  Enter       accept / run / open"),
+            Line::from("  Esc         dismiss"),
+            Line::from(""),
+            Line::from(Span::styled("Search hits", app.theme.help_title)),
+            Line::from("  n / N       next / previous hit (after `/` is closed)"),
+        ],
+        "Dates" => vec![
+            Line::from(Span::styled(
+                "Insert-mode slash commands",
+                app.theme.help_title,
+            )),
+            Line::from("  /date-today          [[YYYY-MM-DD]]  (also /dt, /dtm, /dy)"),
+            Line::from("  /date-next-monday    next Monday's journal ref"),
+            Line::from("                       (one alias per weekday)"),
+            Line::from("  /date +3d            offset: +Nd, -Nw, +Nm  or absolute YYYY-MM-DD"),
+            Line::from("  /time-now            HH:MM, plain (no brackets)"),
+            Line::from("  /datetime-now        [[YYYY-MM-DD]] HH:MM  (alias /stamp)"),
+            Line::from("  /iso-date-today      YYYY-MM-DD, no brackets (for `due::` etc)"),
+            Line::from("  /week-num            #YYYY-Www  (ISO week as a tag)"),
+            Line::from(""),
+            Line::from(Span::styled(
+                format!("theme: {}", app.theme.name),
+                app.theme.dim,
+            )),
+        ],
+        _ => vec![Line::from("  (no content for this tab)")],
+    }
 }

--- a/crates/outl-tui/src/view/overlays.rs
+++ b/crates/outl-tui/src/view/overlays.rs
@@ -194,16 +194,30 @@ fn render_preview_pane(f: &mut ratatui::Frame<'_>, area: Rect, app: &App, qs: &Q
         return;
     };
 
+    // One-slot cache: the renderer is called on every poll tick, but
+    // the underlying file changes only when the user touches j/k (or
+    // edits a page elsewhere). Re-read only when the cached key
+    // doesn't match the current candidate.
     let path = app.index.by_slug(&candidate.key).map(|e| e.path.clone());
-    let body_lines: Vec<Line<'static>> = match path.as_deref() {
-        Some(p) => match std::fs::read_to_string(p) {
-            Ok(text) => preview_lines(&text, area.height.saturating_sub(2) as usize, app),
-            Err(_) => vec![Line::from(Span::styled(
-                "  (couldn't read file)",
-                app.theme.dim,
-            ))],
-        },
-        None => vec![Line::from(Span::styled(
+    let cached_text: Option<String> = {
+        let mut slot = qs.preview_cache.borrow_mut();
+        let hit = matches!(slot.as_ref(), Some((k, _)) if k == &candidate.key);
+        if !hit {
+            *slot = path
+                .as_deref()
+                .and_then(|p| std::fs::read_to_string(p).ok())
+                .map(|text| (candidate.key.clone(), text));
+        }
+        slot.as_ref().map(|(_, text)| text.clone())
+    };
+
+    let body_lines: Vec<Line<'static>> = match (path.is_some(), cached_text) {
+        (true, Some(text)) => preview_lines(&text, area.height.saturating_sub(2) as usize, app),
+        (true, None) => vec![Line::from(Span::styled(
+            "  (couldn't read file)",
+            app.theme.dim,
+        ))],
+        (false, _) => vec![Line::from(Span::styled(
             "  (not yet indexed)",
             app.theme.dim,
         ))],
@@ -375,12 +389,19 @@ pub(crate) fn render_slash_overlay(
     buckets.sort_by_key(|(k, _)| category_order(k));
 
     let mut lines: Vec<Line<'static>> = Vec::new();
+    // Track which visual row the highlighted command landed on so
+    // we can scroll the Paragraph to keep it in view when category
+    // headers + blank rows push it past the visible height.
+    let mut highlighted_row: Option<usize> = None;
     for (cat, items) in &buckets {
         lines.push(Line::from(Span::styled(
             format!(" {} {} ", category_icon(cat), cat),
             app.theme.help_title,
         )));
         for (orig_idx, c) in items {
+            if *orig_idx == s.selected {
+                highlighted_row = Some(lines.len());
+            }
             let style = if *orig_idx == s.selected {
                 app.theme.list_selected
             } else {
@@ -398,6 +419,21 @@ pub(crate) fn render_slash_overlay(
         lines.push(Line::raw(""));
     }
 
+    // Viewport height inside the bordered block.
+    let inner_h = outer[1].height.saturating_sub(2) as usize;
+    let total = lines.len();
+    // Auto-scroll: when the highlighted row would render past the
+    // bottom of the viewport, push the scroll offset just enough to
+    // bring it back into view. Clamps so the bottom of the list
+    // doesn't scroll past the last row.
+    let scroll: u16 = match highlighted_row {
+        Some(row) if inner_h > 0 && row >= inner_h => {
+            let max = total.saturating_sub(inner_h);
+            ((row + 1).saturating_sub(inner_h)).min(max) as u16
+        }
+        _ => 0,
+    };
+
     let list = Paragraph::new(lines)
         .block(
             Block::default()
@@ -405,7 +441,8 @@ pub(crate) fn render_slash_overlay(
                 .border_style(app.theme.border)
                 .title(format!(" {} commands · ↑↓ Enter Esc ", s.candidates.len())),
         )
-        .style(Style::default().bg(app.theme.popup_bg));
+        .style(Style::default().bg(app.theme.popup_bg))
+        .scroll((scroll, 0));
     f.render_widget(list, outer[1]);
 }
 

--- a/crates/outl-tui/src/view/sidebar.rs
+++ b/crates/outl-tui/src/view/sidebar.rs
@@ -1,0 +1,233 @@
+//! Left sidebar — mini-calendar, pinned pages, recent.
+//!
+//! Default hidden. The orchestrator (`view.rs`) only calls
+//! [`render_sidebar`] when `app.show_sidebar == true`. The width is
+//! fixed (24 cols) so the outline column has a stable layout when the
+//! sidebar toggles on/off — no jitter mid-edit.
+//!
+//! Each section is rendered as a labelled `Block`. The section that
+//! currently has keyboard focus (Tab inside the sidebar) gets a
+//! highlighted border so the user always knows where the cursor lives.
+
+use crate::state::{App, SidebarSection, View};
+use chrono::{Datelike, Local, NaiveDate};
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
+
+/// Width the orchestrator should reserve for the sidebar. Fixed so
+/// the main column has a predictable Rect for cursor math.
+pub(crate) const SIDEBAR_WIDTH: u16 = 24;
+
+pub(crate) fn render_sidebar(f: &mut ratatui::Frame<'_>, area: Rect, app: &App) {
+    // Three stacked sections. The fixed heights keep `recent` getting
+    // the leftover space — recent is the longest list in practice and
+    // benefits from being elastic.
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(11),
+            Constraint::Length(7),
+            Constraint::Min(5),
+        ])
+        .split(area);
+
+    render_calendar(f, chunks[0], app);
+    render_pinned(f, chunks[1], app);
+    render_recent(f, chunks[2], app);
+}
+
+// ─── calendar ─────────────────────────────────────────────────────────
+
+fn render_calendar(f: &mut ratatui::Frame<'_>, area: Rect, app: &App) {
+    let today = Local::now().date_naive();
+    let viewing = match &app.view {
+        View::Journal(d) => *d,
+        View::Page(_) => today,
+    };
+    let first = NaiveDate::from_ymd_opt(viewing.year(), viewing.month(), 1).unwrap_or(today);
+    // Weekday index, 0 = Monday — line up with the `Mo Tu …` header.
+    let weekday_offset = first.weekday().num_days_from_monday() as usize;
+    let days_in_month = days_in_month(viewing.year(), viewing.month());
+
+    let mut lines: Vec<Line<'static>> = vec![Line::from(Span::styled(
+        "Mo Tu We Th Fr Sa Su",
+        app.theme.dim,
+    ))];
+
+    let mut row_spans: Vec<Span<'static>> = Vec::new();
+    // Pad the first week with blanks so day 1 aligns with its weekday.
+    for _ in 0..weekday_offset {
+        row_spans.push(Span::raw("   "));
+    }
+    for day in 1..=days_in_month {
+        let date = NaiveDate::from_ymd_opt(viewing.year(), viewing.month(), day)
+            .expect("constructed from validated y/m");
+        let has_journal = app
+            .index
+            .by_slug(&date.format("%Y-%m-%d").to_string())
+            .is_some_and(|e| e.is_journal);
+
+        let style = if date == today {
+            // Bullseye on today, regardless of journal status.
+            app.theme.heading.add_modifier(Modifier::BOLD)
+        } else if date == viewing {
+            app.theme.selected_bullet
+        } else if has_journal {
+            app.theme.ref_link
+        } else {
+            app.theme.dim
+        };
+
+        let glyph = if date == today {
+            format!("◉{day:>2}")
+        } else if has_journal {
+            format!("●{day:>2}")
+        } else {
+            format!("·{day:>2}")
+        };
+        row_spans.push(Span::styled(glyph, style));
+
+        // 7 days per row. After Sunday, flush.
+        if (weekday_offset + day as usize).is_multiple_of(7) {
+            lines.push(Line::from(std::mem::take(&mut row_spans)));
+        }
+    }
+    if !row_spans.is_empty() {
+        lines.push(Line::from(row_spans));
+    }
+
+    let focused = app.sidebar_focus == Some(SidebarSection::Calendar);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(if focused {
+            app.theme.heading
+        } else {
+            app.theme.border
+        })
+        .title(Span::styled(
+            format!(" 📅 {} ", viewing.format("%B %Y")),
+            app.theme.hint,
+        ));
+    f.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn days_in_month(year: i32, month: u32) -> u32 {
+    // Trick: first day of next month minus one day.
+    let (ny, nm) = if month == 12 {
+        (year + 1, 1)
+    } else {
+        (year, month + 1)
+    };
+    NaiveDate::from_ymd_opt(ny, nm, 1)
+        .and_then(|d| d.pred_opt())
+        .map(|d| d.day())
+        .unwrap_or(30)
+}
+
+// ─── pinned ───────────────────────────────────────────────────────────
+
+fn render_pinned(f: &mut ratatui::Frame<'_>, area: Rect, app: &App) {
+    let mut pinned: Vec<(&str, Option<&str>)> = app
+        .index
+        .pages()
+        .filter(|p| p.pinned)
+        .map(|p| (p.title.as_str(), p.icon.as_deref()))
+        .collect();
+    pinned.sort_by_key(|(t, _)| t.to_lowercase());
+
+    let focused = app.sidebar_focus == Some(SidebarSection::Pinned);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(if focused {
+            app.theme.heading
+        } else {
+            app.theme.border
+        })
+        .title(Span::styled(" ⭐ Pinned ", app.theme.hint));
+
+    if pinned.is_empty() {
+        f.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                " (pin pages with pinned:: true)",
+                app.theme.dim,
+            )))
+            .block(block),
+            area,
+        );
+        return;
+    }
+
+    let items: Vec<ListItem<'_>> = pinned
+        .into_iter()
+        .enumerate()
+        .map(|(i, (title, icon))| {
+            let selected = focused && i == app.sidebar_cursor;
+            let style = if selected {
+                app.theme.list_selected
+            } else {
+                Style::default()
+            };
+            let label = match icon {
+                Some(ic) => format!(" {ic} {title}"),
+                None => format!(" 📄 {title}"),
+            };
+            ListItem::new(Line::from(Span::styled(label, style)))
+        })
+        .collect();
+    f.render_widget(List::new(items).block(block), area);
+}
+
+// ─── recent ───────────────────────────────────────────────────────────
+
+fn render_recent(f: &mut ratatui::Frame<'_>, area: Rect, app: &App) {
+    let focused = app.sidebar_focus == Some(SidebarSection::Recent);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(if focused {
+            app.theme.heading
+        } else {
+            app.theme.border
+        })
+        .title(Span::styled(" 🕘 Recent ", app.theme.hint));
+
+    if app.recent_paths.is_empty() {
+        f.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                " (opened pages show here)",
+                app.theme.dim,
+            )))
+            .block(block),
+            area,
+        );
+        return;
+    }
+
+    let items: Vec<ListItem<'_>> = app
+        .recent_paths
+        .iter()
+        .take(20)
+        .enumerate()
+        .map(|(i, path)| {
+            let selected = focused && i == app.sidebar_cursor;
+            let style = if selected {
+                app.theme.list_selected
+            } else {
+                Style::default()
+            };
+            let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("?");
+            let entry = app.index.by_slug(stem);
+            let (icon, label) = match entry {
+                Some(e) if e.is_journal => ("📅".to_string(), e.title.clone()),
+                Some(e) => (
+                    e.icon.clone().unwrap_or_else(|| "📄".to_string()),
+                    e.title.clone(),
+                ),
+                None => ("📄".to_string(), stem.to_string()),
+            };
+            ListItem::new(Line::from(Span::styled(format!(" {icon} {label}"), style)))
+        })
+        .collect();
+    f.render_widget(List::new(items).block(block), area);
+}

--- a/crates/outl-tui/src/view/sidebar.rs
+++ b/crates/outl-tui/src/view/sidebar.rs
@@ -12,9 +12,9 @@
 use crate::state::{App, SidebarSection, View};
 use chrono::{Datelike, Local, NaiveDate};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
-use ratatui::style::{Modifier, Style};
+use ratatui::style::Modifier;
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
 
 /// Width the orchestrator should reserve for the sidebar. Fixed so
 /// the main column has a predictable Rect for cursor math.
@@ -161,22 +161,26 @@ fn render_pinned(f: &mut ratatui::Frame<'_>, area: Rect, app: &App) {
 
     let items: Vec<ListItem<'_>> = pinned
         .into_iter()
-        .enumerate()
-        .map(|(i, (title, icon))| {
-            let selected = focused && i == app.sidebar_cursor;
-            let style = if selected {
-                app.theme.list_selected
-            } else {
-                Style::default()
-            };
+        .map(|(title, icon)| {
             let label = match icon {
                 Some(ic) => format!(" {ic} {title}"),
                 None => format!(" 📄 {title}"),
             };
-            ListItem::new(Line::from(Span::styled(label, style)))
+            ListItem::new(Line::from(Span::raw(label)))
         })
         .collect();
-    f.render_widget(List::new(items).block(block), area);
+
+    // `ListState` carries the selected index AND the scroll offset.
+    // ratatui auto-scrolls so the highlighted row stays visible —
+    // we just feed it the cursor and let it figure out the offset.
+    let mut state = ListState::default();
+    if focused {
+        state.select(Some(app.sidebar_cursor));
+    }
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(app.theme.list_selected);
+    f.render_stateful_widget(list, area, &mut state);
 }
 
 // ─── recent ───────────────────────────────────────────────────────────
@@ -208,14 +212,7 @@ fn render_recent(f: &mut ratatui::Frame<'_>, area: Rect, app: &App) {
         .recent_paths
         .iter()
         .take(20)
-        .enumerate()
-        .map(|(i, path)| {
-            let selected = focused && i == app.sidebar_cursor;
-            let style = if selected {
-                app.theme.list_selected
-            } else {
-                Style::default()
-            };
+        .map(|path| {
             let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("?");
             let entry = app.index.by_slug(stem);
             let (icon, label) = match entry {
@@ -226,8 +223,19 @@ fn render_recent(f: &mut ratatui::Frame<'_>, area: Rect, app: &App) {
                 ),
                 None => ("📄".to_string(), stem.to_string()),
             };
-            ListItem::new(Line::from(Span::styled(format!(" {icon} {label}"), style)))
+            ListItem::new(Line::from(Span::raw(format!(" {icon} {label}"))))
         })
         .collect();
-    f.render_widget(List::new(items).block(block), area);
+
+    // ListState handles offset for us — feeding it the cursor lets
+    // ratatui keep the highlighted row inside the (variable-height)
+    // Recent panel even when the user walks past the visible window.
+    let mut state = ListState::default();
+    if focused {
+        state.select(Some(app.sidebar_cursor));
+    }
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(app.theme.list_selected);
+    f.render_stateful_widget(list, area, &mut state);
 }

--- a/crates/outl-tui/src/view/toasts.rs
+++ b/crates/outl-tui/src/view/toasts.rs
@@ -1,0 +1,92 @@
+//! Bottom-right toast stack — visual confirmation for transient
+//! actions (saved, reloaded, undid, …). Stacks multiple at once;
+//! each one expires on its own timer.
+//!
+//! The stack draws *over* everything else (after main, overlays,
+//! help) so a save toast still pops up even when a modal is open.
+
+use crate::state::{App, ToastKind};
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+
+/// Per-toast height (border + 1 content row).
+const TOAST_HEIGHT: u16 = 3;
+/// Gap below the footer where toasts anchor.
+const BOTTOM_GAP: u16 = 4;
+
+pub(crate) fn render_toasts(f: &mut ratatui::Frame<'_>, full: Rect, app: &App) {
+    if app.toasts.is_empty() {
+        return;
+    }
+
+    // Width: cap at 50 chars, but never more than half the screen.
+    // Real terminals get a comfortable card; narrow ones still see
+    // something readable.
+    let width = 50u16.min(full.width.saturating_sub(4));
+    if width < 12 {
+        return; // not worth drawing in a sliver
+    }
+
+    // Anchor: bottom-right, walking up the stack.
+    let right_x = full.x + full.width.saturating_sub(width + 2);
+    let mut y_cursor = full.y + full.height.saturating_sub(BOTTOM_GAP + TOAST_HEIGHT);
+
+    // Walk newest-first so the most recent toast sits on top.
+    for toast in app.toasts.iter().rev() {
+        if y_cursor < full.y + 2 {
+            break;
+        }
+        let area = Rect {
+            x: right_x,
+            y: y_cursor,
+            width,
+            height: TOAST_HEIGHT,
+        };
+        f.render_widget(Clear, area);
+
+        let (icon, accent) = icon_and_color(toast.kind);
+        let body = Line::from(vec![
+            Span::styled(
+                format!(" {icon} "),
+                Style::default().fg(accent).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(toast.message.clone()),
+        ]);
+        let card = Paragraph::new(body)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(accent))
+                    .title(Span::styled(
+                        format!(" {} ", label_for(toast.kind)),
+                        Style::default().fg(accent).add_modifier(Modifier::BOLD),
+                    )),
+            )
+            .style(Style::default().bg(app.theme.popup_bg));
+        f.render_widget(card, area);
+
+        // Step up for the next toast. Saturating sub so we never
+        // wrap into the chrome.
+        y_cursor = y_cursor.saturating_sub(TOAST_HEIGHT);
+    }
+}
+
+fn icon_and_color(kind: ToastKind) -> (&'static str, Color) {
+    match kind {
+        ToastKind::Success => ("✓", Color::LightGreen),
+        ToastKind::Info => ("ℹ", Color::LightCyan),
+        ToastKind::Warning => ("⚠", Color::LightYellow),
+        ToastKind::Error => ("✕", Color::LightRed),
+    }
+}
+
+fn label_for(kind: ToastKind) -> &'static str {
+    match kind {
+        ToastKind::Success => "ok",
+        ToastKind::Info => "info",
+        ToastKind::Warning => "warn",
+        ToastKind::Error => "error",
+    }
+}

--- a/crates/outl-tui/src/view/toasts.rs
+++ b/crates/outl-tui/src/view/toasts.rs
@@ -52,7 +52,9 @@ pub(crate) fn render_toasts(f: &mut ratatui::Frame<'_>, full: Rect, app: &App) {
                 format!(" {icon} "),
                 Style::default().fg(accent).add_modifier(Modifier::BOLD),
             ),
-            Span::raw(toast.message.clone()),
+            // Borrow rather than clone — render runs every poll
+            // tick; a per-frame allocation per toast adds up.
+            Span::raw(toast.message.as_str()),
         ]);
         let card = Paragraph::new(body)
             .block(


### PR DESCRIPTION
Extensive pass on the TUI using ratatui more aggressively. Moving away from the 1-line header/footer + raw outline, stepping into a rich chrome with chips, optional side sidebar, interactive help with tabs and exclusive focus, toasts, visual scrollbar, switcher with preview, and slash palette grouped by category. Also adds the pin toggle (`gp` / `/pin`) and breaks `commands/builtins.rs` into sibling modules