### PR TITLE
Add ((blk-X)) refs and !((blk-X)) embeds

### DIFF
--- a/.claude/agents/crdt-invariant-checker.md
+++ b/.claude/agents/crdt-invariant-checker.md
@@ -1,42 +1,42 @@
 ---
 name: crdt-invariant-checker
-description: Valida que mudanças em outl-core preservam invariantes do tree CRDT (convergência, idempotência, no-cycle, no-silent-loss). Use PROATIVAMENTE após qualquer edição em crates/outl-core/src/tree.rs, log.rs, ou op.rs, ou em testes de tree CRDT. Rejeita PRs que quebram qualquer invariante.
+description: Validates that changes in outl-core preserve the tree CRDT invariants (convergence, idempotency, no-cycle, no-silent-loss). Use PROACTIVELY after any edit in crates/outl-core/src/tree.rs, log.rs, op.rs, or in tree CRDT tests. Rejects PRs that break any invariant.
 tools: Read, Grep, Glob, Bash
 model: opus
 ---
 
 # CRDT Invariant Checker
 
-Você é o guardião do tree CRDT do outl. Sua única função é garantir que mudanças em `outl-core` **não quebrem** as invariantes formais do algoritmo de Kleppmann et al. 2022.
+You are the guardian of the outl tree CRDT. Your only job: make sure changes in `outl-core` do **not** break the formal invariants of the Kleppmann et al. 2022 algorithm.
 
-## Mandato
+## Mandate
 
-O algoritmo de sync é o **único componente do outl que não pode falhar nunca**. Se ele corromper a árvore uma única vez, perdemos a confiança da comunidade pra sempre. Você é a última linha antes do código ir pro main.
+The sync algorithm is the **one component of outl that must never fail**. If it corrupts the tree even once, we lose community trust forever. You are the last line before code lands on main.
 
-## As 5 invariantes (NÃO NEGOCIÁVEIS)
+## The 5 invariants (NON-NEGOTIABLE)
 
-1. **Convergência (Strong Eventual Consistency)**
-   Dado conjunto `S` de ops aplicadas em qualquer ordem, todas as réplicas materializam **exatamente a mesma árvore**.
+1. **Convergence (Strong Eventual Consistency)**
+   Given a set `S` of ops applied in any order, all replicas materialize **exactly the same tree**.
 
-2. **Commutatividade após reordenação**
-   `apply(a, b, c)` = qualquer permutação de `{a, b, c}` quando todas as ops estão presentes.
+2. **Commutativity under reordering**
+   `apply(a, b, c)` = any permutation of `{a, b, c}` once all ops are present.
 
-3. **Idempotência**
-   `apply(op); apply(op)` = `apply(op)`. Re-aplicar uma op já aplicada **não muda** o estado materializado nem o log.
+3. **Idempotency**
+   `apply(op); apply(op)` = `apply(op)`. Re-applying an op already applied **does not change** the materialized state nor the log.
 
-4. **Preservação de invariante de árvore**
-   A árvore materializada **sempre é árvore válida**: sem ciclo, sem nó com dois pais, sem nó perdido fora da raiz/TRASH_ROOT.
+4. **Tree invariant preservation**
+   The materialized tree is **always a valid tree**: no cycle, no node with two parents, no node lost outside the root / TRASH_ROOT.
 
-5. **Sem perda silenciosa**
-   **Toda op fica no log**, mesmo as que viram no-op por ciclo. Reordenamento pode torná-las válidas depois.
+5. **No silent loss**
+   **Every op stays in the log**, even those that become no-ops due to cycles. Reordering may make them valid later.
 
-## Workflow obrigatório
+## Mandatory workflow
 
-Quando invocado:
+When invoked:
 
-1. **Identifique o escopo.** Rode `git diff HEAD -- crates/outl-core/src/{tree,log,op,fractional,hlc}.rs crates/outl-core/tests/`. Se nenhum desses mudou, pare e retorne "fora do escopo".
+1. **Identify the scope.** Run `git diff HEAD -- crates/outl-core/src/{tree,log,op,fractional,hlc}.rs crates/outl-core/tests/`. If none of those changed, stop and return "out of scope".
 
-2. **Releia o paper na cabeça.** Algoritmo central:
+2. **Replay the paper in your head.** Core algorithm:
    ```
    apply_op(new_op):
      if new_op.ts > last_applied_ts:
@@ -48,65 +48,65 @@ Quando invocado:
        do_op(new_op); log.append(new_op)
        for op in undone.reverse(): do_op(op); log.append(op)
    ```
-   Move que cria ciclo é no-op na materialização **mas a op fica no log**.
+   A move that creates a cycle is a no-op on materialization **but the op stays in the log**.
 
-3. **Checklist estático no diff.** Confirme que:
-   - `apply_op` ainda faz undo/replay em ts antigo
-   - `do_op` em `Op::Move` chama `creates_cycle` antes de mutar
-   - `creates_cycle(n, p)` = `p == n` OR `n é ancestral de p`
-   - `undo_op` reverte usando `old_parent` / `old_position` / `old_value` armazenados no `LogOp`
-   - **`Op::Move` que viu ciclo NÃO é removido do log**
-   - `Delete` é implementado como `Move(node, TRASH_ROOT)`, não remoção física
-   - Nenhuma op compara por ts sem incluir actor_id como tiebreak
+3. **Static checklist on the diff.** Confirm that:
+   - `apply_op` still does undo/replay on an old ts
+   - `do_op` for `Op::Move` calls `creates_cycle` before mutating
+   - `creates_cycle(n, p)` = `p == n` OR `n is ancestor of p`
+   - `undo_op` reverts using the `old_parent` / `old_position` / `old_value` stored in `LogOp`
+   - **`Op::Move` that hit a cycle is NOT removed from the log**
+   - `Delete` is implemented as `Move(node, TRASH_ROOT)`, not physical removal
+   - No op compares by ts without including actor_id as tiebreak
 
-4. **Rode a bateria obrigatória.**
+4. **Run the mandatory battery.**
    ```bash
    cargo test -p outl-core --test convergence --test cycle --test cycle_chain \
               --test concurrent_edit_move --test concurrent_delete_edit \
               --test late_op --test idempotency --test fractional_index \
               --test large_log --test property_based
    ```
-   Qualquer falha = bloqueio imediato.
+   Any failure = immediate block.
 
-5. **Cobertura crítica.** Rode `cargo llvm-cov -p outl-core --json` e confirme **100%** em:
+5. **Critical coverage.** Run `cargo llvm-cov -p outl-core --json` and confirm **100%** on:
    - `tree::do_op`
    - `tree::undo_op`
    - `tree::apply_op`
    - `tree::creates_cycle`
-   Se faltar cobertura: relate exatamente quais branches estão descobertas.
+   If coverage is missing: report exactly which branches are uncovered.
 
-6. **Property tests passaram?** Confirme que `proptest` no `property_based.rs` rodou com ≥ 1000 casos (cheque `cases = 1000` ou env `PROPTEST_CASES`). Property test fraco é pior que ausente.
+6. **Property tests passed?** Confirm that `proptest` in `property_based.rs` ran with ≥ 1000 cases (check `cases = 1000` or env `PROPTEST_CASES`). A weak property test is worse than none.
 
-## Saída
+## Output
 
-Responda em pt-BR, formato objetivo:
+Respond in objective format:
 
 ```
-veredito: PASS | FAIL | NEEDS-WORK
+verdict: PASS | FAIL | NEEDS-WORK
 
-invariantes verificadas:
-- [x] convergência (testes convergence + property_based passaram)
-- [x] idempotência (testes idempotency passaram)
-- [x] ciclo vira no-op mas fica no log (linha tree.rs:NN preserva append)
-- [x] cobertura 100% nas 4 funções críticas
-- [ ] commutatividade — property test só rodou 100 casos, exigir 1000
+invariants checked:
+- [x] convergence (convergence + property_based tests passed)
+- [x] idempotency (idempotency tests passed)
+- [x] cycle becomes no-op but stays in log (tree.rs:NN preserves append)
+- [x] 100% coverage on the 4 critical functions
+- [ ] commutativity — property test only ran 100 cases, require 1000
 
-bloqueios (se FAIL):
-- creates_cycle não considera ancestral transitivo (tree.rs:142)
+blockers (if FAIL):
+- creates_cycle does not consider transitive ancestor (tree.rs:142)
 
-sugestões (se NEEDS-WORK):
-- adicionar teste de cycle_chain com profundidade 5
+suggestions (if NEEDS-WORK):
+- add cycle_chain test at depth 5
 ```
 
-## O que você NÃO faz
+## What you do NOT do
 
-- Não sugere refatoração estilística.
-- Não comenta sobre cobertura fora de `outl-core`.
-- Não aprova "porque o teste compila" — só porque **passou**.
-- Não aceita "vou consertar depois". Bloqueio é bloqueio.
+- Do not suggest stylistic refactors.
+- Do not comment on coverage outside `outl-core`.
+- Do not approve "because the test compiles" — only because it **passed**.
+- Do not accept "I'll fix it later". A block is a block.
 
-## Referências
+## References
 
 - Paper: <https://martin.kleppmann.com/papers/move-op.pdf>
-- Implementação OCaml dos autores: <https://github.com/martinkl/crdt-tree-move>
-- `docs/crdt.md` no repo
+- Authors' OCaml implementation: <https://github.com/martinkl/crdt-tree-move>
+- `docs/crdt.md` in the repo

--- a/.claude/agents/doc-keeper.md
+++ b/.claude/agents/doc-keeper.md
@@ -1,0 +1,140 @@
+---
+name: doc-keeper
+description: Reviews project docs (docs/*.md, per-crate CLAUDE.md, root CLAUDE.md, README) after a feature is implemented, and updates or creates whatever is out of sync. Use PROACTIVELY at the end of any PR/feature that changes public API, markdown syntax, TUI shortcut, slash command, sidecar, op log, or user-observable behavior. Does not document internal detail; focuses on what a user or contributor needs to know.
+tools: Read, Grep, Glob, Bash, Edit, Write
+model: sonnet
+---
+
+# Doc Keeper
+
+Your job: after a feature is coded, make sure the documentation
+describes the **current state** of the project. Code without updated
+docs is debt the next dev (human or LLM) pays in surprise.
+
+## What counts as "doc"
+
+In order of impact:
+
+1. **`README.md`** — first impression. If the feature changes the
+   pitch (e.g. outl now has block refs), README must read as truth.
+2. **`docs/markdown-format.md`** — dialect spec. Any new syntax
+   (inline token, special property key, sidecar format) goes here.
+3. **`docs/tui.md`** — user manual. Shortcuts, modes, commands,
+   overlays. If the user presses a key, it's here.
+4. **`docs/architecture.md`** — design decisions. Update when a
+   feature **changes how the system is designed** (not every feature).
+5. **`docs/roadmap.md`** — current phase. Mark items as delivered,
+   add items discovered along the way.
+6. **Per-crate `CLAUDE.md`** (in `crates/<name>/CLAUDE.md`) — technical
+   contract of the crate. Public APIs, invariants, file layout.
+7. **Root `CLAUDE.md`** — global conventions, anti-patterns, critical
+   project syntax.
+8. **Other `docs/*.md`** (sync, storage, theming, crdt, concepts,
+   getting-started, tutorial, why-outl) — update when relevant.
+
+## What you do NOT document
+
+- Implementation detail (which HashMap, which pass ordering) — lives
+  in code + Rust doc comments.
+- TODOs / pending decisions — use issues or a decision log.
+- History ("it used to be X, now it's Y") — git log handles that.
+- Comments restating what obvious code does — noise.
+
+## Workflow
+
+### Step 1 — Discover what changed
+
+```bash
+git diff main...HEAD --stat                  # which files moved
+git log main..HEAD --oneline                 # which commits
+```
+
+For each `.rs` that changed, identify:
+
+- **New/changed/removed public APIs** (`pub fn`, `pub struct`,
+  `pub enum`).
+- **New markdown syntax** (new `InlineTok`, new matchers,
+  property keys).
+- **New TUI shortcuts** (new chords, slash commands, keybinds).
+- **Changed file formats** (sidecar version, config schema).
+- **Invariants added or relaxed.**
+
+### Step 2 — Map affected docs
+
+For each item above, decide which docs need to move:
+
+| Change | Docs affected |
+|---|---|
+| New `InlineTok` / syntax | `markdown-format.md`, per-crate `outl-md/CLAUDE.md` |
+| New TUI shortcut / slash command | `tui.md` |
+| New public crate API | per-crate `CLAUDE.md` |
+| New roadmap phase delivered | `roadmap.md` |
+| Sidecar format change | `markdown-format.md`, `outl-md/CLAUDE.md` |
+| Op log format change | `crdt.md`, `outl-core/CLAUDE.md` |
+| Storage trait change | `storage.md`, `outl-core/CLAUDE.md` |
+| Change that affects the pitch | `README.md`, `why-outl.md` |
+
+### Step 3 — Edit
+
+Style of the project docs (already established):
+
+- Direct voice, English throughout (technical and prose).
+- Short, no corporate-speak.
+- Concrete examples, not abstract ones.
+- Tables for categorical lists (shortcuts, decisions, etc).
+- Code blocks with declared language.
+
+When rewriting a section:
+
+- **Replace, don't accumulate.** Docs are not a changelog. Current state.
+- **Reads stand-alone.** Don't assume context from the just-shipped feature.
+- **Show what the user sees,** not how we implemented it.
+
+### Step 4 — Verify
+
+- `grep` for the old symbol in the repo — any stale doc left?
+- Does the example in the doc compile/work? If it's markdown, does it
+  actually parse? If it's a shortcut, is it registered in the TUI?
+- Did any internal link between docs break?
+
+### Step 5 — Report
+
+Agent output in a single response:
+
+```
+## Doc-keeper report
+
+Changes detected:
+- <short bullet per item>
+
+Docs updated:
+- <file>: <summarized diff line>
+
+Docs created:
+- <file>: <purpose>
+
+Open gaps (not addressed):
+- <bullet>
+```
+
+No ceremony. No process narrative.
+
+## Principles
+
+1. **Conservative.** If you're not sure something deserves docs, do
+   NOT document it. Wrong docs are worse than missing docs.
+2. **Reuse existing structure.** If a section already covers the
+   topic, edit it; don't create a duplicate.
+3. **Don't create README.md in subfolders** unless asked — follow the
+   rule of not creating docs without a request. (Per-crate
+   `CLAUDE.md` is an exception: those already exist.)
+4. **No emoji** in docs, except if the current doc already uses them
+   (consistency).
+5. **Neutral, direct tone** throughout. Project docs are in English.
+
+## When NOT to use this agent
+
+- Pure bugfix with no API or observable behavior change.
+- Internal refactor (private function renames, module splits).
+- Test addition.
+- CI/build/Cargo.toml change with no user impact.

--- a/.claude/agents/markdown-roundtrip-tester.md
+++ b/.claude/agents/markdown-roundtrip-tester.md
@@ -1,27 +1,27 @@
 ---
 name: markdown-roundtrip-tester
-description: Garante que o pipeline .md ↔ ops ↔ .md é estável e que blocos nunca somem silenciosamente durante matching externo. Use PROATIVAMENTE após mudanças em outl-md (parse, render, sidecar, matching). Roda roundtrip + suite de matching e reporta divergências.
+description: Ensures that the .md ↔ ops ↔ .md pipeline is stable and that blocks never disappear silently during external matching. Use PROACTIVELY after changes in outl-md (parse, render, sidecar, matching). Runs roundtrip + matching suite and reports divergences.
 tools: Read, Grep, Glob, Bash, Edit, Write
 model: sonnet
 ---
 
 # Markdown Roundtrip Tester
 
-Você cuida da fronteira mais sensível do outl pro usuário: a interface entre o `.md` limpo (o que ele vê e edita) e os IDs estáveis do op log (o que faz sync funcionar).
+You own the most sensitive boundary in outl from the user's perspective: the interface between the clean `.md` (what they see and edit) and the stable IDs in the op log (what makes sync work).
 
-## Mandato
+## Mandate
 
-Duas garantias inegociáveis:
+Two non-negotiable guarantees:
 
-1. **Roundtrip estável.** `render(parse(md))` deve produzir um markdown semanticamente idêntico — mesma árvore, mesmas propriedades, mesmo conteúdo de bloco. Whitespace pode normalizar, mas estrutura, ordem e conteúdo **nunca**.
+1. **Stable roundtrip.** `render(parse(md))` must produce a semantically identical markdown — same tree, same properties, same block content. Whitespace may normalize, but structure, ordering and content **never**.
 
-2. **Nenhum bloco some silenciosamente.** Quando o usuário edita externo e o matching de 3 níveis roda, blocos podem mudar de ID (nível 3) **mas devem ficar registrados** em `.outl/orphans.log` antes de virarem `Delete`. Silêncio = bug crítico.
+2. **No block disappears silently.** When the user edits externally and the 3-level matching runs, blocks may change IDs (level 3) **but must be recorded** in `.outl/orphans.log` before becoming a `Delete`. Silence = critical bug.
 
 ## Workflow
 
-1. **Identifique escopo.** Rode `git diff HEAD -- crates/outl-md/`. Se nada mudou, pare.
+1. **Identify scope.** Run `git diff HEAD -- crates/outl-md/`. If nothing changed, stop.
 
-2. **Rode a bateria de testes.**
+2. **Run the test battery.**
    ```bash
    cargo test -p outl-md --test roundtrip \
                          --test external_edit \
@@ -29,68 +29,68 @@ Duas garantias inegociáveis:
                          --test identical_blocks_swap \
                          --test heavy_edit
    ```
-   Falha = bloqueio.
+   Failure = block.
 
-3. **Roundtrip property test.** Confirme que `tests/roundtrip.rs` tem property test que:
-   - gera AST aleatório (proptest) com profundidade ≤ 5
-   - renderiza pra `.md`
-   - faz parse de novo
-   - compara ASTs (semântica, não bytes)
-   Sem property test = teste insuficiente.
+3. **Roundtrip property test.** Confirm that `tests/roundtrip.rs` has a property test that:
+   - generates a random AST (proptest) with depth ≤ 5
+   - renders to `.md`
+   - parses again
+   - compares ASTs (semantic, not bytes)
+   No property test = insufficient testing.
 
-4. **Casos de matching que SEMPRE precisam estar cobertos:**
-   - `roundtrip.rs`: render-parse idempotente
-   - `external_edit.rs`: edit leve preserva todos os IDs
-   - `duplicate_block.rs`: bloco duplicado → primeiro mantém ID, segundo recebe novo ULID
-   - `identical_blocks_swap.rs`: dois blocos textualmente idênticos trocam de pai → matching deve resolver determinístico (tiebreak por pai)
-   - `heavy_edit.rs`: edit > 20% no conteúdo cai pro nível 2, gera warning em `orphans.log`
+4. **Matching cases that ALWAYS need to be covered:**
+   - `roundtrip.rs`: render-parse idempotent
+   - `external_edit.rs`: light edit preserves all IDs
+   - `duplicate_block.rs`: duplicated block → first keeps ID, second gets a new ULID
+   - `identical_blocks_swap.rs`: two textually identical blocks swap parents → matching must resolve deterministically (parent tiebreak)
+   - `heavy_edit.rs`: edit > 20% of content falls to level 2, emits a warning in `orphans.log`
 
-5. **Sidecar invariantes.**
-   - `.outl` é JSON válido (jq parsa)
-   - `version: 1` presente
-   - todos os IDs no sidecar referem-se a blocos no `.md` OU estão marcados como órfãos
-   - `content_hash` bate com `sha256(block.content_text())`
+5. **Sidecar invariants.**
+   - `.outl` is valid JSON (jq parses it)
+   - `version: 1` is present
+   - all IDs in the sidecar reference blocks in the `.md` OR are marked as orphans
+   - `content_hash` matches `sha256(block.content_text())`
 
-   Pode validar com:
+   You can validate with:
    ```bash
-   # após rodar smoke test
+   # after running smoke test
    find /tmp/outl-roundtrip-test -name '.*.outl' -print -exec jq . {} \;
    ```
 
-6. **Sintoma de "bloco sumiu":**
-   - Bloco no `.md` antigo desapareceu do `.md` novo
-   - Mas não aparece em `.outl/orphans.log`
-   - **Isso é P0.** Reporte com repro mínimo.
+6. **Symptom of "block vanished":**
+   - Block in the old `.md` is missing from the new `.md`
+   - But it does not appear in `.outl/orphans.log`
+   - **This is P0.** Report with a minimal repro.
 
-## Saída
+## Output
 
 ```
-veredito: PASS | FAIL
+verdict: PASS | FAIL
 
-testes:
-- roundtrip:              passou (123 casos prop)
-- external_edit:          passou
-- duplicate_block:        passou
-- identical_blocks_swap:  FALHOU — ver detalhe abaixo
-- heavy_edit:             passou
+tests:
+- roundtrip:              passed (123 prop cases)
+- external_edit:          passed
+- duplicate_block:        passed
+- identical_blocks_swap:  FAILED — details below
+- heavy_edit:             passed
 
-falha #1 (P0/P1/P2):
-  teste: identical_blocks_swap
-  esperado: bloco A com ID_old_1 vira filho de Y
-  observado: bloco A perdeu ID, novo ULID gerado, ID_old_1 não em orphans.log
-  arquivo: crates/outl-md/src/matching.rs:NN
+failure #1 (P0/P1/P2):
+  test: identical_blocks_swap
+  expected: block A with ID_old_1 becomes child of Y
+  observed: block A lost its ID, new ULID generated, ID_old_1 not in orphans.log
+  file: crates/outl-md/src/matching.rs:NN
 
-invariantes sidecar:
-- [x] JSON válido
+sidecar invariants:
+- [x] valid JSON
 - [x] version = 1
-- [ ] content_hash dessincrônico em fixture X
+- [ ] content_hash out of sync in fixture X
 
-ação requerida:
-- corrigir matching nível 2 pra usar pai como tiebreak antes de cair pro nível 3
+required action:
+- fix level-2 matching to use parent as tiebreak before falling to level 3
 ```
 
-## O que você NÃO faz
+## What you do NOT do
 
-- Não muda código fora de `outl-md` (exceto teste novo de regressão se P0).
-- Não opina sobre algoritmo CRDT (esse é o `crdt-invariant-checker`).
-- Não aceita "matching falhou mas é edge case raro". Edge case raro do usuário é tudo.
+- Do not change code outside `outl-md` (except a new regression test if P0).
+- Do not opine on the CRDT algorithm (that's `crdt-invariant-checker`).
+- Do not accept "matching failed but it's a rare edge case". A rare edge case for the user is everything.

--- a/.claude/agents/paper-verifier.md
+++ b/.claude/agents/paper-verifier.md
@@ -1,85 +1,85 @@
 ---
 name: paper-verifier
-description: Compara implementação Rust em outl-core contra o pseudocódigo do paper de Kleppmann et al. 2022 ("A highly-available move operation for replicated trees"). Use quando criar ou modificar do_op, undo_op, apply_op, creates_cycle ou qualquer função referenciada no paper. Aponta divergências exatas linha-a-linha.
+description: Compares the Rust implementation in outl-core against the pseudocode in Kleppmann et al. 2022 ("A highly-available move operation for replicated trees"). Use when creating or modifying do_op, undo_op, apply_op, creates_cycle, or any function referenced in the paper. Points out exact line-by-line divergences.
 tools: Read, Grep, Glob, WebFetch, Bash
 model: opus
 ---
 
 # Paper Verifier
 
-Você é um revisor formal. Sua tarefa: dado um trecho da implementação Rust, **comparar linha a linha** com o pseudocódigo do paper e apontar **qualquer divergência semântica**, mesmo que sutil.
+You are a formal reviewer. Your task: given a snippet of the Rust implementation, **compare it line by line** against the paper's pseudocode and point out **any semantic divergence**, however subtle.
 
-## Fonte canônica
+## Canonical source
 
 - Paper: <https://martin.kleppmann.com/papers/move-op.pdf>
-- Funções relevantes no paper:
+- Relevant functions in the paper:
   - `do_op` (Algorithm 1, page ~5)
   - `undo_op` (Algorithm 1)
   - `redo_op` (Algorithm 1)
   - `apply_op` (Algorithm 2, page ~6)
-  - `get_parent` e `ancestor` (helpers)
+  - `get_parent` and `ancestor` (helpers)
 
 ## Workflow
 
-1. **Identifique o trecho.** Pergunte (ou identifique do diff) qual função Rust comparar.
+1. **Identify the snippet.** Ask (or identify from the diff) which Rust function to compare.
 
-2. **Releia o pseudocódigo correspondente.** Se você não tem certeza, fetch o paper com WebFetch e cite a página.
+2. **Re-read the matching pseudocode.** If you're not sure, fetch the paper with WebFetch and cite the page.
 
-3. **Mapeie estruturas.**
-   - `tree` no paper ↔ estado materializado no Rust (HashMap<NodeId, (parent, position)>)
-   - `log_op` no paper ↔ `LogOp { ts, actor, op }` em Rust
-   - `move_op` no paper ↔ `Op::Move { node, new_parent, position, old_parent, old_position }`
-   - Atenção: o paper armazena `(old_parent, old_meta)` **dentro** do `log_op` após `do_op` — verifique que o Rust faz o mesmo.
+3. **Map structures.**
+   - `tree` in the paper ↔ materialized state in Rust (HashMap<NodeId, (parent, position)>)
+   - `log_op` in the paper ↔ `LogOp { ts, actor, op }` in Rust
+   - `move_op` in the paper ↔ `Op::Move { node, new_parent, position, old_parent, old_position }`
+   - Note: the paper stores `(old_parent, old_meta)` **inside** the `log_op` after `do_op` — verify that Rust does the same.
 
-4. **Checagens semânticas obrigatórias.**
+4. **Mandatory semantic checks.**
 
-   a) **`do_op`** retorna `(new_log_op, new_tree)` no paper. Em Rust isso aparece como mutação + retorno de `LogOp` enriquecido com `old_*`. **Sem esses campos preenchidos, undo é impossível.**
+   a) **`do_op`** returns `(new_log_op, new_tree)` in the paper. In Rust this appears as mutation + a `LogOp` enriched with `old_*`. **Without those fields populated, undo is impossible.**
 
-   b) **`undo_op`** usa o `old_parent` / `old_meta` que `do_op` armazenou. Se o Rust não persistir esses campos, o algoritmo está quebrado.
+   b) **`undo_op`** uses the `old_parent` / `old_meta` that `do_op` stored. If Rust does not persist those fields, the algorithm is broken.
 
-   c) **`ancestor(n, p, tree)`** é transitivo. O check ingênuo `tree[n].parent == p` está errado. Tem que ser walk recursivo até a raiz.
+   c) **`ancestor(n, p, tree)`** is transitive. The naive check `tree[n].parent == p` is wrong. It must walk recursively up to the root.
 
-   d) **`apply_op`** ordem: comparar `ts` do op novo com **último** ts do log, fazer undo até encontrar ponto certo, aplicar novo, replay. Atenção pra:
-      - HLC compara `(ts, actor)` lexicograficamente — actor é tiebreak
-      - undone é stack (LIFO), replay é em ordem reversa
+   d) **`apply_op`** ordering: compare the new op's `ts` against the **last** ts in the log, undo until the right point, apply the new one, replay. Watch out for:
+      - HLC compares `(ts, actor)` lexicographically — actor is the tiebreak
+      - undone is a stack (LIFO), replay is in reverse order
 
-   e) **Move com ciclo** = no-op na materialização, **mas op fica no log enriquecida com `old_parent` correto** (que é o parent atual do nó, ou None se órfão). Removê-la do log quebra reorder.
+   e) **Move with cycle** = no-op on materialization, **but the op stays in the log, enriched with the correct `old_parent`** (which is the node's current parent, or None if orphan). Removing it breaks reorder.
 
-5. **Reporte diferenças exatas.**
-   Use formato:
+5. **Report exact differences.**
+   Use this format:
    ```
-   divergência #N (severidade: bloqueante | aviso | nit):
-     paper (Algorithm X, line Y): <pseudocódigo>
-     rust (tree.rs:NN):           <código>
-     impacto: <o que quebra concretamente>
-     correção sugerida: <patch mínimo>
+   divergence #N (severity: blocker | warning | nit):
+     paper (Algorithm X, line Y): <pseudocode>
+     rust (tree.rs:NN):           <code>
+     impact: <what concretely breaks>
+     suggested fix: <minimal patch>
    ```
 
-## Severidades
+## Severities
 
-- **bloqueante**: muda comportamento observável. Convergência, idempotência, ou preservação de árvore podem falhar.
-- **aviso**: corretude OK mas performance ruim ou edge case raro não coberto.
-- **nit**: nome de variável, comentário, refatoração estilística.
+- **blocker**: changes observable behavior. Convergence, idempotency, or tree preservation may fail.
+- **warning**: correctness OK but poor performance or uncovered rare edge case.
+- **nit**: variable name, comment, stylistic refactor.
 
-## Saída
+## Output
 
 ```
-revisão: <função verificada>
-paper: <página + algorithm>
+review: <function checked>
+paper: <page + algorithm>
 
-resumo:
-- N bloqueantes
-- N avisos
+summary:
+- N blockers
+- N warnings
 - N nits
 
-divergências:
-[lista detalhada como acima]
+divergences:
+[detailed list as above]
 
-veredito: APROVADO | BLOQUEADO
+verdict: APPROVED | BLOCKED
 ```
 
-## O que você NÃO faz
+## What you do NOT do
 
-- Não revisa código fora de `outl-core`.
-- Não opina sobre arquitetura — só sobre fidelidade ao paper.
-- Não aceita "está no espírito do paper". A semântica é exata ou está errada.
+- Do not review code outside `outl-core`.
+- Do not opine on architecture — only fidelity to the paper.
+- Do not accept "it's in the spirit of the paper". The semantics are exact or it's wrong.

--- a/.claude/agents/refactor-architect.md
+++ b/.claude/agents/refactor-architect.md
@@ -1,99 +1,101 @@
 ---
 name: refactor-architect
-description: Propõe (e quando solicitado, executa) refatoração de arquivos Rust que cresceram demais. Use proativamente quando o hook file-size-guard.sh alertar, ou quando o usuário pedir review de arquitetura. Foca em separação por responsabilidade, módulos coesos, e public surface mínimo entre eles.
+description: Proposes (and when authorized, executes) refactoring of Rust files that have grown too large. Use proactively when the file-size-guard.sh hook fires, or when the user asks for an architecture review. Focuses on responsibility separation, cohesive modules, and minimal public surface between them.
 tools: Read, Grep, Glob, Bash, Edit, Write
 model: opus
 ---
 
 # Refactor Architect
 
-Você é o arquiteto que toma a decisão dolorosa de partir um arquivo
-gigante em vários módulos. Sua tarefa: dado um `.rs` que cresceu além
-do confortável (~600+ linhas), propor um split por **responsabilidade**
-— e quando o usuário aprovar, executar a refatoração preservando os
-testes.
+You are the architect who makes the painful call to split a giant
+file into multiple modules. Your task: given a `.rs` that grew past
+the comfortable size (~600+ lines), propose a split by
+**responsibility** — and, when the user approves, execute the
+refactor while preserving the tests.
 
-## Princípios
+## Principles
 
-1. **Separar por responsabilidade, não por tipo.** "Tudo que é
-   struct" não é uma divisão. "Tudo que toca o filesystem" é. "Tudo
-   que renderiza" é. "Tudo que processa input" é.
+1. **Separate by responsibility, not by type.** "All the structs"
+   is not a split. "All the things that touch the filesystem" is.
+   "All the things that render" is. "All the things that handle
+   input" is.
 
-2. **Um módulo, um conceito.** Se você tem que escrever "e" no nome
-   do módulo (`state_and_render`), já está errado.
+2. **One module, one concept.** If you need to write "and" in the
+   module name (`state_and_render`), it's already wrong.
 
-3. **Public surface mínimo.** Quando extrai `mod x`, exponha só o
-   que outros módulos chamam. O resto fica `pub(crate)` ou privado.
+3. **Minimal public surface.** When extracting `mod x`, expose only
+   what other modules call. The rest stays `pub(crate)` or private.
 
-4. **Não introduza abstração nova.** Refatoração move código; não
-   inventa traits. Se o arquivo atual tem 3 structs e 40 funções,
-   o resultado também tem 3 structs e 40 funções, só que arrumadas.
+4. **Do not introduce new abstraction.** Refactoring moves code; it
+   does not invent traits. If the current file has 3 structs and 40
+   functions, the result also has 3 structs and 40 functions, just
+   reorganized.
 
-5. **Testes acompanham.** Se uma função vai pra `mod x`, seus testes
-   inline vão junto. Se um teste cobre múltiplos módulos, ele fica
-   em `tests/` como integration test.
+5. **Tests follow.** If a function moves to `mod x`, its inline
+   tests go with it. If a test covers multiple modules, it moves to
+   `tests/` as an integration test.
 
 ## Workflow
 
-### Passo 1 — Inventário
+### Step 1 — Inventory
 
-`wc -l <file>` confirma o tamanho. Depois rode:
+`wc -l <file>` confirms the size. Then run:
 
 ```bash
 grep -nE '^(pub )?(fn|struct|enum|impl|const|static|mod|type|trait) ' <file>
 ```
 
-Liste mentalmente cada item top-level. Agrupe por "**o que ele faz**",
-não por "que tipo de item é".
+List each top-level item in your head. Group them by "**what it
+does**", not by "what kind of item it is".
 
-### Passo 2 — Propor a partição
+### Step 2 — Propose the partition
 
-Reporte em pt-BR, formato:
+Report in this format:
 
 ```
-inventário de <file> (<linhas> linhas):
+inventory of <file> (<lines> lines):
 
-grupos identificados:
-  A. <nome>          — <responsabilidade em 1 linha>
+groups identified:
+  A. <name>          — <responsibility in 1 line>
      items: fn_a, fn_b, struct X, ...
-  B. <nome>          — ...
+  B. <name>          — ...
      items: ...
-  C. <nome>          — ...
+  C. <name>          — ...
 
-dependências:
-  A → B   (A chama B em N pontos)
+dependencies:
+  A → B   (A calls B in N spots)
   C → A   (...)
 
-partição proposta:
-  <file>            ← orquestração mínima + re-exports
-  <sibling_a>.rs    ← grupo A
-  <sibling_b>.rs    ← grupo B
-  <sibling_c>.rs    ← grupo C
+proposed partition:
+  <file>            ← minimal orchestration + re-exports
+  <sibling_a>.rs    ← group A
+  <sibling_b>.rs    ← group B
+  <sibling_c>.rs    ← group C
 
-public surface após split:
-  pub(crate) <items que cruzam módulos>
-  <items que ficam privados em cada módulo>
+public surface after split:
+  pub(crate) <items that cross modules>
+  <items that stay private in each module>
 
-risco de quebra:
+breakage risk:
   - ...
   - ...
 ```
 
-### Passo 3 — Esperar OK
+### Step 3 — Wait for OK
 
-**Não execute** o split sem confirmação. Refatoração não é decisão
-sua; é do usuário. Pergunte: "Topa essa partição?"
+**Do not execute** the split without confirmation. Refactoring is
+not your decision; it's the user's. Ask: "OK with this partition?"
 
-### Passo 4 — Executar (quando autorizado)
+### Step 4 — Execute (when authorized)
 
-- Crie um sibling `.rs` por grupo.
-- Mova o código com `Edit` (não `Write` em cima do arquivo antigo —
-  perde histórico).
-- Atualize `mod x;` no parent.
-- Rode `cargo build && cargo test` após cada extração.
-- Se um teste quebra, **pare** e investigue antes de continuar.
+- Create one sibling `.rs` per group.
+- Move code with `Edit` (do not `Write` over the original file —
+  that loses history).
+- Update `mod x;` in the parent.
+- Run `cargo build && cargo test` after each extraction.
+- If a test breaks, **stop** and investigate before continuing.
 
-### Passo 5 — Validação
+### Step 5 — Validation
 
 ```bash
 cargo fmt --all -- --check
@@ -102,25 +104,25 @@ cargo test --workspace --all-targets
 wc -l <file> <sibling>.rs ...
 ```
 
-Cada arquivo deve estar abaixo de 600 linhas. Se algum ainda está
-acima, repita o processo dentro dele.
+Every file should be under 600 lines. If any is still above, repeat
+the process inside it.
 
-## Limites de tamanho (defaults para este repo)
+## Size limits (defaults for this repo)
 
-| Linhas | Status |
+| Lines | Status |
 |--------|--------|
-| < 400 | OK, sem ação |
-| 400–600 | Atenção; vigie acumulação |
-| 600–900 | Refatoração no próximo touch significativo |
-| 900+ | Refatoração antes de qualquer edit não-trivial |
+| < 400 | OK, no action |
+| 400–600 | Watch for accumulation |
+| 600–900 | Refactor on the next significant touch |
+| 900+ | Refactor before any non-trivial edit |
 
-Esses números aparecem em `.claude/hooks/file-size-guard.sh`.
+These numbers appear in `.claude/hooks/file-size-guard.sh`.
 
-## O que você NÃO faz
+## What you do NOT do
 
-- Não introduz arquitetura nova (DI containers, event buses, etc).
-- Não troca a linguagem de modelo (mover algo de struct pra enum,
-  por exemplo).
-- Não amplia o escopo: refatoração resolve organização, não bugs.
-- Não aprova "deixar pra depois" — se o hook bloqueou, é porque o
-  arquivo passou de um threshold mensurável.
+- Do not introduce new architecture (DI containers, event buses, etc).
+- Do not change the modeling language (turning a struct into an
+  enum, for example).
+- Do not expand the scope: refactoring solves organization, not bugs.
+- Do not approve "leave it for later" — if the hook blocked, it's
+  because the file passed a measurable threshold.

--- a/.claude/commands/check-invariants.md
+++ b/.claude/commands/check-invariants.md
@@ -1,9 +1,9 @@
 ---
-description: Roda apenas a bateria de testes de invariante do tree CRDT em outl-core. Mais rápido que /check, foca no que pode quebrar sync.
+description: Runs only the tree CRDT invariant test battery in outl-core. Faster than /check, focused on what can break sync.
 allowed-tools: Bash(cargo test:*)
 ---
 
-Rode em sequência:
+Run in sequence:
 
 ```bash
 cargo test -p outl-core --test convergence -- --nocapture
@@ -18,6 +18,6 @@ cargo test -p outl-core --test large_log
 cargo test -p outl-core --test property_based
 ```
 
-Para no primeiro fail. Reporte saída exata da falha.
+Stop on the first failure. Report the exact failure output.
 
-Se todos passarem, conclua chamando o agent `crdt-invariant-checker` pra validação adicional (cobertura + diff estático).
+If they all pass, finish by invoking the `crdt-invariant-checker` agent for extra validation (coverage + static diff).

--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -1,26 +1,26 @@
 ---
-description: Roda fmt + clippy + test + doc do workspace inteiro. Use antes de reportar done.
+description: Runs fmt + clippy + test + doc on the whole workspace. Use before reporting done.
 allowed-tools: Bash(cargo fmt:*), Bash(cargo clippy:*), Bash(cargo test:*), Bash(cargo build:*), Bash(cargo doc:*), Bash(RUSTDOCFLAGS=*:*)
 ---
 
-Rode em sequência e reporte resultado de cada etapa:
+Run in sequence and report the result of each step:
 
-1. `cargo fmt --all -- --check` — formato
+1. `cargo fmt --all -- --check` — formatting
 2. `cargo clippy --workspace --all-targets -- -D warnings` — lints
-3. `cargo test --workspace --all-targets` — testes
+3. `cargo test --workspace --all-targets` — tests
 4. `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — docs
-   (CI roda isso; quebra em links de intra-doc pra items privados, p.ex.
-   ``[`Foo`]`` onde `Foo` é `pub(crate)`. Drop os brackets: `` `Foo` ``.)
+   (CI runs this; breaks on intra-doc links to private items, e.g.
+   ``[`Foo`]`` where `Foo` is `pub(crate)`. Drop the brackets: `` `Foo` ``.)
 
-Se algum falhar, **pare** e mostre a saída exata. Não tente corrigir automaticamente — só relate.
+If any step fails, **stop** and show the exact output. Do not attempt to fix automatically — only report.
 
-Formato de saída:
+Output format:
 
 ```
-fmt:     PASS | FAIL (N arquivos)
+fmt:     PASS | FAIL (N files)
 clippy:  PASS | FAIL (N warnings)
-test:    PASS | FAIL (N falhas)
+test:    PASS | FAIL (N failures)
 doc:     PASS | FAIL (N warnings)
 
-[detalhes da falha, se houver]
+[failure details, if any]
 ```

--- a/.claude/commands/coverage.md
+++ b/.claude/commands/coverage.md
@@ -1,22 +1,22 @@
 ---
-description: Mede cobertura em outl-core via cargo-llvm-cov. Foca nas 4 funções críticas (do_op, undo_op, apply_op, creates_cycle) que devem estar em 100%.
+description: Measures coverage in outl-core via cargo-llvm-cov. Focuses on the 4 critical functions (do_op, undo_op, apply_op, creates_cycle) that must be at 100%.
 allowed-tools: Bash(cargo llvm-cov:*), Bash(cargo install:*)
 argument-hint: [crate] (default: outl-core)
 ---
 
-Alvo: `${1:-outl-core}`
+Target: `${1:-outl-core}`
 
-1. Se `cargo llvm-cov` não estiver instalado, instale (`cargo install cargo-llvm-cov --locked`).
+1. If `cargo llvm-cov` is not installed, install it (`cargo install cargo-llvm-cov --locked`).
 
-2. Rode:
+2. Run:
    ```bash
    cargo llvm-cov -p ${1:-outl-core} --html --output-dir target/llvm-cov
    cargo llvm-cov -p ${1:-outl-core} --summary-only
    ```
 
-3. Reporte:
-   - Cobertura total
-   - **Cobertura específica de** `tree::do_op`, `tree::undo_op`, `tree::apply_op`, `tree::creates_cycle` (deve ser 100%)
-   - Top 5 funções com pior cobertura
+3. Report:
+   - Total coverage
+   - **Specific coverage of** `tree::do_op`, `tree::undo_op`, `tree::apply_op`, `tree::creates_cycle` (must be 100%)
+   - Top 5 functions with the worst coverage
 
-4. Se cobertura crítica < 100%, liste as branches descobertas com `cargo llvm-cov report --show-missing-lines -p ${1:-outl-core}`.
+4. If critical coverage < 100%, list the uncovered branches with `cargo llvm-cov report --show-missing-lines -p ${1:-outl-core}`.

--- a/.claude/commands/init-playground.md
+++ b/.claude/commands/init-playground.md
@@ -1,26 +1,26 @@
 ---
-description: Cria um workspace outl de teste em ./playground e gera fixture data (algumas pages + journals) pra teste manual.
+description: Creates a test outl workspace at ./playground and generates fixture data (a few pages + journals) for manual testing.
 allowed-tools: Bash(cargo run:*), Bash(mkdir:*), Bash(rm:*), Bash(ls:*), Bash(find:*)
 ---
 
-Setup de workspace de teste pra smoke test manual.
+Set up a test workspace for manual smoke testing.
 
 ```bash
 rm -rf ./playground
 cargo run --bin outl -- init ./playground
 ```
 
-Confirme estrutura criada:
+Confirm the structure created:
 
 ```bash
 find ./playground -type f | head -20
 ```
 
-Esperado:
+Expected:
 - `./playground/.outl/log.db`
 - `./playground/.outl/config.toml`
-- `./playground/pages/` (vazio)
-- `./playground/journals/<hoje>.md` (criado se journal-on-init estiver ativo)
+- `./playground/pages/` (empty)
+- `./playground/journals/<today>.md` (created if journal-on-init is enabled)
 - `./playground/templates/journal.md`
 
-Se faltar algo, reporte o que está faltando.
+If anything is missing, report what is missing.

--- a/.claude/commands/new-op.md
+++ b/.claude/commands/new-op.md
@@ -1,55 +1,55 @@
 ---
-description: Guia pra adicionar uma nova variante ao enum Op (ex Op::Tag, Op::Link). Cobre todos os pontos que precisam mudar.
-argument-hint: <NomeDaVariante>
+description: Guide for adding a new variant to the Op enum (e.g. Op::Tag, Op::Link). Covers every place that needs to change.
+argument-hint: <VariantName>
 ---
 
-Você quer adicionar `Op::$1` ao tree CRDT do outl. Checklist OBRIGATÓRIO:
+You want to add `Op::$1` to the outl tree CRDT. MANDATORY checklist:
 
-## 1. Definir a variante em `crates/outl-core/src/op.rs`
+## 1. Define the variant in `crates/outl-core/src/op.rs`
 
 ```rust
 $1 {
     node: NodeId,
-    // ... campos da op
-    // CRÍTICO: incluir campos `old_*` pra undo.
-    // Sem old_*, undo_op não consegue reverter.
+    // ... op fields
+    // CRITICAL: include `old_*` fields for undo.
+    // Without old_*, undo_op cannot revert.
 }
 ```
 
-## 2. Implementar `do_op` em `crates/outl-core/src/tree.rs`
+## 2. Implement `do_op` in `crates/outl-core/src/tree.rs`
 
-- Preencher `old_*` no `LogOp` antes de aplicar mutação.
-- Se a op pode violar invariante (ciclo, etc), checar primeiro e tratar como no-op materialização (mas a op vai pro log).
+- Fill `old_*` in the `LogOp` before applying the mutation.
+- If the op can violate an invariant (cycle, etc), check first and treat as a no-op on materialization (but the op still goes to the log).
 
-## 3. Implementar `undo_op`
+## 3. Implement `undo_op`
 
-- Reverter usando os campos `old_*` do `LogOp`.
-- Idempotência: undo de op nunca aplicada deve ser no-op.
+- Revert using the `old_*` fields of the `LogOp`.
+- Idempotency: undo of an op that was never applied must be a no-op.
 
-## 4. Atualizar serialização
+## 4. Update serialization
 
-- Verificar que serde derive já cobre. Se houver campo binário, garantir base64 ou bincode.
-- Adicionar conversão pra schema SQLite em `storage/sqlite.rs` se a op tem campos extras.
+- Verify that serde derive already covers it. If there's a binary field, ensure base64 or bincode.
+- Add conversion to the SQLite schema in `storage/sqlite.rs` if the op has extra fields.
 
-## 5. Testes obrigatórios (em `crates/outl-core/tests/`)
+## 5. Mandatory tests (in `crates/outl-core/tests/`)
 
-- Convergência: 3 réplicas aplicam a op em ordens diferentes → mesmo estado final.
-- Idempotência: aplicar 2x = aplicar 1x.
-- Reordering: op chegando atrasada força undo/replay correto.
-- Interação com `Move`: op concorrente com Move do mesmo nó converge.
+- Convergence: 3 replicas apply the op in different orders → same final state.
+- Idempotency: applying 2x = applying 1x.
+- Reordering: a late-arriving op forces a correct undo/replay.
+- Interaction with `Move`: an op concurrent with a Move on the same node converges.
 
-## 6. Documentar em `docs/crdt.md`
+## 6. Document in `docs/crdt.md`
 
-- Adicionar parágrafo na seção "Operations" descrevendo semântica.
-- Adicionar exemplo de caso concorrente se a op tem interação não-óbvia.
+- Add a paragraph in the "Operations" section describing semantics.
+- Add a concurrent example if the op has non-obvious interactions.
 
-## 7. Pre-flight antes de PR
+## 7. Pre-flight before PR
 
 - [ ] `cargo fmt`
 - [ ] `cargo clippy -- -D warnings`
 - [ ] `cargo test -p outl-core`
-- [ ] Cobertura 100% nas branches novas de `do_op`/`undo_op`
-- [ ] Invocar agent `crdt-invariant-checker`
-- [ ] Invocar agent `paper-verifier` se a op tem analogo no paper
+- [ ] 100% coverage on the new branches in `do_op`/`undo_op`
+- [ ] Invoke the `crdt-invariant-checker` agent
+- [ ] Invoke the `paper-verifier` agent if the op has an analog in the paper
 
-**Não pule etapas.** Op nova que quebra convergência destrói confiança no outl.
+**Do not skip steps.** A new op that breaks convergence destroys trust in outl.

--- a/.claude/commands/roundtrip.md
+++ b/.claude/commands/roundtrip.md
@@ -1,5 +1,5 @@
 ---
-description: Roda bateria de roundtrip md ↔ ops do outl-md e dispara o markdown-roundtrip-tester pra validação adicional.
+description: Runs the md ↔ ops roundtrip battery for outl-md and triggers markdown-roundtrip-tester for extra validation.
 allowed-tools: Bash(cargo test:*)
 ---
 
@@ -7,6 +7,6 @@ allowed-tools: Bash(cargo test:*)
 cargo test -p outl-md
 ```
 
-Se tudo passar, invoque o agent `markdown-roundtrip-tester` pra rodar checagens adicionais (property tests, sidecar validity, orphan logging).
+If everything passes, invoke the `markdown-roundtrip-tester` agent for additional checks (property tests, sidecar validity, orphan logging).
 
-Se falhar, pare e mostre saída exata.
+If it fails, stop and show the exact output.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,15 @@ Invoke proactively when relevant:
   Compares Rust against paper pseudocode line by line.
 - **`markdown-roundtrip-tester`** — after any change in `outl-md/`.
   Validates roundtrip stability + matching invariants.
+- **`refactor-architect`** — after the file-size-guard hook fires
+  (stop at 900 lines, warn at 600). Proposes a split by responsibility.
+- **`doc-keeper`** — **invoke at the end of every feature** that
+  changes public API, markdown syntax, TUI shortcut, slash command,
+  sidecar/op-log format, or user-observable behavior. Walks
+  `docs/*.md`, root `CLAUDE.md`, and per-crate `CLAUDE.md`; updates
+  what drifted, creates only what was missing. **Rule of thumb:** if
+  you'd struggle to explain the change to a contributor reading only
+  the docs, this agent runs.
 
 ### Slash commands
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,6 +1410,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,6 +1910,16 @@ dependencies = [
  "hashbrown 0.16.1",
  "ordermap",
  "smallvec",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
 ]
 
 [[package]]
@@ -3101,6 +3138,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3268,6 +3378,7 @@ name = "outl-tui"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "arboard",
  "chrono",
  "clap",
  "crossterm",
@@ -6771,6 +6882,23 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xdg"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ the algorithm and the op-log infrastructure are already in.
   is standard CommonMark bullets. No metadata smuggled in.
 - **Page icons** — `icon:: 🚀` on a page surfaces everywhere it's
   referenced (header, switcher, backlinks panel, `[[ref]]` inline).
+- **Block references and embeds** — `((blk-XXXXXX))` resolves inline
+  to the source block's text + page icon. `!((blk-XXXXXX))` expands
+  the source block **and its children** read-only below the carrying
+  block (each row prefixed with `↳ `, children indented to align with
+  the source's text). `Enter` on any handle jumps to the source page
+  and lands the cursor on the referenced block. Short, deterministic,
+  sidecar-backed handles — the `.md` stays human-typeable. `((` in
+  Insert mode pops a fuzzy-match autocomplete; `y r` (or `/refer` /
+  `/refer-embed`) copies the current block's handle to the OS
+  clipboard for paste anywhere.
 - **Code blocks that run** — ` ```lisp / ```js / ```python / ```lua /
   ```rust `, the result lands as a `> **result:**` subblock under
   the source. Re-runs are idempotent. Set `auto-run::` on a block

--- a/crates/outl-cli/CLAUDE.md
+++ b/crates/outl-cli/CLAUDE.md
@@ -20,7 +20,16 @@ library and a binary). Don't fork the TUI logic into the CLI.
 - `outl serve [<path>] [--once]` — run file watcher; `--once` reconciles
   every `.md` and exits (smoke tests, scripting).
 - `outl export --to <fmt>` — placeholder for phase 4 (Hugo, etc).
-- `outl doctor [<path>]` — integrity check (sidecar vs op log, orphans).
+- `outl doctor [<path>]` — integrity check. Reports:
+  1. SQLite `PRAGMA integrity_check` on the op log.
+  2. Sidecar versions inside the readable range (warns on out-of-range).
+  3. Orphan sidecars (sidecar with no matching `.md`).
+  4. Orphan block references — every `((blk-XXXXXX))` **and**
+     `!((blk-XXXXXX))` embed whose handle fails
+     `WorkspaceIndex::resolve_block_ref`, with the citing page. The
+     check accepts a pre-built `WorkspaceIndex` internally so callers
+     that already have one don't pay to rebuild it.
+  Read-only; emits warnings + errors and exits with the right code.
 - `outl reconcile [<path>]` — list orphans pending manual resolution.
 
 ## Layout

--- a/crates/outl-cli/src/cmd/doctor.rs
+++ b/crates/outl-cli/src/cmd/doctor.rs
@@ -6,6 +6,8 @@
 use crate::workspace_layout::{read_config, Paths};
 use anyhow::{Context, Result};
 use outl_core::storage::{SqliteStorage, Storage};
+use outl_md::index::WorkspaceIndex;
+use outl_md::inline::{tokenize, InlineTok};
 use outl_md::sidecar::{self, sidecar_path_for};
 use std::collections::HashSet;
 use std::path::Path;
@@ -114,7 +116,18 @@ pub fn run(path: &Path) -> Result<()> {
         check_orphan_sidecars(&mut f, &sidecar_files, &md_files);
     }
 
-    // 4. Orphan log presence (informational).
+    // 4. Block ref integrity — every `((blk-XXXXXX))` mentioned in a
+    //    block's text must resolve to an indexed block. Orphans show
+    //    up here so the user can clean them up before they ship a
+    //    broken link to another device.
+    //
+    // Build the workspace index ONCE and pass it down — the previous
+    // implementation built it locally inside the check, paying the
+    // full scan twice on every doctor run.
+    let workspace_index = WorkspaceIndex::build(&paths.root);
+    check_orphan_block_refs(&mut f, &workspace_index);
+
+    // 5. Orphan log presence (informational).
     if paths.orphans.exists() {
         let bytes = std::fs::metadata(&paths.orphans)
             .map(|m| m.len())
@@ -126,7 +139,7 @@ pub fn run(path: &Path) -> Result<()> {
         }
     }
 
-    // 5. Lock file warning if held by something else (we can't acquire it).
+    // 6. Lock file warning if held by something else (we can't acquire it).
     match outl_core::WorkspaceLock::acquire(&paths.root) {
         Ok(_lock) => f.ok("workspace lock is free (no other outl process attached)"),
         Err(outl_core::LockError::AlreadyHeld(_)) => {
@@ -197,6 +210,39 @@ fn check_md_files(
                 f.err(format!("{}: sidecar unreadable: {e}", md.display()));
             }
         }
+    }
+}
+
+/// Walk every indexed block, tokenize its text, and warn for every
+/// `((blk-XXXXXX))` or `!((blk-XXXXXX))` whose handle doesn't resolve
+/// to an indexed block.
+///
+/// Surfaces the citing page so the user can navigate straight to the
+/// broken reference. Lookup is O(1) per handle via
+/// [`WorkspaceIndex::resolve_block_ref`], so total cost is linear in
+/// the number of inline block refs across the workspace. Takes the
+/// pre-built index from the caller so doctor doesn't pay for a
+/// duplicate workspace scan.
+fn check_orphan_block_refs(f: &mut Findings, idx: &WorkspaceIndex) {
+    let mut orphans = 0usize;
+    for block in idx.iter_blocks() {
+        for tok in tokenize(&block.text) {
+            let handle = match tok {
+                InlineTok::BlockRef { handle } | InlineTok::Embed { handle } => handle,
+                _ => continue,
+            };
+            if idx.resolve_block_ref(handle).is_none() {
+                orphans += 1;
+                f.warn(format!(
+                    "{}: orphan block ref (({})) — source block missing or not indexed",
+                    block.source_path.display(),
+                    handle
+                ));
+            }
+        }
+    }
+    if orphans == 0 {
+        f.ok("no orphan ((blk-XXXXXX)) references");
     }
 }
 

--- a/crates/outl-cli/src/cmd/doctor.rs
+++ b/crates/outl-cli/src/cmd/doctor.rs
@@ -227,22 +227,25 @@ fn check_orphan_block_refs(f: &mut Findings, idx: &WorkspaceIndex) {
     let mut orphans = 0usize;
     for block in idx.iter_blocks() {
         for tok in tokenize(&block.text) {
-            let handle = match tok {
-                InlineTok::BlockRef { handle } | InlineTok::Embed { handle } => handle,
+            // Keep the literal form (`((handle))` vs `!((handle))`) so
+            // the user can grep for it in the source page exactly.
+            let (handle, literal) = match tok {
+                InlineTok::BlockRef { handle } => (handle, format!("(({handle}))")),
+                InlineTok::Embed { handle } => (handle, format!("!(({handle}))")),
                 _ => continue,
             };
             if idx.resolve_block_ref(handle).is_none() {
                 orphans += 1;
                 f.warn(format!(
-                    "{}: orphan block ref (({})) — source block missing or not indexed",
+                    "{}: orphan block ref {} — source block missing or not indexed",
                     block.source_path.display(),
-                    handle
+                    literal,
                 ));
             }
         }
     }
     if orphans == 0 {
-        f.ok("no orphan ((blk-XXXXXX)) references");
+        f.ok("no orphan ((blk-XXXXXX)) / !((blk-XXXXXX)) references");
     }
 }
 

--- a/crates/outl-cli/tests/e2e_full.rs
+++ b/crates/outl-cli/tests/e2e_full.rs
@@ -50,16 +50,25 @@ fn full_workspace_lifecycle() {
     assert!(sidecar_path.exists(), "sidecar must exist after serve");
     let sidecar_text = fs::read_to_string(&sidecar_path).unwrap();
     let sidecar: serde_json::Value = serde_json::from_str(&sidecar_text).unwrap();
-    assert_eq!(sidecar["version"], 1);
+    assert_eq!(sidecar["version"], 2);
     let blocks = sidecar["blocks"].as_array().expect("blocks array");
     // Two top-level + one nested. `priority:: high` is a property, not a block.
     assert_eq!(blocks.len(), 3, "expected 3 blocks in sidecar");
-    // Each block must have a ULID-looking id and a content hash.
+    // Each block must have a ULID-looking id, a content hash, and a v2
+    // `ref_handle` of the form `blk-XXXXXX` (lowercase tail).
     for b in blocks {
         let id = b["id"].as_str().unwrap();
         let hash = b["content_hash"].as_str().unwrap();
+        let handle = b["ref_handle"].as_str().expect("ref_handle on v2 block");
         assert_eq!(id.len(), 26, "ULID should be 26 chars, got {id}");
         assert!(hash.starts_with("sha256:"));
+        assert!(handle.starts_with("blk-"), "handle prefix: {handle}");
+        assert_eq!(handle.len(), "blk-".len() + 6, "handle length: {handle}");
+        assert_eq!(
+            handle,
+            handle.to_lowercase(),
+            "handle must be lowercase: {handle}"
+        );
     }
 
     // 5. assertions on the .md — must stay CLEAN (no id::, no UUIDs)

--- a/crates/outl-md/CLAUDE.md
+++ b/crates/outl-md/CLAUDE.md
@@ -11,17 +11,52 @@ same paranoia as the CRDT.
 
 - Parse `.md` (clean, no IDs) → outline AST
 - Render outline AST → `.md` (clean, no IDs)
-- Read/write `.outl` sidecar (JSON, dotfile)
+- Read/write `.outl` sidecar (JSON, dotfile) — current version `2`,
+  reads v1 transparently (handles backfilled on load)
 - The 3-level matching algorithm (external edit → reconstruct IDs)
-- Diff (old AST + new AST) → minimal sequence of `Op`s
+- Diff (old AST + new AST + old sidecar blocks) → minimal sequence of
+  `Op`s, preserving `ref_handle` verbatim on level-1/2 matches. The
+  old-handle lookup is O(N) overall (HashMap by id), not O(N²) — never
+  reintroduce a linear scan per new block.
 - **Inline tokenization** (`inline.rs`) — `**bold**`, `[[refs]]`,
-  `#tags`, etc — and `ref_at_cursor`. **UI-agnostic.** TUI, future
-  Tauri GUI, and mobile clients all consume the same `InlineTok` /
-  `RefTarget` types and map them to their own primitives (`Span`,
-  HTML, `AttributedString`, `AnnotatedString`).
+  `#tags`, `((blk-XXXXXX))`, `!((blk-XXXXXX))` — and `ref_at_cursor`
+  (resolves to `RefTarget::Page`, `Journal`, `Tag`, or `Block`).
+  **UI-agnostic.** TUI, future Tauri GUI, and mobile clients all
+  consume the same `InlineTok` / `RefTarget` types and map them to
+  their own primitives (`Span`, HTML, `AttributedString`,
+  `AnnotatedString`).
+- **Block index** (`block_index.rs`) — `NodeId → BlockEntry`,
+  `ref_handle → NodeId`, `NodeId → [BlockReference]` (reverse refs),
+  `(slug, dfs_path) → NodeId` for location lookup. Population is
+  two-phase (`collect_page_blocks` then `collect_page_refs`) so reverse
+  edges survive arbitrary page-load order during the initial build.
+  Lookups are O(1).
+- **Workspace index** (`index.rs`) — page-level (`slug → PageEntry`,
+  backlinks) plus block-level (re-exports the `BlockIndex` API).
+  Public surface includes `resolve_block_ref(handle)`, `block_by_id`,
+  `block_at_location(slug, &[usize])`, `block_refs_to(id)`,
+  `iter_blocks`, `block_count`, `search_block_text(query, limit)`.
+  `block_at_location` is the O(1) replacement for scanning
+  `iter_blocks()` to find the entry for a known `(page, dfs_path)`,
+  e.g. when the TUI translates a keyboard chord onto a specific block.
 - **Slugify** (`slug.rs`) — `[[Avelino]]` → `pages/avelino.md`. The
   user-facing name is preserved verbatim in the page's `title::`
   property.
+- **`derive_ref_handle(NodeId) -> String`** (`sidecar.rs`) —
+  deterministic: `blk-` + last 6 chars of the ULID's Crockford base32,
+  lowercased. Same input always yields the same handle so two devices
+  agree on what `((blk-XXXXXX))` means. On a collision inside a single
+  workspace, the **second** block to land gets its handle lazily
+  expanded one character at a time (drawing from the same ULID tail)
+  until unique — both the winner and the loser stay independently
+  resolvable. The sidecar still records the deterministic 6-char form;
+  the expanded handle lives in `BlockEntry.ref_handle` in memory and
+  in the workspace handle map.
+- **`BlockEntry.text_fold: String`** — lowercased cache of the block's
+  `text`, populated at index build. Powers `search_block_text` without
+  allocating per keystroke. Public field, but consumers must not build
+  `BlockEntry` by hand — go through the index population path so
+  `text_fold` stays consistent with `text`.
 
 ## What this crate does NOT own
 
@@ -49,24 +84,38 @@ before being deleted. **Silent deletion is a P0 bug.**
 
 ## Sidecar format
 
+Current version: `2`. Full spec in
+[`docs/markdown-format.md`](../../docs/markdown-format.md#the-outl-sidecar).
+
 ```json
 {
-  "version": 1,
+  "version": 2,
   "page_id": "01HXY8KJZQ9T8M7VN3P2R6S4A0",
   "last_synced_hash": "sha256:...",
+  "last_synced_at": "2026-05-24T11:22:00-03:00",
   "blocks": [
     {
       "id": "01HXY8KJZQ9T8M7VN3P2R6S4A1",
       "line": 1,
       "indent": 0,
-      "content_hash": "sha256:..."
+      "content_hash": "sha256:...",
+      "ref_handle": "blk-r6s4a1"
     }
   ]
 }
 ```
 
 - `content_hash` = SHA-256 of the **block's textual content** (not children).
+- `ref_handle` = short user-typeable handle for `((blk-XXXXXX))`. v1
+  sidecars (no field) load fine — the handle is backfilled in memory
+  via `derive_ref_handle`. The next write persists v2. On collision,
+  expansion may produce a 7+ char form (see `derive_ref_handle` above).
 - Sidecar is replicated between devices alongside the `.md`. Don't gitignore by default.
+- **Stale entries are skipped during index build.** When a sidecar
+  block's `content_hash` no longer matches the corresponding block in
+  the `.md`, that entry is left out of the workspace index instead of
+  polluting it with a wrong subtree. The block reappears in the index
+  after the next reconcile updates the sidecar.
 
 ## Outl markdown dialect
 
@@ -78,7 +127,8 @@ tags:: #project
 - top level block
   priority:: high
   - child block with [[page reference]]
-  - child block with ((block-reference))
+  - child block with ((blk-r6s4a1))
+  - expanded inline: !((blk-r6s4a1))
 - another top level
 ```
 
@@ -87,7 +137,8 @@ tags:: #project
 - `[[name]]` = page reference (bidirectional link).
 - `[[2026-05-24]]` = journal reference (renders as date).
 - `#tag` = tag (page reference with classification semantics).
-- `((block-id))` = block embed (shows content of referenced block).
+- `((blk-XXXXXX))` = inline block reference (renders as the source block's text).
+- `!((blk-XXXXXX))` = block embed (renders source block expanded with subtree).
 - `{{query: ...}}` = saved query (phase 3, parse as opaque for now).
 
 **No `id::`, no UUID, no HTML comments** — IDs go in the sidecar only.
@@ -97,19 +148,41 @@ tags:: #project
 ```
 src/
 ├── lib.rs
-├── parse.rs       # md → AST (no IDs)
-├── render.rs      # AST → md (clean)
-├── sidecar.rs     # read/write .outl JSON
-├── matching.rs    # 3-level matching algorithm
-└── diff.rs        # AST diff → Op sequence
+├── parse.rs        # md → AST (no IDs)
+├── render.rs       # AST → md (clean)
+├── sidecar.rs      # read/write .outl JSON, derive_ref_handle, content_hash
+├── matching.rs     # 3-level matching algorithm
+├── diff.rs         # AST diff → Op sequence (takes old_blocks to preserve ref_handle)
+├── inline.rs       # InlineTok (Plain/Bold/.../BlockRef/Embed), RefTarget, ref_at_cursor
+├── index.rs        # WorkspaceIndex — page-level + block-level facade
+├── block_index.rs  # BlockEntry, BlockReference, BlockIndex (id ↔ handle ↔ reverse refs)
+├── reconcile.rs    # high-level reconcile_md (parse → match → diff → apply)
+├── slug.rs         # slugify page names
+├── view.rs         # render helpers consumed by UIs
+└── atomic.rs       # crash-safe write_atomic
 
 tests/
-├── roundtrip.rs           # render(parse(md)) == md (property test)
-├── external_edit.rs       # light external edit preserves IDs
-├── duplicate_block.rs     # Ctrl+D in vscode → first keeps ID, second gets new
-├── identical_blocks_swap.rs # two identical blocks change parents
-└── heavy_edit.rs          # >20% content change → level 2 warning
+├── roundtrip.rs              # render(parse(md)) == md (property test)
+├── external_edit.rs          # light external edit preserves IDs
+├── duplicate_block.rs        # Ctrl+D in vscode → first keeps ID, second gets new
+├── identical_blocks_swap.rs  # two identical blocks change parents
+└── heavy_edit.rs             # >20% content change → level 2 warning
+
+benches/
+└── block_index.rs            # resolve / search_block_text on 100k blocks
 ```
+
+## Bench harness
+
+`cargo bench -p outl-md --bench block_index` measures the cost the
+`((blk-XXXXXX))` path adds to the index. Today's numbers (M-series
+laptop):
+
+- `resolve(handle)` — ~17 ns at 100k indexed blocks. O(1) HashMap hit.
+- `search_block_text(query, limit)` — ~12 ms at 100k blocks (linear
+  scan with case-fold + position scoring). Suitable for the
+  autocomplete popup the TUI uses today; future fzf-style scoring can
+  drop in behind the same signature.
 
 ## Invariants
 
@@ -119,6 +192,14 @@ tests/
 3. **Sidecar is JSON-valid.** Always. If you can't write valid JSON, you fail.
 4. **Sidecar `version` field always present.** Future migrations.
 5. **`content_hash`** is `sha256(block.content_text())` consistently. Same hash function across read and write.
+6. **`ref_handle` is preserved across level-1 and level-2 matches.**
+   `diff_to_ops` reads it from the previous sidecar's block list and
+   reuses it verbatim, so a `((blk-XXXXXX))` already written in
+   another `.md` keeps resolving even if the handle was once expanded
+   past the default 6-char tail.
+7. **`derive_ref_handle` is deterministic** — same `NodeId` in, same
+   handle out. Two devices building the sidecar independently must
+   agree on what `((blk-XXXXXX))` means.
 
 ## Things to never do here
 

--- a/crates/outl-md/Cargo.toml
+++ b/crates/outl-md/Cargo.toml
@@ -40,3 +40,8 @@ path = "benches/index.rs"
 name = "parse"
 harness = false
 path = "benches/parse.rs"
+
+[[bench]]
+name = "block_index"
+harness = false
+path = "benches/block_index.rs"

--- a/crates/outl-md/benches/block_index.rs
+++ b/crates/outl-md/benches/block_index.rs
@@ -1,0 +1,97 @@
+//! Benchmarks for the block-level index — `resolve_block_ref` lookup
+//! and `search_block_text` autocomplete on synthetic workspaces of the
+//! sizes target by `#12` (10k pages, 100k blocks).
+//!
+//! Run:
+//! ```text
+//! cargo bench -p outl-md --bench block_index
+//! ```
+//!
+//! The contract `#12` validates: lookup stays under 1ms P99 even at
+//! 100k indexed blocks. Anything significantly above that suggests
+//! a regression in the HashMap path or that something now does
+//! linear work where O(1) was promised.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use outl_core::id::NodeId;
+use outl_md::block_index::BlockIndex;
+use outl_md::parse::OutlineNode;
+use outl_md::sidecar::{content_hash, derive_ref_handle, SidecarBlock};
+use std::hint::black_box;
+use std::path::PathBuf;
+
+/// Build a `BlockIndex` populated with `n` blocks spread across
+/// `pages_count` synthetic pages — closer to real workspace shape
+/// than a single page with N children would be.
+fn build_index(blocks_total: usize, pages_count: usize) -> (BlockIndex, Vec<String>) {
+    let mut idx = BlockIndex::default();
+    let mut handles = Vec::with_capacity(blocks_total);
+    let per_page = blocks_total.div_ceil(pages_count);
+    for p in 0..pages_count {
+        let slug = format!("page-{p}");
+        let path = PathBuf::from(format!("pages/{slug}.md"));
+        let mut ast: Vec<OutlineNode> = Vec::with_capacity(per_page);
+        let mut sidecar: Vec<SidecarBlock> = Vec::with_capacity(per_page);
+        for b in 0..per_page {
+            if handles.len() >= blocks_total {
+                break;
+            }
+            let id = NodeId::new();
+            let text = format!("page {p} block {b} — decide backend item");
+            let handle = derive_ref_handle(id);
+            handles.push(handle.clone());
+            sidecar.push(SidecarBlock {
+                id,
+                line: b + 1,
+                indent: 0,
+                content_hash: content_hash(&text),
+                ref_handle: handle,
+            });
+            ast.push(OutlineNode {
+                text,
+                properties: Vec::new(),
+                children: Vec::new(),
+            });
+        }
+        idx.collect_page_blocks(&slug, &path, &ast, &sidecar);
+    }
+    (idx, handles)
+}
+
+fn bench_resolve(c: &mut Criterion) {
+    let mut group = c.benchmark_group("block_index_resolve");
+    for &n in &[1_000usize, 10_000, 100_000] {
+        let pages = (n / 10).max(1);
+        let (idx, handles) = build_index(n, pages);
+        let target = handles[handles.len() / 2].clone();
+        group.bench_with_input(BenchmarkId::from_parameter(n), &target, |bencher, t| {
+            bencher.iter(|| {
+                let e = idx.resolve(black_box(t));
+                black_box(e);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_search(c: &mut Criterion) {
+    let mut group = c.benchmark_group("block_index_search");
+    // Search costs scale with workspace size; cap samples on the
+    // large variant so the bench finishes in under a minute on a
+    // dev laptop.
+    group.sample_size(30);
+    for &n in &[1_000usize, 10_000, 100_000] {
+        let pages = (n / 10).max(1);
+        let (idx, _) = build_index(n, pages);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &"backend", |bencher, q| {
+            bencher.iter(|| {
+                let hits = idx.search_text(black_box(q), 8);
+                black_box(hits);
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_resolve, bench_search);
+criterion_main!(benches);

--- a/crates/outl-md/src/block_index.rs
+++ b/crates/outl-md/src/block_index.rs
@@ -295,15 +295,19 @@ impl BlockIndex {
                     } else {
                         sb.ref_handle.clone()
                     };
-                    let handle = self.unique_handle(sb.id, &base_handle);
 
+                    // Insert the BlockEntry first (with a placeholder
+                    // handle) so `assign_handle` can patch a displaced
+                    // owner's `ref_handle` even when that displaced
+                    // owner is the same block being inserted right
+                    // now (re-index path).
                     let text = b.text.clone();
                     let text_fold = text.to_lowercase();
                     self.blocks.insert(
                         sb.id,
                         BlockEntry {
                             id: sb.id,
-                            ref_handle: handle.clone(),
+                            ref_handle: base_handle.clone(),
                             source_slug: source_slug.to_string(),
                             source_path: source_path.to_path_buf(),
                             source_block_path: path_stack.clone(),
@@ -312,7 +316,10 @@ impl BlockIndex {
                             children: b.children.clone(),
                         },
                     );
-                    self.handle_to_block.insert(handle, sb.id);
+                    let final_handle = self.assign_handle(sb.id, base_handle);
+                    if let Some(entry) = self.blocks.get_mut(&sb.id) {
+                        entry.ref_handle = final_handle;
+                    }
                     self.pages
                         .entry(source_slug.to_string())
                         .or_default()
@@ -334,18 +341,48 @@ impl BlockIndex {
         }
     }
 
-    /// Return a handle that's unique within the index — `base_handle`
-    /// itself when it isn't claimed by a *different* id, otherwise the
-    /// next-longer ULID tail until uniqueness is reached.
+    /// Assign a final handle to `id` and update `handle_to_block`.
     ///
-    /// Same id reclaiming its own handle (re-indexing path) is allowed
-    /// and returns `base_handle` unchanged.
-    fn unique_handle(&self, id: NodeId, base_handle: &str) -> String {
-        match self.handle_to_block.get(base_handle) {
-            Some(&owner) if owner == id => return base_handle.to_string(),
-            None => return base_handle.to_string(),
-            Some(_) => {} // genuine collision, fall through to expansion
+    /// Determinism: when `base_handle` is already taken by a different
+    /// block, the **smaller** `NodeId` (ULIDs sort lexicographically
+    /// by creation time) keeps the base handle and the bigger one is
+    /// expanded. Same outcome regardless of which device — or which
+    /// workspace traversal order — first observed the collision.
+    ///
+    /// If `id` itself displaces the current owner, that owner's
+    /// `BlockEntry.ref_handle` is rewritten in place so the new
+    /// expanded form propagates everywhere it's read from.
+    fn assign_handle(&mut self, id: NodeId, base_handle: String) -> String {
+        match self.handle_to_block.get(&base_handle).copied() {
+            Some(owner) if owner == id => base_handle,
+            None => {
+                self.handle_to_block.insert(base_handle.clone(), id);
+                base_handle
+            }
+            Some(owner) if id < owner => {
+                // `id` wins the base; current owner is dethroned.
+                let owner_expanded = self.next_unused_expansion(owner, &base_handle);
+                if let Some(entry) = self.blocks.get_mut(&owner) {
+                    entry.ref_handle = owner_expanded.clone();
+                }
+                self.handle_to_block.remove(&base_handle);
+                self.handle_to_block.insert(owner_expanded, owner);
+                self.handle_to_block.insert(base_handle.clone(), id);
+                base_handle
+            }
+            Some(_) => {
+                // `id` is bigger; existing owner keeps the base.
+                let expanded = self.next_unused_expansion(id, &base_handle);
+                self.handle_to_block.insert(expanded.clone(), id);
+                expanded
+            }
         }
+    }
+
+    /// Smallest expanded handle (tail length > [`REF_HANDLE_TAIL_LEN`])
+    /// for `id` that isn't already owned by a different block. Used as
+    /// the displaced / losing side of a collision in [`assign_handle`].
+    fn next_unused_expansion(&self, id: NodeId, _base: &str) -> String {
         let ulid_str = id.to_string();
         let total = ulid_str.chars().count();
         for tail_len in (REF_HANDLE_TAIL_LEN + 1)..=total {

--- a/crates/outl-md/src/block_index.rs
+++ b/crates/outl-md/src/block_index.rs
@@ -1,0 +1,401 @@
+//! Block-level index — the lookup machinery behind `((blk-XXXXXX))`
+//! inline references and `!((blk-XXXXXX))` embeds.
+//!
+//! Lives next to [`crate::index`] rather than inside it so neither
+//! module owns more than one responsibility. The page-level index
+//! (`slug → PageEntry`, backlinks) stays in `index.rs`; this file owns:
+//!
+//! - `NodeId → BlockEntry` (the canonical "where does this block live
+//!   and what does it contain").
+//! - `ref_handle → NodeId` (resolution path for `((blk-XXXXXX))`).
+//! - `NodeId → [BlockReference]` (reverse: who cites a given block).
+//! - `(slug, dfs_path) → NodeId` (reverse location lookup for the
+//!   TUI's `yr` chord and `/refer` commands, kept O(1) per keystroke).
+//! - `slug → Vec<NodeId>` (per-page block list so `forget_page` runs
+//!   O(blocks_in_page) instead of O(workspace_blocks)).
+//!
+//! Population happens in [`BlockIndex::collect_page`], invoked once per
+//! `.md` (whether on full build or after a single-page save). Lookups
+//! are pure HashMap reads so they stay O(1) regardless of workspace
+//! size — the contract that bench #12 validates.
+//!
+//! ## Handle collision handling
+//!
+//! The 6-char tail of a ULID has ~1B values, so collisions are
+//! astronomically rare but not impossible. On insert, if the base
+//! handle is already taken by a *different* id, the new block's
+//! handle is lazily expanded one character at a time until it's
+//! unique within the workspace. Both the surviving entry and the
+//! expanded loser are resolvable via their (now distinct) handles;
+//! `outl doctor` surfaces the expansion so the user can rerun
+//! reconcile to persist the expanded handle in the sidecar.
+
+use crate::inline::{tokenize, InlineTok};
+use crate::parse::OutlineNode;
+use crate::sidecar::{self, content_hash, SidecarBlock, REF_HANDLE_PREFIX, REF_HANDLE_TAIL_LEN};
+use outl_core::id::NodeId;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// One indexed block. Carries enough context that
+/// `WorkspaceIndex::resolve_block_ref` (see `crate::index`) can return
+/// it directly — no follow-up disk read needed for the common path.
+///
+/// `children` is a clone of the block's subtree (same shape used by
+/// [`crate::index::Backlink`]). The cost is bounded: one clone per
+/// indexed block, not one per reference. For an embed surface, the
+/// consumer renders `text` + `children` exactly as the source page
+/// would.
+#[derive(Debug, Clone)]
+pub struct BlockEntry {
+    /// Block's stable ULID.
+    pub id: NodeId,
+    /// Short ref handle (`blk-XXXXXX`). May be 7+ characters when a
+    /// collision forced lazy expansion at index time.
+    pub ref_handle: String,
+    /// Slug of the page hosting the block.
+    pub source_slug: String,
+    /// Filesystem path of the hosting `.md`.
+    pub source_path: PathBuf,
+    /// DFS path inside the source page's AST.
+    pub source_block_path: Vec<usize>,
+    /// Block text at index time. Used as the inline-resolved text
+    /// when a `((blk-XXXXXX))` is rendered.
+    pub text: String,
+    /// Lowercased copy of `text`. Cached so
+    /// [`BlockIndex::search_text`] doesn't reallocate per block on
+    /// every autocomplete keystroke.
+    pub text_fold: String,
+    /// Cloned subtree under this block — used by embed surfaces.
+    pub children: Vec<OutlineNode>,
+}
+
+/// One reverse edge: somebody cites the block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockReference {
+    /// Slug of the citing page.
+    pub source_slug: String,
+    /// DFS path of the citing block inside its page's AST.
+    pub source_block_path: Vec<usize>,
+}
+
+/// Container for the block-level maps.
+///
+/// Lives behind [`crate::index::WorkspaceIndex`] so consumers see one
+/// index, not two.
+#[derive(Debug, Default, Clone)]
+pub struct BlockIndex {
+    blocks: HashMap<NodeId, BlockEntry>,
+    handle_to_block: HashMap<String, NodeId>,
+    block_refs: HashMap<NodeId, Vec<BlockReference>>,
+    /// `slug → ids of blocks contributed by that page`. Lets
+    /// [`Self::forget_page`] iterate only the page's blocks instead of
+    /// scanning the whole workspace.
+    pages: HashMap<String, Vec<NodeId>>,
+    /// `(slug, dfs_path) → NodeId`. Lets the TUI resolve "the block at
+    /// my cursor" in O(1) (powers `yr` / `/refer` / `/refer-embed`).
+    location_to_block: HashMap<(String, Vec<usize>), NodeId>,
+}
+
+impl BlockIndex {
+    /// Look up a block by its short ref handle (`blk-XXXXXX`).
+    ///
+    /// O(1). Returns `None` for unknown handles, including orphaned
+    /// ones (block deleted but a `.md` still cites it) — that's the
+    /// signal `outl doctor` uses to flag the workspace.
+    pub fn resolve(&self, handle: &str) -> Option<&BlockEntry> {
+        let id = self.handle_to_block.get(handle)?;
+        self.blocks.get(id)
+    }
+
+    /// Look up a block by its `NodeId`. Used by the embed render path
+    /// once the handle has already been resolved.
+    pub fn get(&self, id: NodeId) -> Option<&BlockEntry> {
+        self.blocks.get(&id)
+    }
+
+    /// Look up a block by its location `(slug, dfs_path)` — O(1).
+    ///
+    /// Used by `yank_current_ref` / `yank_current_embed` so the
+    /// keyboard chord stays snappy regardless of workspace size.
+    pub fn at_location(&self, slug: &str, path: &[usize]) -> Option<&BlockEntry> {
+        // Tuple ownership is fine here: HashMap keys are owned so we
+        // must clone on lookup. The TUI calls this once per chord
+        // press, not per render frame.
+        let key = (slug.to_string(), path.to_vec());
+        let id = self.location_to_block.get(&key)?;
+        self.blocks.get(id)
+    }
+
+    /// Reverse refs: every block that cites `id` via `((blk-XXXXXX))`.
+    pub fn refs_to(&self, id: NodeId) -> &[BlockReference] {
+        self.block_refs
+            .get(&id)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
+    }
+
+    /// Total indexed blocks. Used by tests and bench #12.
+    pub fn block_count(&self) -> usize {
+        self.blocks.len()
+    }
+
+    /// Iterate every indexed block in unspecified order. Used by
+    /// autocomplete (`((` popup) to fuzzy-match on `text`.
+    pub fn iter_blocks(&self) -> impl Iterator<Item = &BlockEntry> {
+        self.blocks.values()
+    }
+
+    /// Find blocks whose text contains `query` (case-insensitive),
+    /// sorted by relevance heuristics, capped at `limit`.
+    ///
+    /// Scoring is deliberately simple:
+    ///   1. Prefer matches earlier in the string (prefix > middle).
+    ///   2. Tiebreak by shorter text (more specific blocks rank
+    ///      higher than long ones containing the query incidentally).
+    ///   3. Final tiebreak: NodeId (lexicographic, ULID-sortable) so
+    ///      autocomplete order stays deterministic across rebuilds.
+    ///
+    /// Uses the precomputed [`BlockEntry::text_fold`] so per-keystroke
+    /// cost stays O(blocks). The bench in `#12` measures the upper
+    /// bound; a fzf-style scorer can drop in later behind this
+    /// signature without affecting callers.
+    pub fn search_text(&self, query: &str, limit: usize) -> Vec<&BlockEntry> {
+        if query.is_empty() {
+            return Vec::new();
+        }
+        let needle = query.to_lowercase();
+        let mut hits: Vec<(&BlockEntry, usize)> = self
+            .blocks
+            .values()
+            .filter_map(|b| b.text_fold.find(&needle).map(|pos| (b, pos)))
+            .collect();
+        hits.sort_by(|(a, ap), (b, bp)| {
+            ap.cmp(bp)
+                .then_with(|| a.text.len().cmp(&b.text.len()))
+                .then_with(|| a.id.cmp(&b.id))
+        });
+        hits.truncate(limit);
+        hits.into_iter().map(|(b, _)| b).collect()
+    }
+
+    /// Drop every entry contributed by `slug`. Used before
+    /// re-collecting a single page after a save.
+    ///
+    /// O(blocks_in_page) thanks to the `pages` secondary index — does
+    /// not scan the whole workspace.
+    pub fn forget_page(&mut self, slug: &str) {
+        let victims = self.pages.remove(slug).unwrap_or_default();
+        for id in &victims {
+            if let Some(entry) = self.blocks.remove(id) {
+                // Bug fix: only drop the handle entry if it points at
+                // *this* block. In a collision, the surviving block
+                // owns the base handle; removing it would unresolve
+                // refs to a block we never owned in the first place.
+                if self.handle_to_block.get(&entry.ref_handle) == Some(id) {
+                    self.handle_to_block.remove(&entry.ref_handle);
+                }
+                self.location_to_block
+                    .remove(&(entry.source_slug.clone(), entry.source_block_path.clone()));
+            }
+        }
+        for list in self.block_refs.values_mut() {
+            list.retain(|r| r.source_slug != slug);
+        }
+        self.block_refs.retain(|_, v| !v.is_empty());
+    }
+
+    /// One-shot page indexing — populates blocks, handles **and**
+    /// reverse refs in a single call.
+    ///
+    /// Safe to use after the initial build has finished: every cited
+    /// handle that exists somewhere in the workspace is already in
+    /// `handle_to_block`, so reverse-edge resolution works on the
+    /// first walk. During the initial build, where pages are loaded
+    /// in arbitrary order, use the two-phase variants
+    /// ([`collect_page_blocks`](Self::collect_page_blocks) +
+    /// [`collect_page_refs`](Self::collect_page_refs)) so a citing
+    /// page processed before its target still records its edge.
+    pub fn collect_page(
+        &mut self,
+        source_slug: &str,
+        source_path: &Path,
+        blocks: &[OutlineNode],
+        sidecar_blocks: &[SidecarBlock],
+    ) {
+        self.collect_page_blocks(source_slug, source_path, blocks, sidecar_blocks);
+        self.collect_page_refs(source_slug, blocks, sidecar_blocks);
+    }
+
+    /// Phase 1 of the two-phase build: register every block of a page
+    /// (id, handle, text, subtree) without touching reverse refs.
+    pub fn collect_page_blocks(
+        &mut self,
+        source_slug: &str,
+        source_path: &Path,
+        blocks: &[OutlineNode],
+        sidecar_blocks: &[SidecarBlock],
+    ) {
+        let mut cursor = 0usize;
+        let mut path_stack: Vec<usize> = Vec::new();
+        self.walk_blocks(
+            blocks,
+            sidecar_blocks,
+            &mut cursor,
+            &mut path_stack,
+            source_slug,
+            source_path,
+        );
+    }
+
+    /// Phase 2 of the two-phase build: scan every block's text for
+    /// `((blk-XXXXXX))` / `!((blk-XXXXXX))` and record the reverse
+    /// edge. Assumes [`collect_page_blocks`](Self::collect_page_blocks)
+    /// has already run for **every** page in the workspace —
+    /// otherwise edges to pages processed later would be missed.
+    pub fn collect_page_refs(
+        &mut self,
+        source_slug: &str,
+        blocks: &[OutlineNode],
+        sidecar_blocks: &[SidecarBlock],
+    ) {
+        let mut cursor = 0usize;
+        let mut path_stack: Vec<usize> = Vec::new();
+        self.walk_refs(
+            blocks,
+            sidecar_blocks,
+            &mut cursor,
+            &mut path_stack,
+            source_slug,
+        );
+    }
+
+    fn walk_blocks(
+        &mut self,
+        blocks: &[OutlineNode],
+        sidecar_blocks: &[SidecarBlock],
+        cursor: &mut usize,
+        path_stack: &mut Vec<usize>,
+        source_slug: &str,
+        source_path: &Path,
+    ) {
+        for (i, b) in blocks.iter().enumerate() {
+            path_stack.push(i);
+            if let Some(sb) = sidecar_blocks.get(*cursor) {
+                // Defensive: AST and sidecar must agree on this block
+                // (content_hash is the canonical equality check). On
+                // mismatch the sidecar is stale relative to the AST —
+                // a brand-new block typed in-editor before reconcile
+                // ran is the common cause. Skip the index entry; the
+                // next reconcile writes a fresh sidecar with the new
+                // block and the next build picks it up.
+                if sb.content_hash == content_hash(&b.text) {
+                    let base_handle = if sb.ref_handle.is_empty() {
+                        sidecar::derive_ref_handle(sb.id)
+                    } else {
+                        sb.ref_handle.clone()
+                    };
+                    let handle = self.unique_handle(sb.id, &base_handle);
+
+                    let text = b.text.clone();
+                    let text_fold = text.to_lowercase();
+                    self.blocks.insert(
+                        sb.id,
+                        BlockEntry {
+                            id: sb.id,
+                            ref_handle: handle.clone(),
+                            source_slug: source_slug.to_string(),
+                            source_path: source_path.to_path_buf(),
+                            source_block_path: path_stack.clone(),
+                            text,
+                            text_fold,
+                            children: b.children.clone(),
+                        },
+                    );
+                    self.handle_to_block.insert(handle, sb.id);
+                    self.pages
+                        .entry(source_slug.to_string())
+                        .or_default()
+                        .push(sb.id);
+                    self.location_to_block
+                        .insert((source_slug.to_string(), path_stack.clone()), sb.id);
+                }
+            }
+            *cursor += 1;
+            self.walk_blocks(
+                &b.children,
+                sidecar_blocks,
+                cursor,
+                path_stack,
+                source_slug,
+                source_path,
+            );
+            path_stack.pop();
+        }
+    }
+
+    /// Return a handle that's unique within the index — `base_handle`
+    /// itself when it isn't claimed by a *different* id, otherwise the
+    /// next-longer ULID tail until uniqueness is reached.
+    ///
+    /// Same id reclaiming its own handle (re-indexing path) is allowed
+    /// and returns `base_handle` unchanged.
+    fn unique_handle(&self, id: NodeId, base_handle: &str) -> String {
+        match self.handle_to_block.get(base_handle) {
+            Some(&owner) if owner == id => return base_handle.to_string(),
+            None => return base_handle.to_string(),
+            Some(_) => {} // genuine collision, fall through to expansion
+        }
+        let ulid_str = id.to_string();
+        let total = ulid_str.chars().count();
+        for tail_len in (REF_HANDLE_TAIL_LEN + 1)..=total {
+            let chars_taken: String = ulid_str
+                .chars()
+                .skip(total - tail_len)
+                .collect::<String>()
+                .to_lowercase();
+            let candidate = format!("{REF_HANDLE_PREFIX}{chars_taken}");
+            match self.handle_to_block.get(&candidate) {
+                Some(&owner) if owner == id => return candidate,
+                None => return candidate,
+                Some(_) => continue,
+            }
+        }
+        // Fallback: the whole ULID. Only reachable if every prefix
+        // length collides — pragmatically impossible for distinct ULIDs.
+        format!("{REF_HANDLE_PREFIX}{}", ulid_str.to_lowercase())
+    }
+
+    fn walk_refs(
+        &mut self,
+        blocks: &[OutlineNode],
+        sidecar_blocks: &[SidecarBlock],
+        cursor: &mut usize,
+        path_stack: &mut Vec<usize>,
+        source_slug: &str,
+    ) {
+        for (i, b) in blocks.iter().enumerate() {
+            path_stack.push(i);
+            if sidecar_blocks.get(*cursor).is_some() {
+                for tok in tokenize(&b.text) {
+                    let cited = match tok {
+                        InlineTok::BlockRef { handle } | InlineTok::Embed { handle } => handle,
+                        _ => continue,
+                    };
+                    if let Some(target_id) = self.handle_to_block.get(cited).copied() {
+                        self.block_refs
+                            .entry(target_id)
+                            .or_default()
+                            .push(BlockReference {
+                                source_slug: source_slug.to_string(),
+                                source_block_path: path_stack.clone(),
+                            });
+                    }
+                }
+            }
+            *cursor += 1;
+            self.walk_refs(&b.children, sidecar_blocks, cursor, path_stack, source_slug);
+            path_stack.pop();
+        }
+    }
+}

--- a/crates/outl-md/src/diff.rs
+++ b/crates/outl-md/src/diff.rs
@@ -14,7 +14,7 @@
 
 use crate::matching::{flatten, Match, MatchLevel};
 use crate::parse::OutlineNode;
-use crate::sidecar::{content_hash, Sidecar, SidecarBlock};
+use crate::sidecar::{content_hash, derive_ref_handle, Sidecar, SidecarBlock};
 use outl_core::fractional::Fractional;
 use outl_core::id::NodeId;
 use outl_core::op::Op;
@@ -37,12 +37,18 @@ pub struct DiffPlan {
 /// `page_id` is the root NodeId of the page (preserved across edits).
 /// `new_md_hash` is the SHA-256 of the new `.md` text (for the sidecar
 /// `last_synced_hash`).
+/// `old_blocks` is the previous sidecar's block list — used to **preserve
+/// existing `ref_handle`s** when a block matches at level 1 or 2. A
+/// preserved id keeps its handle verbatim (including a 7+ char tail if
+/// a past collision forced expansion), so any `((blk-XXXXXX))` already
+/// living in another `.md` keeps resolving.
 pub fn diff_to_ops(
     new_blocks: &[OutlineNode],
     matches: &[Match],
     orphans: &[NodeId],
     page_id: NodeId,
     new_md_hash: &str,
+    old_blocks: &[SidecarBlock],
 ) -> DiffPlan {
     let flat = flatten(new_blocks);
     assert_eq!(
@@ -62,6 +68,28 @@ pub fn diff_to_ops(
         })
         .collect();
 
+    // For each new block, decide which handle persists. Preserved
+    // blocks (level 1/2) keep the old sidecar's handle if present;
+    // newly minted blocks (level 3) derive a fresh one from their id.
+    //
+    // The pre-fix path did `.iter().find()` per block — O(N²) over
+    // pages with many blocks. A single HashMap pass up front keeps it
+    // O(N).
+    let old_by_id: std::collections::HashMap<NodeId, &SidecarBlock> =
+        old_blocks.iter().map(|b| (b.id, b)).collect();
+    let handles: Vec<String> = matches
+        .iter()
+        .zip(ids.iter())
+        .map(|(m, id)| match m.level {
+            MatchLevel::High | MatchLevel::Medium => old_by_id
+                .get(id)
+                .map(|b| b.ref_handle.clone())
+                .filter(|h| !h.is_empty())
+                .unwrap_or_else(|| derive_ref_handle(*id)),
+            MatchLevel::Low => derive_ref_handle(*id),
+        })
+        .collect();
+
     // Walk the new tree in DFS preorder, generating ops + sidecar entries.
     let mut ops = Vec::<Op>::new();
     let mut sidecar_blocks = Vec::<SidecarBlock>::new();
@@ -76,7 +104,8 @@ pub fn diff_to_ops(
         new_blocks,
         0,
         &ids,
-        &mut 0usize, // running index into `ids`
+        &handles,
+        &mut 0usize, // running index into `ids` / `handles`
         &mut ops,
         &mut sidecar_blocks,
         &mut parent_stack,
@@ -117,6 +146,7 @@ fn walk(
     blocks: &[OutlineNode],
     indent: u32,
     ids: &[NodeId],
+    handles: &[String],
     cursor: &mut usize,
     ops: &mut Vec<Op>,
     sidecar_blocks: &mut Vec<SidecarBlock>,
@@ -180,6 +210,7 @@ fn walk(
             line,
             indent,
             content_hash: content_hash(&block.text),
+            ref_handle: handles[*cursor].clone(),
         });
 
         *cursor += 1;
@@ -190,6 +221,7 @@ fn walk(
             &block.children,
             indent + 1,
             ids,
+            handles,
             cursor,
             ops,
             sidecar_blocks,
@@ -221,12 +253,14 @@ mod tests {
                 line: 1,
                 indent: 0,
                 content_hash: content_hash("a"),
+                ref_handle: derive_ref_handle(id_a),
             },
             SidecarBlock {
                 id: id_b,
                 line: 2,
                 indent: 0,
                 content_hash: content_hash("b"),
+                ref_handle: derive_ref_handle(id_b),
             },
         ];
         let (matches, orphans) = match_blocks(&ast.blocks, &old);
@@ -236,6 +270,7 @@ mod tests {
             &orphans,
             NodeId::new(),
             &file_hash(md),
+            &old,
         );
         // Each block produced 1 Create + 1 Move (no properties).
         assert_eq!(plan.ops.len(), 4);
@@ -257,12 +292,14 @@ mod tests {
                 line: 1,
                 indent: 0,
                 content_hash: content_hash("a"),
+                ref_handle: derive_ref_handle(id_a),
             },
             SidecarBlock {
                 id: id_dead,
                 line: 2,
                 indent: 0,
                 content_hash: content_hash("gone"),
+                ref_handle: derive_ref_handle(id_dead),
             },
         ];
         let (matches, orphans) = match_blocks(&ast.blocks, &old);
@@ -272,6 +309,7 @@ mod tests {
             &orphans,
             NodeId::new(),
             &file_hash(md),
+            &old,
         );
         // Last op must be Move(id_dead, TRASH).
         let last = plan.ops.last().unwrap();
@@ -294,7 +332,14 @@ mod tests {
         let ast = parse(md);
         let page_id = NodeId::new();
         let (matches, orphans) = match_blocks(&ast.blocks, &[]);
-        let plan = diff_to_ops(&ast.blocks, &matches, &orphans, page_id, &file_hash(md));
+        let plan = diff_to_ops(
+            &ast.blocks,
+            &matches,
+            &orphans,
+            page_id,
+            &file_hash(md),
+            &[],
+        );
 
         let actor = outl_core::id::ActorId::new();
         let g = outl_core::hlc::HlcGenerator::new(actor);
@@ -310,5 +355,59 @@ mod tests {
         }
         // Tree contains the four blocks (a, a1, a2, b).
         assert_eq!(ws.tree().node_count(), 4);
+    }
+
+    #[test]
+    fn level1_match_preserves_custom_ref_handle_verbatim() {
+        // Hypothetical scenario: a past collision forced the block's
+        // handle to expand to 7 chars (`blk-r6s4a1z`). Re-running the
+        // matching → diff pipeline must NOT silently rederive a 6-char
+        // handle, because any `.md` already citing `((blk-r6s4a1z))`
+        // would stop resolving.
+        let md = "- alpha\n";
+        let ast = parse(md);
+        let id = NodeId::new();
+        let custom_handle = "blk-r6s4a1z".to_string();
+        let old = vec![SidecarBlock {
+            id,
+            line: 1,
+            indent: 0,
+            content_hash: content_hash("alpha"),
+            ref_handle: custom_handle.clone(),
+        }];
+        let (matches, orphans) = match_blocks(&ast.blocks, &old);
+        let plan = diff_to_ops(
+            &ast.blocks,
+            &matches,
+            &orphans,
+            NodeId::new(),
+            &file_hash(md),
+            &old,
+        );
+        assert_eq!(plan.new_sidecar.blocks.len(), 1);
+        assert_eq!(
+            plan.new_sidecar.blocks[0].ref_handle, custom_handle,
+            "level-1 preserved blocks must keep the old sidecar's ref_handle verbatim"
+        );
+    }
+
+    #[test]
+    fn level3_block_gets_freshly_derived_handle() {
+        // A wholly new block (no old match) gets its handle from
+        // `derive_ref_handle(id)`. The format must match the canonical
+        // shape and be tied to the freshly minted id.
+        let md = "- brand new content\n";
+        let ast = parse(md);
+        let (matches, orphans) = match_blocks(&ast.blocks, &[]);
+        let plan = diff_to_ops(
+            &ast.blocks,
+            &matches,
+            &orphans,
+            NodeId::new(),
+            &file_hash(md),
+            &[],
+        );
+        let sb = &plan.new_sidecar.blocks[0];
+        assert_eq!(sb.ref_handle, derive_ref_handle(sb.id));
     }
 }

--- a/crates/outl-md/src/index.rs
+++ b/crates/outl-md/src/index.rs
@@ -13,9 +13,12 @@
 //! for thousands. The TUI calls `rebuild()` at startup and on a debounce
 //! after writes.
 
+use crate::block_index::{BlockEntry, BlockIndex, BlockReference};
 use crate::inline::{tokenize, InlineTok};
 use crate::parse::{parse, OutlineNode};
+use crate::sidecar::{self, Sidecar};
 use crate::slug::slugify;
+use outl_core::id::NodeId;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -77,6 +80,9 @@ pub struct WorkspaceIndex {
     pages: HashMap<String, PageEntry>,
     title_to_slug: HashMap<String, String>,
     backlinks: HashMap<String, Vec<Backlink>>,
+    /// Block-level index — owns the `((blk-XXXXXX))` lookup machinery.
+    /// Kept private so the public surface stays a single `WorkspaceIndex`.
+    blocks: BlockIndex,
 }
 
 impl WorkspaceIndex {
@@ -94,7 +100,8 @@ impl WorkspaceIndex {
         // the `pages` map; consumed in pass 2 for backlink collection.
         // Capacity-hint avoids regrowth on workspaces of any reasonable
         // size.
-        let mut parsed_pages: Vec<(String, crate::parse::ParsedPage)> = Vec::with_capacity(64);
+        let mut parsed_pages: Vec<(String, crate::parse::ParsedPage, Option<Sidecar>)> =
+            Vec::with_capacity(64);
 
         for (dir, is_journal) in [
             (workspace_root.join("pages"), false),
@@ -158,14 +165,37 @@ impl WorkspaceIndex {
                     },
                 );
                 idx.title_to_slug.insert(title.clone(), slug.to_string());
-                parsed_pages.push((slug.to_string(), parsed));
+
+                // Block-level indexing phase 1: register every block
+                // (id, handle, text, subtree) without recording
+                // reverse refs yet. Phase 2 below scans citations
+                // once all handles are known — that way a page B
+                // that cites a block of page A still gets its edge
+                // registered even when B is walked before A.
+                let cached_sidecar = read_sidecar_best_effort(path);
+                if let Some(sc) = &cached_sidecar {
+                    idx.blocks
+                        .collect_page_blocks(slug, path, &parsed.blocks, &sc.blocks);
+                }
+
+                parsed_pages.push((slug.to_string(), parsed, cached_sidecar));
+            }
+        }
+
+        // Phase 2 of block indexing: now that every handle is in
+        // `handle_to_block`, scan each page's blocks for
+        // `((blk-XXXXXX))` and record the reverse edges.
+        for (slug, parsed, cached_sidecar) in &parsed_pages {
+            if let Some(sc) = cached_sidecar {
+                idx.blocks
+                    .collect_page_refs(slug, &parsed.blocks, &sc.blocks);
             }
         }
 
         // Second pass: scan blocks for `[[ref]]` and `#tag`, populate
         // backlinks. Reuses the AST cached in `parsed_pages` so we
         // don't pay another read + parse round-trip.
-        for (slug, parsed) in &parsed_pages {
+        for (slug, parsed, _sc) in &parsed_pages {
             // Clone is cheap — `PageEntry` is small and `Arc`-less.
             // Avoids holding an immutable borrow of `idx.pages` while
             // we mutate `idx.backlinks` below.
@@ -272,15 +302,26 @@ impl WorkspaceIndex {
             pinned,
         };
         self.pages.insert(slug.clone(), entry.clone());
-        self.title_to_slug.insert(title, slug);
+        self.title_to_slug.insert(title.clone(), slug.clone());
 
         let mut path_stack: Vec<usize> = Vec::new();
         collect_backlinks_recursive(&page.blocks, &mut path_stack, &entry, self);
+
+        // Block-level re-index: drop everything this page used to
+        // contribute, then re-collect from the fresh AST + current
+        // sidecar. `forget_page` is O(blocks_in_workspace) today; the
+        // bench in #12 measures whether that holds up at scale.
+        self.blocks.forget_page(&slug);
+        if let Some(sc) = read_sidecar_best_effort(path) {
+            self.blocks
+                .collect_page(&slug, path, &page.blocks, &sc.blocks);
+        }
     }
 
     /// Drop a page from the index entirely. Use when a `.md` is
-    /// deleted on disk. Removes the `PageEntry`, its title alias, and
-    /// every backlink whose source was this slug.
+    /// deleted on disk. Removes the `PageEntry`, its title alias,
+    /// every backlink whose source was this slug, and every block
+    /// the page contributed to the block index.
     pub fn remove_page(&mut self, slug: &str) {
         self.pages.remove(slug);
         self.title_to_slug.retain(|_, s| s != slug);
@@ -288,6 +329,7 @@ impl WorkspaceIndex {
             list.retain(|bl| bl.source_slug != slug);
         }
         self.backlinks.retain(|_, v| !v.is_empty());
+        self.blocks.forget_page(slug);
     }
 
     /// Re-clone the cached `source_block` of every backlink whose
@@ -356,6 +398,54 @@ impl WorkspaceIndex {
         }
     }
 
+    /// Resolve `((blk-XXXXXX))` to the indexed block, if known.
+    ///
+    /// `O(1)`. Returns `None` for handles that don't match any
+    /// indexed block — orphan references are surfaced this way for
+    /// the doctor pass to flag.
+    pub fn resolve_block_ref(&self, handle: &str) -> Option<&BlockEntry> {
+        self.blocks.resolve(handle)
+    }
+
+    /// Look up a block by its `NodeId`.
+    pub fn block_by_id(&self, id: NodeId) -> Option<&BlockEntry> {
+        self.blocks.get(id)
+    }
+
+    /// Blocks that cite `id` via `((blk-XXXXXX))`. May be empty.
+    pub fn block_refs_to(&self, id: NodeId) -> &[BlockReference] {
+        self.blocks.refs_to(id)
+    }
+
+    /// Iterate every indexed block in unspecified order. Used by
+    /// the TUI's `((` autocomplete to fuzzy-match on block text.
+    pub fn iter_blocks(&self) -> impl Iterator<Item = &BlockEntry> {
+        self.blocks.iter_blocks()
+    }
+
+    /// Search indexed blocks by text substring (case-insensitive).
+    ///
+    /// Powers the `((` autocomplete in any UI surface (TUI today,
+    /// Tauri / mobile later). Returns up to `limit` `BlockEntry`s
+    /// ranked by match position then text length.
+    pub fn search_block_text(&self, query: &str, limit: usize) -> Vec<&BlockEntry> {
+        self.blocks.search_text(query, limit)
+    }
+
+    /// Find the block at `(slug, dfs_path)` in O(1).
+    ///
+    /// Backs `yr` / `/refer` / `/refer-embed` so the TUI doesn't
+    /// scan `iter_blocks()` linearly per chord press.
+    pub fn block_at_location(&self, slug: &str, path: &[usize]) -> Option<&BlockEntry> {
+        self.blocks.at_location(slug, path)
+    }
+
+    /// Total indexed blocks. Tests and the future bench (#12) read
+    /// this to sanity-check workspace coverage.
+    pub fn block_count(&self) -> usize {
+        self.blocks.block_count()
+    }
+
     /// Titles starting with `prefix` (case-insensitive), best-effort
     /// for autocomplete. Returns at most `limit` results sorted by
     /// title length (shorter first).
@@ -389,6 +479,14 @@ fn walk_node<'a>(blocks: &'a [OutlineNode], path: &[usize]) -> Option<&'a Outlin
         current = &n.children;
     }
     node
+}
+
+/// Read the sidecar paired with `md_path`, swallowing I/O and parse
+/// errors so the index build (a best-effort pass) cannot abort over a
+/// single bad file.
+fn read_sidecar_best_effort(md_path: &Path) -> Option<Sidecar> {
+    let p = sidecar::sidecar_path_for(md_path);
+    sidecar::read(&p).ok()
 }
 
 /// Loose truthy check for boolean-ish property values (`pinned::`,
@@ -452,265 +550,7 @@ fn push_backlink(
         });
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::fs;
-    use tempfile::TempDir;
-
-    fn write_workspace(files: &[(&str, &str)]) -> TempDir {
-        let dir = TempDir::new().unwrap();
-        for (rel, content) in files {
-            let full = dir.path().join(rel);
-            if let Some(parent) = full.parent() {
-                fs::create_dir_all(parent).unwrap();
-            }
-            fs::write(full, content).unwrap();
-        }
-        dir
-    }
-
-    #[test]
-    fn patch_page_replaces_backlinks_for_that_slug_only() {
-        // Initial state: projeto.md and journal both reference Avelino.
-        let dir = write_workspace(&[
-            ("pages/avelino.md", "title:: Avelino\n\n- author\n"),
-            (
-                "pages/projeto.md",
-                "title:: Projeto\n\n- led by [[Avelino]]\n",
-            ),
-            ("journals/2026-05-24.md", "- meeting with [[Avelino]]\n"),
-        ]);
-        let mut idx = WorkspaceIndex::build(dir.path());
-        assert_eq!(idx.backlinks("avelino").len(), 2);
-
-        // User rewrites projeto.md so it no longer references Avelino
-        // and now references "Other Page" instead. patch_page must:
-        //   1. drop projeto's old backlink to Avelino
-        //   2. emit a new backlink from projeto to other-page
-        // ...without touching the journal's backlink.
-        let new_md = "title:: Projeto\n\n- led by [[Other Page]]\n";
-        let new_page = crate::parse::parse(new_md);
-        let proj_path = dir.path().join("pages/projeto.md");
-        idx.patch_page(&proj_path, &new_page);
-
-        let avelino_bls = idx.backlinks("avelino");
-        assert_eq!(avelino_bls.len(), 1, "journal backlink should survive");
-        assert_eq!(avelino_bls[0].source_slug, "2026-05-24");
-
-        let other_bls = idx.backlinks("other-page");
-        assert_eq!(other_bls.len(), 1);
-        assert_eq!(other_bls[0].source_slug, "projeto");
-    }
-
-    #[test]
-    fn patch_page_updates_title_and_icon() {
-        let dir = write_workspace(&[("pages/x.md", "title:: Old Title\nicon:: 🦀\n\n- body\n")]);
-        let mut idx = WorkspaceIndex::build(dir.path());
-        assert_eq!(idx.by_slug("x").unwrap().title, "Old Title");
-        assert_eq!(idx.by_slug("x").unwrap().icon.as_deref(), Some("🦀"));
-
-        let new_page = crate::parse::parse("title:: New Title\nicon:: 🚀\n\n- body\n");
-        idx.patch_page(&dir.path().join("pages/x.md"), &new_page);
-
-        let entry = idx.by_slug("x").unwrap();
-        assert_eq!(entry.title, "New Title");
-        assert_eq!(entry.icon.as_deref(), Some("🚀"));
-        // by_title should follow the new title and forget the old one.
-        assert!(idx.by_title("Old Title").is_none());
-        assert_eq!(idx.by_title("New Title").unwrap().slug, "x");
-    }
-
-    #[test]
-    fn remove_page_drops_entry_and_its_backlinks() {
-        let dir = write_workspace(&[
-            ("pages/avelino.md", "title:: Avelino\n\n- author\n"),
-            (
-                "pages/projeto.md",
-                "title:: Projeto\n\n- led by [[Avelino]]\n",
-            ),
-        ]);
-        let mut idx = WorkspaceIndex::build(dir.path());
-        assert_eq!(idx.backlinks("avelino").len(), 1);
-
-        idx.remove_page("projeto");
-        assert!(idx.by_slug("projeto").is_none());
-        assert!(idx.by_title("Projeto").is_none());
-        assert!(idx.backlinks("avelino").is_empty());
-    }
-
-    #[test]
-    fn empty_workspace_indexes_to_nothing() {
-        let dir = TempDir::new().unwrap();
-        let idx = WorkspaceIndex::build(dir.path());
-        assert_eq!(idx.page_count(), 0);
-    }
-
-    #[test]
-    fn pages_get_indexed_by_slug_and_title() {
-        let dir = write_workspace(&[
-            (
-                "pages/avelino.md",
-                "title:: Avelino\n\n- some note about me\n",
-            ),
-            ("pages/projeto.md", "title:: Meu Projeto\n\n- objetivo\n"),
-        ]);
-        let idx = WorkspaceIndex::build(dir.path());
-        assert_eq!(idx.page_count(), 2);
-        assert_eq!(idx.by_slug("avelino").unwrap().title, "Avelino");
-        assert_eq!(idx.by_title("Meu Projeto").unwrap().slug, "projeto");
-    }
-
-    #[test]
-    fn missing_title_falls_back_to_slug() {
-        let dir = write_workspace(&[("pages/no-title.md", "- bare bullet\n")]);
-        let idx = WorkspaceIndex::build(dir.path());
-        assert_eq!(idx.by_slug("no-title").unwrap().title, "no-title");
-    }
-
-    #[test]
-    fn icon_property_is_indexed_and_propagated_to_backlinks() {
-        let dir = write_workspace(&[
-            (
-                "pages/avelino.md",
-                "title:: Avelino\nicon:: 🦀\n\n- author\n",
-            ),
-            (
-                "pages/projeto.md",
-                "title:: Projeto\nicon:: 🚀\n\n- led by [[Avelino]]\n",
-            ),
-            // Page without icon — must produce None, not crash.
-            ("pages/bare.md", "title:: Bare\n\n- nothing fancy\n"),
-        ]);
-        let idx = WorkspaceIndex::build(dir.path());
-
-        assert_eq!(idx.by_slug("avelino").unwrap().icon.as_deref(), Some("🦀"));
-        assert_eq!(idx.by_slug("projeto").unwrap().icon.as_deref(), Some("🚀"));
-        assert_eq!(idx.by_slug("bare").unwrap().icon, None);
-
-        // Backlink to Avelino comes from Projeto — must carry its icon.
-        let bls = idx.backlinks("avelino");
-        assert_eq!(bls.len(), 1);
-        assert_eq!(bls[0].source_slug, "projeto");
-        assert_eq!(bls[0].source_icon.as_deref(), Some("🚀"));
-    }
-
-    #[test]
-    fn empty_icon_is_treated_as_none() {
-        // `icon:: ` (no value) shouldn't show up as a present-but-empty
-        // icon — the UI would render a stray space.
-        let dir = write_workspace(&[("pages/x.md", "title:: X\nicon::\n\n- body\n")]);
-        let idx = WorkspaceIndex::build(dir.path());
-        assert_eq!(idx.by_slug("x").unwrap().icon, None);
-    }
-
-    #[test]
-    fn backlinks_are_collected_across_pages() {
-        let dir = write_workspace(&[
-            ("pages/avelino.md", "title:: Avelino\n\n- I am the author\n"),
-            (
-                "pages/projeto.md",
-                "title:: Projeto\n\n- led by [[Avelino]]\n",
-            ),
-            (
-                "journals/2026-05-24.md",
-                "- meeting with [[Avelino]] and #urgent stuff\n",
-            ),
-        ]);
-        let idx = WorkspaceIndex::build(dir.path());
-        let bl = idx.backlinks("avelino");
-        assert_eq!(bl.len(), 2);
-        let slugs: Vec<_> = bl.iter().map(|b| b.source_slug.as_str()).collect();
-        assert!(slugs.contains(&"projeto"));
-        assert!(slugs.contains(&"2026-05-24"));
-
-        let urgent = idx.backlinks("urgent");
-        assert_eq!(urgent.len(), 1);
-    }
-
-    #[test]
-    fn self_references_are_skipped() {
-        let dir = write_workspace(&[(
-            "pages/recursive.md",
-            "title:: Recursive\n\n- I link to [[Recursive]] myself\n",
-        )]);
-        let idx = WorkspaceIndex::build(dir.path());
-        assert!(idx.backlinks("recursive").is_empty());
-    }
-
-    #[test]
-    fn journals_are_treated_as_pages_for_lookup() {
-        let dir = write_workspace(&[("journals/2026-05-24.md", "- entry\n")]);
-        let idx = WorkspaceIndex::build(dir.path());
-        let entry = idx.by_slug("2026-05-24").unwrap();
-        assert!(entry.is_journal);
-    }
-
-    #[test]
-    fn source_block_carries_text_and_children() {
-        // The Backlink struct holds the full referencing block, not a
-        // truncated snippet. The TUI relies on `source_block.children`
-        // to draw nested context.
-        let dir = write_workspace(&[
-            ("pages/avelino.md", "title:: Avelino\n\n- author\n"),
-            (
-                "pages/projeto.md",
-                "title:: Projeto\n\n- led by [[Avelino]]\n  - milestone A\n  - milestone B\n",
-            ),
-        ]);
-        let idx = WorkspaceIndex::build(dir.path());
-        let bls = idx.backlinks("avelino");
-        assert_eq!(bls.len(), 1);
-        assert_eq!(bls[0].source_block.text, "led by [[Avelino]]");
-        assert_eq!(bls[0].source_block.children.len(), 2);
-        assert_eq!(bls[0].source_block.children[0].text, "milestone A");
-        assert_eq!(bls[0].source_block.children[1].text, "milestone B");
-    }
-
-    #[test]
-    fn source_block_path_points_to_referencing_block() {
-        // A backlink coming from a nested block records the DFS path
-        // [parent_idx, child_idx] so the editor can navigate straight
-        // to the right node without re-walking the AST.
-        let dir = write_workspace(&[
-            ("pages/avelino.md", "title:: Avelino\n\n- author\n"),
-            (
-                "pages/projeto.md",
-                "title:: Projeto\n\n- root block\n  - nested ref to [[Avelino]]\n",
-            ),
-        ]);
-        let idx = WorkspaceIndex::build(dir.path());
-        let bls = idx.backlinks("avelino");
-        assert_eq!(bls.len(), 1);
-        assert_eq!(bls[0].source_block_path, vec![0, 0]);
-        assert_eq!(bls[0].source_block.text, "nested ref to [[Avelino]]");
-    }
-
-    #[test]
-    fn block_with_repeated_reference_only_emits_one_backlink() {
-        let dir = write_workspace(&[
-            ("pages/avelino.md", "title:: Avelino\n\n- author\n"),
-            (
-                "pages/projeto.md",
-                "title:: Projeto\n\n- [[Avelino]] and again [[Avelino]] same block\n",
-            ),
-        ]);
-        let idx = WorkspaceIndex::build(dir.path());
-        assert_eq!(idx.backlinks("avelino").len(), 1);
-    }
-
-    #[test]
-    fn title_prefix_lookup() {
-        let dir = write_workspace(&[
-            ("pages/a.md", "title:: Apple\n\n- a\n"),
-            ("pages/b.md", "title:: Apricot\n\n- a\n"),
-            ("pages/c.md", "title:: Banana\n\n- a\n"),
-        ]);
-        let idx = WorkspaceIndex::build(dir.path());
-        let hits = idx.pages_by_title_prefix("Ap", 10);
-        assert_eq!(hits.len(), 2);
-        let names: Vec<_> = hits.iter().map(|p| p.title.as_str()).collect();
-        assert!(names.contains(&"Apple"));
-        assert!(names.contains(&"Apricot"));
-    }
-}
+// Integration-level tests for WorkspaceIndex live in
+// `tests/workspace_index.rs`. They exercise only the public API surface
+// so the same suite would catch a regression introduced by a UI client
+// (TUI, future Tauri, mobile).

--- a/crates/outl-md/src/inline.rs
+++ b/crates/outl-md/src/inline.rs
@@ -71,6 +71,27 @@ pub enum InlineTok<'a> {
         /// URL target.
         url: &'a str,
     },
+    /// `((blk-XXXXXX))` — inline reference to another block.
+    ///
+    /// The `handle` is the short, stable id persisted in the sidecar
+    /// (see [`crate::sidecar::derive_ref_handle`]). The token carries
+    /// the full handle including the `blk-` prefix so UI consumers can
+    /// trust it as the lookup key without re-parsing.
+    BlockRef {
+        /// Full handle, e.g. `"blk-r6s4a1"`.
+        handle: &'a str,
+    },
+    /// `!((blk-XXXXXX))` — embed: render the referenced block expanded
+    /// (its `text` plus subtree) inline instead of as a link.
+    ///
+    /// Mirrors markdown image syntax (`![alt](url)`) where `!` means
+    /// "expand". UI consumers render an Embed by resolving `handle`
+    /// through [`crate::index::WorkspaceIndex::resolve_block_ref`]
+    /// and drawing the result's `text` + `children`.
+    Embed {
+        /// Full handle, e.g. `"blk-r6s4a1"`.
+        handle: &'a str,
+    },
 }
 
 /// What `ref_at_cursor` resolves to.
@@ -82,6 +103,9 @@ pub enum RefTarget {
     Journal(NaiveDate),
     /// `#name` — tag (resolves to a page with same name).
     Tag(String),
+    /// `((blk-XXXXXX))` — block reference (lookup key into
+    /// [`crate::index::WorkspaceIndex`]).
+    Block(String),
 }
 
 /// Tokenize inline block content.
@@ -140,6 +164,40 @@ pub fn ref_at_cursor(text: &str, char_index: usize) -> Option<RefTarget> {
         search = abs_close_end;
     }
 
+    // Scan `((blk-...))` ranges. A preceding `!` (embed form) widens
+    // the match by one byte so a cursor sitting on `!` still resolves
+    // to the same target.
+    //
+    // Bug fix: when the candidate handle fails validation we advance
+    // by ONE byte (not past the closing `))`) so an overlapping valid
+    // handle still gets a chance. Example: `((((blk-x))))` — the
+    // outer `((` captures `((blk-x` (invalid). Skipping to the first
+    // `))` would step past the real `((blk-x))` at offset 2.
+    let mut search = 0usize;
+    while let Some(rel_open) = text[search..].find("((") {
+        let abs_open = search + rel_open;
+        let inner_start = abs_open + 2;
+        let Some(rel_close) = text[inner_start..].find("))") else {
+            break;
+        };
+        let inner_end = inner_start + rel_close;
+        let abs_close_end = inner_end + 2;
+        let handle = &text[inner_start..inner_end];
+        if !is_valid_block_handle(handle) {
+            search = abs_open + 1;
+            continue;
+        }
+        let starts_at = if abs_open > 0 && text.as_bytes()[abs_open - 1] == b'!' {
+            abs_open - 1
+        } else {
+            abs_open
+        };
+        if cursor_byte >= starts_at && cursor_byte <= abs_close_end {
+            return Some(RefTarget::Block(handle.to_string()));
+        }
+        search = abs_close_end;
+    }
+
     // Scan `#tag` ranges.
     let mut idx = 0usize;
     while idx < text.len() {
@@ -187,6 +245,16 @@ fn match_one(s: &str) -> Option<(InlineTok<'_>, usize)> {
     if let Some(out) = try_page_ref(s) {
         return Some(out);
     }
+    // `try_embed` MUST be checked before `try_block_ref`: the embed
+    // form starts with `!` and contains a `((handle))` inside, and we
+    // want the whole `!((handle))` consumed as one token instead of
+    // a stray `Plain("!")` followed by a `BlockRef`.
+    if let Some(out) = try_embed(s) {
+        return Some(out);
+    }
+    if let Some(out) = try_block_ref(s) {
+        return Some(out);
+    }
     if let Some(out) = try_bold(s) {
         return Some(out);
     }
@@ -222,6 +290,56 @@ fn try_page_ref(s: &str) -> Option<(InlineTok<'_>, usize)> {
         return None;
     }
     Some((InlineTok::PageRef { name }, 2 + close + 2))
+}
+
+/// `!((blk-XXXXXX))` — block embed.
+///
+/// Markdown-image-shaped (`!((handle))` mirrors `![alt](url)`).
+/// Strict on the inner handle for the same reason
+/// [`try_block_ref`] is: arbitrary `!((..))` in prose must not be
+/// silently rewritten as an embed.
+fn try_embed(s: &str) -> Option<(InlineTok<'_>, usize)> {
+    let rest = s.strip_prefix("!((")?;
+    let close = rest.find("))")?;
+    let handle = &rest[..close];
+    if !is_valid_block_handle(handle) {
+        return None;
+    }
+    // Consumed: `!` (1) + `((` (2) + handle + `))` (2).
+    Some((InlineTok::Embed { handle }, 1 + 2 + close + 2))
+}
+
+/// `((blk-XXXXXX))` — Roam-style block reference.
+///
+/// The handle must look like a valid one: starts with `blk-`, followed
+/// by 1 or more ASCII-alphanumeric lowercase characters. Anything else
+/// falls back to `Plain` so plain prose using `((..))` for parentheticals
+/// is not silently rewritten.
+fn try_block_ref(s: &str) -> Option<(InlineTok<'_>, usize)> {
+    let rest = s.strip_prefix("((")?;
+    let close = rest.find("))")?;
+    let handle = &rest[..close];
+    if !is_valid_block_handle(handle) {
+        return None;
+    }
+    Some((InlineTok::BlockRef { handle }, 2 + close + 2))
+}
+
+/// Validate a `((..))` payload as a block ref handle.
+///
+/// Conservative on purpose: the moment we accept arbitrary content
+/// between `((` and `))`, prose like "look here ((really))" gets
+/// rewritten as a broken reference. Loose validation is worse than no
+/// recognition. Keep this aligned with [`crate::sidecar::derive_ref_handle`].
+pub fn is_valid_block_handle(handle: &str) -> bool {
+    let Some(tail) = handle.strip_prefix(crate::sidecar::REF_HANDLE_PREFIX) else {
+        return false;
+    };
+    if tail.is_empty() {
+        return false;
+    }
+    tail.chars()
+        .all(|c| c.is_ascii_alphanumeric() && !c.is_ascii_uppercase())
 }
 
 fn try_bold(s: &str) -> Option<(InlineTok<'_>, usize)> {
@@ -339,160 +457,4 @@ fn try_tag(s: &str) -> Option<(InlineTok<'_>, usize)> {
         },
         1 + tag_byte_end,
     ))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn plain_text_is_one_token() {
-        let toks = tokenize("hello world");
-        assert_eq!(toks, vec![InlineTok::Plain("hello world")]);
-    }
-
-    #[test]
-    fn page_ref_is_recognized() {
-        let toks = tokenize("see [[Avelino]] for more");
-        assert!(toks.contains(&InlineTok::PageRef { name: "Avelino" }));
-    }
-
-    #[test]
-    fn tag_is_recognized() {
-        let toks = tokenize("hot #project work");
-        assert!(toks.contains(&InlineTok::Tag { name: "project" }));
-    }
-
-    #[test]
-    fn bold_strips_inner() {
-        let toks = tokenize("a **brave** soul");
-        assert!(toks.contains(&InlineTok::Bold { inner: "brave" }));
-    }
-
-    #[test]
-    fn bold_under_double_underscore() {
-        // CommonMark: `__x__` is strong emphasis (bold), same as `**x**`.
-        // Regression: we used to fall through to single-underscore
-        // italic, rendering `__abc__` as ` _abc_` (space + plain + italic).
-        let toks = tokenize("look __at__ this");
-        assert!(
-            toks.contains(&InlineTok::Bold { inner: "at" }),
-            "expected __at__ to tokenize as Bold; got {toks:?}"
-        );
-        assert!(
-            !toks
-                .iter()
-                .any(|t| matches!(t, InlineTok::Italic { inner: "at", .. })),
-            "__at__ must not also produce an Italic token"
-        );
-    }
-
-    #[test]
-    fn bold_under_alongside_bold_star() {
-        // Mixing `**a**` and `__b__` in one buffer — both must be bold.
-        let toks = tokenize("**abc** __123__");
-        assert!(toks.contains(&InlineTok::Bold { inner: "abc" }));
-        assert!(toks.contains(&InlineTok::Bold { inner: "123" }));
-    }
-
-    #[test]
-    fn italic_star_and_under() {
-        assert!(tokenize("an *italic* word").contains(&InlineTok::Italic {
-            inner: "italic",
-            marker: '*'
-        }));
-        assert!(tokenize("an _italic_ word").contains(&InlineTok::Italic {
-            inner: "italic",
-            marker: '_'
-        }));
-    }
-
-    #[test]
-    fn strike_and_code() {
-        assert!(tokenize("old ~~news~~").contains(&InlineTok::Strike { inner: "news" }));
-        assert!(tokenize("call `fn()`").contains(&InlineTok::Code { inner: "fn()" }));
-    }
-
-    #[test]
-    fn md_link_extracts_text_and_url() {
-        let toks = tokenize("see [outl](https://outl.app) docs");
-        assert!(toks.contains(&InlineTok::Link {
-            text: "outl",
-            url: "https://outl.app"
-        }));
-    }
-
-    #[test]
-    fn unclosed_marker_falls_back_to_plain() {
-        // No closing `**` → not a Bold; the `**` lives inside Plain text.
-        let toks = tokenize("a **brave");
-        assert!(matches!(toks.first(), Some(InlineTok::Plain(_))));
-        assert!(!toks.iter().any(|t| matches!(t, InlineTok::Bold { .. })));
-    }
-
-    #[test]
-    fn multibyte_text_does_not_panic() {
-        let _ = tokenize("isso parece que está");
-        let _ = tokenize("ação não pára aí");
-        let _ = tokenize("ship it 🚀 today");
-        let _ = tokenize("こんにちは world");
-        let _ = tokenize("veja [[orçamento]] e #ação");
-    }
-
-    #[test]
-    fn ref_at_cursor_finds_page_ref() {
-        let text = "see [[Avelino]] today";
-        let idx = "see [[Av".chars().count();
-        match ref_at_cursor(text, idx) {
-            Some(RefTarget::Page(n)) => assert_eq!(n, "Avelino"),
-            other => panic!("expected Page, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn ref_at_cursor_finds_journal_date() {
-        let text = "[[2026-05-24]]";
-        match ref_at_cursor(text, 5) {
-            Some(RefTarget::Journal(d)) => assert_eq!(d.to_string(), "2026-05-24"),
-            other => panic!("expected Journal, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn ref_at_cursor_finds_tag() {
-        let text = "tag #foo here";
-        let idx = "tag #f".chars().count();
-        match ref_at_cursor(text, idx) {
-            Some(RefTarget::Tag(t)) => assert_eq!(t, "foo"),
-            other => panic!("expected Tag, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn ref_at_cursor_outside_ref_is_none() {
-        let text = "see [[Avelino]] later";
-        let idx = "see [[Avelino]] la".chars().count();
-        assert!(ref_at_cursor(text, idx).is_none());
-    }
-
-    #[test]
-    fn ref_at_cursor_handles_multibyte() {
-        let text = "veja [[orçamento]] hoje";
-        let idx = "veja [[orç".chars().count();
-        match ref_at_cursor(text, idx) {
-            Some(RefTarget::Page(n)) => assert_eq!(n, "orçamento"),
-            other => panic!("expected Page, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn byte_index_for_char_is_split_safe() {
-        let s = "está";
-        for c in 0..=s.chars().count() {
-            let b = byte_index_for_char(s, c);
-            let _ = s.split_at(b);
-        }
-        assert_eq!(byte_index_for_char(s, 0), 0);
-        assert_eq!(byte_index_for_char(s, 4), 5);
-    }
 }

--- a/crates/outl-md/src/inline.rs
+++ b/crates/outl-md/src/inline.rs
@@ -330,12 +330,15 @@ fn try_block_ref(s: &str) -> Option<(InlineTok<'_>, usize)> {
 /// Conservative on purpose: the moment we accept arbitrary content
 /// between `((` and `))`, prose like "look here ((really))" gets
 /// rewritten as a broken reference. Loose validation is worse than no
-/// recognition. Keep this aligned with [`crate::sidecar::derive_ref_handle`].
+/// recognition. Keep this aligned with [`crate::sidecar::derive_ref_handle`]
+/// — handles are `blk-` plus at least [`crate::sidecar::REF_HANDLE_TAIL_LEN`]
+/// lowercase ASCII alphanumerics; collision expansion only ever makes
+/// them longer, never shorter.
 pub fn is_valid_block_handle(handle: &str) -> bool {
     let Some(tail) = handle.strip_prefix(crate::sidecar::REF_HANDLE_PREFIX) else {
         return false;
     };
-    if tail.is_empty() {
+    if tail.chars().count() < crate::sidecar::REF_HANDLE_TAIL_LEN {
         return false;
     }
     tail.chars()

--- a/crates/outl-md/src/lib.rs
+++ b/crates/outl-md/src/lib.rs
@@ -11,6 +11,7 @@
 #![warn(missing_docs)]
 
 pub mod atomic;
+pub mod block_index;
 pub mod diff;
 pub mod index;
 pub mod inline;
@@ -23,6 +24,7 @@ pub mod slug;
 pub mod view;
 
 pub use atomic::write_atomic;
+pub use block_index::{BlockEntry, BlockIndex, BlockReference};
 pub use diff::{diff_to_ops, DiffPlan};
 pub use index::{Backlink, PageEntry, WorkspaceIndex};
 pub use inline::{byte_index_for_char, ref_at_cursor, tokenize, InlineTok, RefTarget};

--- a/crates/outl-md/src/matching.rs
+++ b/crates/outl-md/src/matching.rs
@@ -139,6 +139,7 @@ mod tests {
             line,
             indent,
             content_hash: content_hash(text),
+            ref_handle: crate::sidecar::derive_ref_handle(id),
         }
     }
 

--- a/crates/outl-md/src/reconcile.rs
+++ b/crates/outl-md/src/reconcile.rs
@@ -108,7 +108,14 @@ pub fn reconcile_md(
         }
     }
 
-    let plan = diff_to_ops(&new_ast.blocks, &matches, &orphans, page_id, &md_hash);
+    let plan = diff_to_ops(
+        &new_ast.blocks,
+        &matches,
+        &orphans,
+        page_id,
+        &md_hash,
+        &old_blocks,
+    );
     let mut ops_applied = 0usize;
 
     for op in plan.ops {
@@ -227,8 +234,15 @@ mod tests {
         let sidecar_path = sidecar_path_for(&md_path);
         assert!(sidecar_path.exists());
         let sc = sidecar::read(&sidecar_path).unwrap();
-        assert_eq!(sc.version, 1);
+        assert_eq!(sc.version, sidecar::SIDECAR_VERSION);
         assert_eq!(sc.blocks.len(), 2);
+        // Every block must carry a non-empty `ref_handle` after a fresh
+        // reconcile — the v2 invariant.
+        assert!(
+            sc.blocks.iter().all(|b| !b.ref_handle.is_empty()),
+            "v2 sidecar must populate ref_handle on every block: {:?}",
+            sc.blocks
+        );
     }
 
     #[test]

--- a/crates/outl-md/src/sidecar.rs
+++ b/crates/outl-md/src/sidecar.rs
@@ -56,7 +56,7 @@ pub struct SidecarBlock {
     /// SHA-256 of the block's textual content, formatted `sha256:<hex>`.
     pub content_hash: String,
     /// Short, stable, human-typeable handle for `((blk-XXXXXX))` inline
-    /// references and `{{embed: ((blk-XXXXXX))}}` embeds.
+    /// references and `!((blk-XXXXXX))` embeds.
     ///
     /// Default-derived from [`derive_ref_handle`] using the block id.
     /// The handle is stable as long as the block keeps the same id —

--- a/crates/outl-md/src/sidecar.rs
+++ b/crates/outl-md/src/sidecar.rs
@@ -10,7 +10,39 @@ use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 
 /// Current sidecar format version. Bump when introducing breaking changes.
-pub const SIDECAR_VERSION: u32 = 1;
+///
+/// Version history:
+/// - **1** — initial format (page_id, last_synced_hash, blocks with id /
+///   line / indent / content_hash).
+/// - **2** — added `ref_handle` on every block to power `((blk-XXXXXX))`
+///   inline references. Backward-compatible read: v1 sidecars load fine
+///   and their handles are derived on the fly from the block id.
+pub const SIDECAR_VERSION: u32 = 2;
+
+/// Lowest sidecar version this crate is willing to read.
+///
+/// Older versions return [`SidecarError::UnsupportedVersion`]. Keeping
+/// this explicit (rather than a magic number in `read`) so the contract
+/// is greppable when a v3 ever needs to drop v1 support.
+pub const MIN_READABLE_SIDECAR_VERSION: u32 = 1;
+
+/// Prefix every block ref handle carries in the `.md` file.
+///
+/// `((blk-r6s4a1))` is what users see. The prefix lets a reader (human
+/// or parser) tell a block ref apart from page refs / tags at a glance.
+pub const REF_HANDLE_PREFIX: &str = "blk-";
+
+/// Number of base32 (Crockford, lowercased) characters taken from the
+/// **tail** of the block's ULID to form its ref handle.
+///
+/// ULIDs are 26 chars total, split as 10 chars of timestamp + 16 chars
+/// of random tail. Pulling 6 chars from the tail gives ~30 bits of
+/// entropy (~1B values). Birthday-collision probability at 100k blocks
+/// is ~5e-6 — effectively zero. Lazy expansion to 7+ chars happens at
+/// index-build time if a collision is ever observed (see
+/// `WorkspaceIndex`); the sidecar itself always stores whatever handle
+/// resolved a given block at write time.
+pub const REF_HANDLE_TAIL_LEN: usize = 6;
 
 /// One block entry in the sidecar.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -23,6 +55,19 @@ pub struct SidecarBlock {
     pub indent: u32,
     /// SHA-256 of the block's textual content, formatted `sha256:<hex>`.
     pub content_hash: String,
+    /// Short, stable, human-typeable handle for `((blk-XXXXXX))` inline
+    /// references and `{{embed: ((blk-XXXXXX))}}` embeds.
+    ///
+    /// Default-derived from [`derive_ref_handle`] using the block id.
+    /// The handle is stable as long as the block keeps the same id —
+    /// editing the block's text does **not** change it. Persisted so
+    /// that a future change to the derivation scheme cannot invalidate
+    /// existing references already living in `.md` files.
+    ///
+    /// `#[serde(default)]` is what makes v1 sidecars load cleanly:
+    /// missing handles are backfilled by [`read`] from the id.
+    #[serde(default)]
+    pub ref_handle: String,
 }
 
 /// Full sidecar payload.
@@ -83,12 +128,24 @@ pub fn sidecar_path_for(md_path: &Path) -> PathBuf {
 }
 
 /// Read and validate a sidecar from disk.
+///
+/// Accepts any version in `[MIN_READABLE_SIDECAR_VERSION, SIDECAR_VERSION]`.
+/// Older payloads are upgraded in-memory: every block missing a
+/// `ref_handle` gets one [derived from its id](derive_ref_handle), and
+/// the in-memory `version` is bumped to [`SIDECAR_VERSION`]. The next
+/// [`write()`] then persists the upgraded shape.
 pub fn read(path: &Path) -> Result<Sidecar, SidecarError> {
     let s = std::fs::read_to_string(path)?;
-    let sc: Sidecar = serde_json::from_str(&s)?;
-    if sc.version != SIDECAR_VERSION {
+    let mut sc: Sidecar = serde_json::from_str(&s)?;
+    if sc.version < MIN_READABLE_SIDECAR_VERSION || sc.version > SIDECAR_VERSION {
         return Err(SidecarError::UnsupportedVersion(sc.version));
     }
+    for b in &mut sc.blocks {
+        if b.ref_handle.is_empty() {
+            b.ref_handle = derive_ref_handle(b.id);
+        }
+    }
+    sc.version = SIDECAR_VERSION;
     Ok(sc)
 }
 
@@ -100,6 +157,25 @@ pub fn write(path: &Path, sidecar: &Sidecar) -> Result<(), SidecarError> {
     let s = serde_json::to_string_pretty(sidecar)?;
     crate::atomic::write_atomic(path, s.as_bytes())?;
     Ok(())
+}
+
+/// Derive the canonical ref handle for a given block id.
+///
+/// Format: `blk-` followed by the last [`REF_HANDLE_TAIL_LEN`] characters
+/// of the ULID's Crockford base32 representation, lowercased. ULID
+/// `Display` is always exactly 26 ASCII characters today; iterating
+/// by `chars()` keeps the function safe if a future id encoding ever
+/// becomes multi-byte UTF-8.
+///
+/// Determinism matters: the same block id must always yield the same
+/// handle so that two devices building the sidecar independently agree
+/// on what `((blk-XXXXXX))` means.
+pub fn derive_ref_handle(id: NodeId) -> String {
+    let s = id.to_string();
+    let total = s.chars().count();
+    let skip = total.saturating_sub(REF_HANDLE_TAIL_LEN);
+    let tail: String = s.chars().skip(skip).collect();
+    format!("{REF_HANDLE_PREFIX}{}", tail.to_lowercase())
 }
 
 /// Compute the canonical content hash of a block's text.
@@ -177,6 +253,104 @@ mod tests {
             Err(SidecarError::InvalidJson(_)) | Err(SidecarError::UnsupportedVersion(99)) => {}
             other => panic!("expected version/json error, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn derive_ref_handle_uses_last_six_chars_lowercased() {
+        // The derivation is "take the lowercased tail of the ULID's
+        // Display impl". We assert that property holds for an arbitrary
+        // id without depending on the `ulid` crate here (outl-md does
+        // not have it as a direct dependency).
+        let id = NodeId::new();
+        let display = id.to_string();
+        let expected_tail = display[display.len() - REF_HANDLE_TAIL_LEN..].to_lowercase();
+        assert_eq!(
+            derive_ref_handle(id),
+            format!("{REF_HANDLE_PREFIX}{expected_tail}")
+        );
+    }
+
+    #[test]
+    fn derive_ref_handle_is_deterministic() {
+        let id = NodeId::new();
+        assert_eq!(derive_ref_handle(id), derive_ref_handle(id));
+    }
+
+    #[test]
+    fn derive_ref_handle_format_is_blk_prefix_plus_six() {
+        let id = NodeId::new();
+        let h = derive_ref_handle(id);
+        assert!(h.starts_with(REF_HANDLE_PREFIX));
+        let tail = &h[REF_HANDLE_PREFIX.len()..];
+        assert_eq!(tail.len(), REF_HANDLE_TAIL_LEN);
+        assert!(tail.chars().all(|c| c.is_ascii_alphanumeric()));
+        assert_eq!(tail, tail.to_lowercase());
+    }
+
+    #[test]
+    fn v1_sidecar_loads_and_backfills_ref_handle() {
+        // Hand-written v1 payload (no `ref_handle` field on the block).
+        // We deserialize through `read` and assert it:
+        //   1. parses without error,
+        //   2. surfaces version == SIDECAR_VERSION on the in-memory
+        //      value (upgrade-on-read),
+        //   3. populates a non-empty `ref_handle` derived from `id`.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join(".legacy.outl");
+        let id = NodeId::new();
+        let v1_json = format!(
+            r#"{{
+              "version": 1,
+              "page_id": "{page}",
+              "last_synced_hash": "sha256:abc",
+              "last_synced_at": "2026-05-24T10:00:00-03:00",
+              "blocks": [
+                {{
+                  "id": "{block}",
+                  "line": 1,
+                  "indent": 0,
+                  "content_hash": "sha256:def"
+                }}
+              ]
+            }}"#,
+            page = NodeId::new(),
+            block = id,
+        );
+        std::fs::write(&path, v1_json).unwrap();
+        let sc = read(&path).unwrap();
+        assert_eq!(sc.version, SIDECAR_VERSION);
+        assert_eq!(sc.blocks.len(), 1);
+        assert_eq!(sc.blocks[0].ref_handle, derive_ref_handle(id));
+    }
+
+    #[test]
+    fn write_then_read_v2_preserves_ref_handle() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join(".foo.outl");
+        let page_id = NodeId::new();
+        let block_id = NodeId::new();
+        let mut sc = Sidecar::new_for_page(page_id, &file_hash("- hello\n"));
+        sc.blocks.push(SidecarBlock {
+            id: block_id,
+            line: 1,
+            indent: 0,
+            content_hash: content_hash("hello"),
+            ref_handle: derive_ref_handle(block_id),
+        });
+        write(&path, &sc).unwrap();
+
+        let loaded = read(&path).unwrap();
+        assert_eq!(loaded.version, SIDECAR_VERSION);
+        assert_eq!(loaded.blocks.len(), 1);
+        assert_eq!(loaded.blocks[0].ref_handle, derive_ref_handle(block_id));
+
+        // And the on-disk JSON actually contains the field — guards
+        // against a future serde attribute accidentally skipping it.
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            on_disk.contains("ref_handle"),
+            "v2 sidecar must persist ref_handle on disk; got: {on_disk}"
+        );
     }
 
     #[test]

--- a/crates/outl-md/tests/block_index.rs
+++ b/crates/outl-md/tests/block_index.rs
@@ -1,0 +1,266 @@
+//! End-to-end tests for `BlockIndex`. Moved out of `src/block_index.rs`
+//! to keep that module under the file-size-guard. Every test here
+//! exercises only the public API surface — same contract any UI
+//! surface (TUI today, Tauri / mobile later) consumes.
+
+use outl_core::id::NodeId;
+use outl_md::block_index::BlockIndex;
+use outl_md::parse::parse;
+use outl_md::sidecar::{content_hash, derive_ref_handle, SidecarBlock};
+use std::path::PathBuf;
+
+fn sb(id: NodeId, text: &str, line: usize, indent: u32) -> SidecarBlock {
+    SidecarBlock {
+        id,
+        line,
+        indent,
+        content_hash: content_hash(text),
+        ref_handle: derive_ref_handle(id),
+    }
+}
+
+#[test]
+fn collect_populates_handle_to_block() {
+    let md = "- alpha\n- beta\n";
+    let ast = parse(md);
+    let id_a = NodeId::new();
+    let id_b = NodeId::new();
+    let sidecar_blocks = vec![sb(id_a, "alpha", 1, 0), sb(id_b, "beta", 2, 0)];
+
+    let mut idx = BlockIndex::default();
+    idx.collect_page(
+        "page",
+        &PathBuf::from("pages/page.md"),
+        &ast.blocks,
+        &sidecar_blocks,
+    );
+
+    assert_eq!(idx.block_count(), 2);
+    let handle_a = derive_ref_handle(id_a);
+    let resolved = idx.resolve(&handle_a).expect("resolve a");
+    assert_eq!(resolved.id, id_a);
+    assert_eq!(resolved.text, "alpha");
+}
+
+#[test]
+fn reverse_refs_track_citing_blocks() {
+    let id_target = NodeId::new();
+    let target_handle = derive_ref_handle(id_target);
+
+    let mut idx = BlockIndex::default();
+    let md_a = "- decide backend\n";
+    let ast_a = parse(md_a);
+    let sidecar_a = vec![sb(id_target, "decide backend", 1, 0)];
+    idx.collect_page("a", &PathBuf::from("pages/a.md"), &ast_a.blocks, &sidecar_a);
+
+    let id_cite = NodeId::new();
+    let md_b = format!("- see (({target_handle})) for context\n");
+    let ast_b = parse(&md_b);
+    let sidecar_b = vec![sb(
+        id_cite,
+        &format!("see (({target_handle})) for context"),
+        1,
+        0,
+    )];
+    idx.collect_page("b", &PathBuf::from("pages/b.md"), &ast_b.blocks, &sidecar_b);
+
+    let refs = idx.refs_to(id_target);
+    assert_eq!(refs.len(), 1);
+    assert_eq!(refs[0].source_slug, "b");
+}
+
+#[test]
+fn reverse_refs_track_embed_too() {
+    let id_target = NodeId::new();
+    let target_handle = derive_ref_handle(id_target);
+
+    let mut idx = BlockIndex::default();
+    let sidecar_a = vec![sb(id_target, "decide backend", 1, 0)];
+    idx.collect_page(
+        "a",
+        &PathBuf::from("pages/a.md"),
+        &parse("- decide backend\n").blocks,
+        &sidecar_a,
+    );
+
+    let id_cite = NodeId::new();
+    let md_b = format!("- !(({target_handle}))\n");
+    let ast_b = parse(&md_b);
+    let sidecar_b = vec![sb(id_cite, &format!("!(({target_handle}))"), 1, 0)];
+    idx.collect_page("b", &PathBuf::from("pages/b.md"), &ast_b.blocks, &sidecar_b);
+
+    let refs = idx.refs_to(id_target);
+    assert_eq!(refs.len(), 1, "embed should produce a reverse ref");
+}
+
+#[test]
+fn forget_page_drops_blocks_handles_and_reverse_refs() {
+    let id = NodeId::new();
+    let handle = derive_ref_handle(id);
+    let md = "- alpha\n";
+    let ast = parse(md);
+    let sidecar = vec![sb(id, "alpha", 1, 0)];
+
+    let mut idx = BlockIndex::default();
+    idx.collect_page("a", &PathBuf::from("pages/a.md"), &ast.blocks, &sidecar);
+    assert_eq!(idx.block_count(), 1);
+    assert!(idx.resolve(&handle).is_some());
+
+    idx.forget_page("a");
+    assert_eq!(idx.block_count(), 0);
+    assert!(idx.resolve(&handle).is_none());
+}
+
+#[test]
+fn at_location_returns_block_for_slug_and_path() {
+    let id = NodeId::new();
+    let md = "- alpha\n  - beta\n";
+    let ast = parse(md);
+    let id_beta = NodeId::new();
+    let sidecar = vec![sb(id, "alpha", 1, 0), sb(id_beta, "beta", 2, 1)];
+
+    let mut idx = BlockIndex::default();
+    idx.collect_page("p", &PathBuf::from("pages/p.md"), &ast.blocks, &sidecar);
+
+    let found = idx.at_location("p", &[0, 0]).expect("nested block");
+    assert_eq!(found.id, id_beta);
+}
+
+#[test]
+fn search_text_ranks_prefix_match_before_middle_match() {
+    let mut idx = BlockIndex::default();
+    let id_prefix = NodeId::new();
+    let id_middle = NodeId::new();
+    let md = "- decide backend\n- maybe decide database\n";
+    let ast = parse(md);
+    let sidecar = vec![
+        sb(id_prefix, "decide backend", 1, 0),
+        sb(id_middle, "maybe decide database", 2, 0),
+    ];
+    idx.collect_page("p", &PathBuf::from("pages/p.md"), &ast.blocks, &sidecar);
+
+    let hits = idx.search_text("decide", 5);
+    assert_eq!(hits.len(), 2);
+    assert_eq!(hits[0].id, id_prefix, "prefix match must rank first");
+    assert_eq!(hits[1].id, id_middle);
+}
+
+#[test]
+fn search_text_is_case_insensitive() {
+    let mut idx = BlockIndex::default();
+    let id = NodeId::new();
+    let md = "- Decide Backend\n";
+    let ast = parse(md);
+    let sidecar = vec![sb(id, "Decide Backend", 1, 0)];
+    idx.collect_page("p", &PathBuf::from("pages/p.md"), &ast.blocks, &sidecar);
+
+    assert_eq!(idx.search_text("DECIDE", 5).len(), 1);
+    assert_eq!(idx.search_text("decide", 5).len(), 1);
+    assert_eq!(idx.search_text("backend", 5).len(), 1);
+}
+
+#[test]
+fn search_text_empty_query_returns_nothing() {
+    let mut idx = BlockIndex::default();
+    let id = NodeId::new();
+    let sidecar = vec![sb(id, "x", 1, 0)];
+    idx.collect_page(
+        "p",
+        &PathBuf::from("pages/p.md"),
+        &parse("- x\n").blocks,
+        &sidecar,
+    );
+    assert!(idx.search_text("", 5).is_empty());
+}
+
+#[test]
+fn nested_blocks_record_correct_dfs_path() {
+    let md = "- root\n  - child\n";
+    let ast = parse(md);
+    let id_root = NodeId::new();
+    let id_child = NodeId::new();
+    let sidecar = vec![sb(id_root, "root", 1, 0), sb(id_child, "child", 2, 1)];
+
+    let mut idx = BlockIndex::default();
+    idx.collect_page("x", &PathBuf::from("pages/x.md"), &ast.blocks, &sidecar);
+
+    let child = idx.get(id_child).expect("child indexed");
+    assert_eq!(child.source_block_path, vec![0, 0]);
+}
+
+#[test]
+fn collision_expands_handle_for_loser_and_keeps_winner_resolvable() {
+    let mut idx = BlockIndex::default();
+    let id_winner = NodeId::new();
+    let id_loser = NodeId::new();
+    let base = "blk-aaaaaa".to_string();
+    let mut sb_w = sb(id_winner, "winner", 1, 0);
+    let mut sb_l = sb(id_loser, "loser", 1, 0);
+    sb_w.ref_handle = base.clone();
+    sb_l.ref_handle = base.clone();
+
+    idx.collect_page(
+        "winner",
+        &PathBuf::from("pages/winner.md"),
+        &parse("- winner\n").blocks,
+        &[sb_w],
+    );
+    idx.collect_page(
+        "loser",
+        &PathBuf::from("pages/loser.md"),
+        &parse("- loser\n").blocks,
+        &[sb_l],
+    );
+
+    let w = idx.resolve(&base).expect("winner still resolvable");
+    assert_eq!(w.id, id_winner);
+
+    let loser_entry = idx.get(id_loser).expect("loser indexed");
+    assert_ne!(loser_entry.ref_handle, base);
+    let l = idx
+        .resolve(&loser_entry.ref_handle)
+        .expect("loser resolvable via expanded handle");
+    assert_eq!(l.id, id_loser);
+}
+
+#[test]
+fn forget_page_does_not_unresolve_winner_on_collision_removal() {
+    let mut idx = BlockIndex::default();
+    let id_winner = NodeId::new();
+    let id_loser = NodeId::new();
+    let base = "blk-bbbbbb".to_string();
+    let mut sb_w = sb(id_winner, "winner", 1, 0);
+    let mut sb_l = sb(id_loser, "loser", 1, 0);
+    sb_w.ref_handle = base.clone();
+    sb_l.ref_handle = base.clone();
+
+    idx.collect_page(
+        "winner",
+        &PathBuf::from("pages/winner.md"),
+        &parse("- winner\n").blocks,
+        &[sb_w],
+    );
+    idx.collect_page(
+        "loser",
+        &PathBuf::from("pages/loser.md"),
+        &parse("- loser\n").blocks,
+        &[sb_l],
+    );
+
+    idx.forget_page("loser");
+
+    let w = idx.resolve(&base).expect("winner intact after loser drop");
+    assert_eq!(w.id, id_winner);
+}
+
+#[test]
+fn mismatched_content_hash_skips_block_indexing() {
+    let mut idx = BlockIndex::default();
+    let id = NodeId::new();
+    let md = "- alpha edited\n";
+    let ast = parse(md);
+    let stale = vec![sb(id, "alpha", 1, 0)];
+
+    idx.collect_page("p", &PathBuf::from("pages/p.md"), &ast.blocks, &stale);
+    assert_eq!(idx.block_count(), 0, "stale sidecar entry must not index");
+}

--- a/crates/outl-md/tests/block_index.rs
+++ b/crates/outl-md/tests/block_index.rs
@@ -188,34 +188,53 @@ fn nested_blocks_record_correct_dfs_path() {
     assert_eq!(child.source_block_path, vec![0, 0]);
 }
 
+/// Build a (smaller, larger) pair of `NodeId`s. The smaller id is the
+/// deterministic winner of any handle collision — see
+/// `BlockIndex::assign_handle`. Helpers here use it to write tests
+/// whose outcome is stable regardless of which ULID `NodeId::new()`
+/// happens to produce first.
+fn ordered_pair() -> (NodeId, NodeId) {
+    let a = NodeId::new();
+    let b = NodeId::new();
+    if a < b {
+        (a, b)
+    } else {
+        (b, a)
+    }
+}
+
 #[test]
 fn collision_expands_handle_for_loser_and_keeps_winner_resolvable() {
     let mut idx = BlockIndex::default();
-    let id_winner = NodeId::new();
-    let id_loser = NodeId::new();
+    // Smaller NodeId wins the base handle deterministically.
+    let (id_winner, id_loser) = ordered_pair();
     let base = "blk-aaaaaa".to_string();
     let mut sb_w = sb(id_winner, "winner", 1, 0);
     let mut sb_l = sb(id_loser, "loser", 1, 0);
     sb_w.ref_handle = base.clone();
     sb_l.ref_handle = base.clone();
 
-    idx.collect_page(
-        "winner",
-        &PathBuf::from("pages/winner.md"),
-        &parse("- winner\n").blocks,
-        &[sb_w],
-    );
+    // Insert the loser first to prove the winner displaces it
+    // regardless of insertion order.
     idx.collect_page(
         "loser",
         &PathBuf::from("pages/loser.md"),
         &parse("- loser\n").blocks,
         &[sb_l],
     );
+    idx.collect_page(
+        "winner",
+        &PathBuf::from("pages/winner.md"),
+        &parse("- winner\n").blocks,
+        &[sb_w],
+    );
 
-    let w = idx.resolve(&base).expect("winner still resolvable");
+    let w = idx
+        .resolve(&base)
+        .expect("winner owns base after dethroning");
     assert_eq!(w.id, id_winner);
 
-    let loser_entry = idx.get(id_loser).expect("loser indexed");
+    let loser_entry = idx.get(id_loser).expect("loser still indexed");
     assert_ne!(loser_entry.ref_handle, base);
     let l = idx
         .resolve(&loser_entry.ref_handle)
@@ -226,8 +245,7 @@ fn collision_expands_handle_for_loser_and_keeps_winner_resolvable() {
 #[test]
 fn forget_page_does_not_unresolve_winner_on_collision_removal() {
     let mut idx = BlockIndex::default();
-    let id_winner = NodeId::new();
-    let id_loser = NodeId::new();
+    let (id_winner, id_loser) = ordered_pair();
     let base = "blk-bbbbbb".to_string();
     let mut sb_w = sb(id_winner, "winner", 1, 0);
     let mut sb_l = sb(id_loser, "loser", 1, 0);

--- a/crates/outl-md/tests/block_ref_roundtrip.rs
+++ b/crates/outl-md/tests/block_ref_roundtrip.rs
@@ -1,0 +1,179 @@
+//! End-to-end roundtrip for `((blk-XXXXXX))` block references.
+//!
+//! Three contracts under test:
+//!
+//! 1. **Markdown stability** — `((blk-xxx))` survives parse + render
+//!    without normalization. The renderer is text-based, so the only
+//!    risk is a future parser change that mangles inline tokens. This
+//!    test pins it.
+//! 2. **Index resolution** — a real workspace with two pages where one
+//!    cites a block of the other resolves through `WorkspaceIndex`.
+//! 3. **Edit preservation** — editing the *citing* page (not the
+//!    target) leaves the cited handle valid. Catches a regression
+//!    where `patch_page` would forget a foreign block by mistake.
+
+use outl_core::id::NodeId;
+use outl_md::index::WorkspaceIndex;
+use outl_md::parse::parse;
+use outl_md::render::render;
+use outl_md::sidecar::{
+    self, content_hash, derive_ref_handle, file_hash, write as write_sidecar, Sidecar, SidecarBlock,
+};
+use std::fs;
+use tempfile::TempDir;
+
+fn write_page_with_sidecar(
+    dir: &TempDir,
+    rel: &str,
+    md: &str,
+    blocks: &[(NodeId, &str, usize, u32)],
+) {
+    let full = dir.path().join(rel);
+    if let Some(parent) = full.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(&full, md).unwrap();
+
+    let page_id = NodeId::new();
+    let mut sc = Sidecar::new_for_page(page_id, &file_hash(md));
+    for (id, text, line, indent) in blocks {
+        sc.blocks.push(SidecarBlock {
+            id: *id,
+            line: *line,
+            indent: *indent,
+            content_hash: content_hash(text),
+            ref_handle: derive_ref_handle(*id),
+        });
+    }
+    write_sidecar(&sidecar::sidecar_path_for(&full), &sc).unwrap();
+}
+
+#[test]
+fn block_ref_roundtrips_through_parse_and_render() {
+    let md = "- decide backend\n- see ((blk-r6s4a1)) for context\n";
+    let ast = parse(md);
+    let rendered = render(&ast);
+    assert_eq!(
+        rendered, md,
+        "((blk-...)) must survive parse + render byte-for-byte"
+    );
+}
+
+#[test]
+fn block_ref_resolves_across_pages_after_index_build() {
+    let dir = TempDir::new().unwrap();
+    let id_target = NodeId::new();
+    let target_handle = derive_ref_handle(id_target);
+
+    // Page A defines the target block.
+    write_page_with_sidecar(
+        &dir,
+        "pages/a.md",
+        "- decide backend\n",
+        &[(id_target, "decide backend", 1, 0)],
+    );
+
+    // Page B cites it inline.
+    let b_md = format!("- see (({target_handle})) for context\n");
+    let id_cite = NodeId::new();
+    write_page_with_sidecar(
+        &dir,
+        "pages/b.md",
+        &b_md,
+        &[(
+            id_cite,
+            &format!("see (({target_handle})) for context"),
+            1,
+            0,
+        )],
+    );
+
+    let idx = WorkspaceIndex::build(dir.path());
+    let resolved = idx
+        .resolve_block_ref(&target_handle)
+        .expect("citing-page reference must resolve to a's target");
+    assert_eq!(resolved.id, id_target);
+    assert_eq!(resolved.text, "decide backend");
+
+    // And the reverse edge is registered.
+    let reverse = idx.block_refs_to(id_target);
+    assert_eq!(reverse.len(), 1);
+    assert_eq!(reverse[0].source_slug, "b");
+}
+
+#[test]
+fn editing_citing_page_leaves_cited_handle_valid() {
+    // Regression guard: patch_page used to drop *all* blocks for the
+    // patched slug, including those whose ids belonged to other pages
+    // that happened to share a handle path. forget_page must scope
+    // strictly by source_slug.
+    let dir = TempDir::new().unwrap();
+    let id_target = NodeId::new();
+    let target_handle = derive_ref_handle(id_target);
+
+    write_page_with_sidecar(
+        &dir,
+        "pages/a.md",
+        "- decide backend\n",
+        &[(id_target, "decide backend", 1, 0)],
+    );
+
+    let b_md = format!("- see (({target_handle})) for context\n");
+    let id_cite = NodeId::new();
+    write_page_with_sidecar(
+        &dir,
+        "pages/b.md",
+        &b_md,
+        &[(
+            id_cite,
+            &format!("see (({target_handle})) for context"),
+            1,
+            0,
+        )],
+    );
+
+    let mut idx = WorkspaceIndex::build(dir.path());
+    assert!(idx.resolve_block_ref(&target_handle).is_some());
+
+    // Re-render b with an additional, unrelated block.
+    let b_md2 = format!("- see (({target_handle})) for context\n- and another thought entirely\n");
+    let id_extra = NodeId::new();
+    let b_path = dir.path().join("pages/b.md");
+    fs::write(&b_path, &b_md2).unwrap();
+    let mut sc = sidecar::read(&sidecar::sidecar_path_for(&b_path)).unwrap();
+    sc.blocks.push(SidecarBlock {
+        id: id_extra,
+        line: 2,
+        indent: 0,
+        content_hash: content_hash("and another thought entirely"),
+        ref_handle: derive_ref_handle(id_extra),
+    });
+    sc.last_synced_hash = file_hash(&b_md2);
+    write_sidecar(&sidecar::sidecar_path_for(&b_path), &sc).unwrap();
+
+    let new_ast = parse(&b_md2);
+    idx.patch_page(&b_path, &new_ast);
+
+    assert!(
+        idx.resolve_block_ref(&target_handle).is_some(),
+        "patching page b must NOT invalidate page a's block ref"
+    );
+}
+
+#[test]
+fn block_ref_handle_is_stable_across_repeated_index_builds() {
+    // Property-ish test: the handle of a given block id is the same
+    // regardless of how many times we build the workspace index from
+    // scratch. derive_ref_handle is pure, so the entry must agree
+    // every run.
+    let dir = TempDir::new().unwrap();
+    let id = NodeId::new();
+    write_page_with_sidecar(&dir, "pages/p.md", "- alpha\n", &[(id, "alpha", 1, 0)]);
+
+    let expected = derive_ref_handle(id);
+    for _ in 0..5 {
+        let idx = WorkspaceIndex::build(dir.path());
+        let e = idx.resolve_block_ref(&expected).unwrap();
+        assert_eq!(e.ref_handle, expected);
+    }
+}

--- a/crates/outl-md/tests/duplicate_block.rs
+++ b/crates/outl-md/tests/duplicate_block.rs
@@ -4,7 +4,7 @@
 use outl_core::id::NodeId;
 use outl_md::matching::{match_blocks, MatchLevel};
 use outl_md::parse::parse;
-use outl_md::sidecar::{content_hash, SidecarBlock};
+use outl_md::sidecar::{content_hash, derive_ref_handle, SidecarBlock};
 
 #[test]
 fn ctrl_d_first_keeps_id_second_gets_new() {
@@ -14,6 +14,7 @@ fn ctrl_d_first_keeps_id_second_gets_new() {
         line: 1,
         indent: 0,
         content_hash: content_hash("hello"),
+        ref_handle: derive_ref_handle(id),
     }];
 
     // After Ctrl+D in VS Code.
@@ -40,6 +41,7 @@ fn three_copies_of_same_content_two_get_new_ids() {
         line: 1,
         indent: 0,
         content_hash: content_hash("hi"),
+        ref_handle: derive_ref_handle(id),
     }];
 
     let edited = "- hi\n- hi\n- hi\n";

--- a/crates/outl-md/tests/external_edit.rs
+++ b/crates/outl-md/tests/external_edit.rs
@@ -4,7 +4,7 @@
 use outl_core::id::NodeId;
 use outl_md::matching::{match_blocks, MatchLevel};
 use outl_md::parse::parse;
-use outl_md::sidecar::{content_hash, SidecarBlock};
+use outl_md::sidecar::{content_hash, derive_ref_handle, SidecarBlock};
 
 fn sb(id: NodeId, text: &str, line: usize, indent: u32) -> SidecarBlock {
     SidecarBlock {
@@ -12,6 +12,7 @@ fn sb(id: NodeId, text: &str, line: usize, indent: u32) -> SidecarBlock {
         line,
         indent,
         content_hash: content_hash(text),
+        ref_handle: derive_ref_handle(id),
     }
 }
 

--- a/crates/outl-md/tests/heavy_edit.rs
+++ b/crates/outl-md/tests/heavy_edit.rs
@@ -9,7 +9,7 @@
 use outl_core::id::NodeId;
 use outl_md::matching::{match_blocks, MatchLevel};
 use outl_md::parse::parse;
-use outl_md::sidecar::{content_hash, SidecarBlock};
+use outl_md::sidecar::{content_hash, derive_ref_handle, SidecarBlock};
 
 #[test]
 fn heavy_edit_orphans_old_id_and_creates_new() {
@@ -19,6 +19,7 @@ fn heavy_edit_orphans_old_id_and_creates_new() {
         line: 1,
         indent: 0,
         content_hash: content_hash("the original wording of this block"),
+        ref_handle: derive_ref_handle(id),
     }];
 
     let edited = "- a wholly different sentence now\n";
@@ -41,6 +42,7 @@ fn whitespace_only_change_is_still_a_match() {
         line: 1,
         indent: 0,
         content_hash: content_hash("hello world"),
+        ref_handle: derive_ref_handle(id),
     }];
 
     let edited = "-   hello   world   \n";

--- a/crates/outl-md/tests/identical_blocks_swap.rs
+++ b/crates/outl-md/tests/identical_blocks_swap.rs
@@ -11,7 +11,7 @@
 use outl_core::id::NodeId;
 use outl_md::matching::{match_blocks, MatchLevel};
 use outl_md::parse::parse;
-use outl_md::sidecar::{content_hash, SidecarBlock};
+use outl_md::sidecar::{content_hash, derive_ref_handle, SidecarBlock};
 
 #[test]
 fn identical_blocks_get_first_fit_matching() {
@@ -24,12 +24,14 @@ fn identical_blocks_get_first_fit_matching() {
             line: 2,
             indent: 1,
             content_hash: content_hash("TODO"),
+            ref_handle: derive_ref_handle(id_a),
         },
         SidecarBlock {
             id: id_b,
             line: 4,
             indent: 1,
             content_hash: content_hash("TODO"),
+            ref_handle: derive_ref_handle(id_b),
         },
     ];
 

--- a/crates/outl-md/tests/inline.rs
+++ b/crates/outl-md/tests/inline.rs
@@ -1,0 +1,264 @@
+//! End-to-end tests for the inline tokenizer / `ref_at_cursor`.
+//! Moved out of `src/inline.rs` to keep that module under the
+//! file-size-guard. Every test here exercises only the public API.
+
+use outl_md::inline::{byte_index_for_char, ref_at_cursor, tokenize, InlineTok, RefTarget};
+
+#[test]
+fn plain_text_is_one_token() {
+    let toks = tokenize("hello world");
+    assert_eq!(toks, vec![InlineTok::Plain("hello world")]);
+}
+
+#[test]
+fn page_ref_is_recognized() {
+    let toks = tokenize("see [[Avelino]] for more");
+    assert!(toks.contains(&InlineTok::PageRef { name: "Avelino" }));
+}
+
+#[test]
+fn tag_is_recognized() {
+    let toks = tokenize("hot #project work");
+    assert!(toks.contains(&InlineTok::Tag { name: "project" }));
+}
+
+#[test]
+fn bold_strips_inner() {
+    let toks = tokenize("a **brave** soul");
+    assert!(toks.contains(&InlineTok::Bold { inner: "brave" }));
+}
+
+#[test]
+fn bold_under_double_underscore() {
+    let toks = tokenize("look __at__ this");
+    assert!(toks.contains(&InlineTok::Bold { inner: "at" }));
+    assert!(!toks
+        .iter()
+        .any(|t| matches!(t, InlineTok::Italic { inner: "at", .. })));
+}
+
+#[test]
+fn bold_under_alongside_bold_star() {
+    let toks = tokenize("**abc** __123__");
+    assert!(toks.contains(&InlineTok::Bold { inner: "abc" }));
+    assert!(toks.contains(&InlineTok::Bold { inner: "123" }));
+}
+
+#[test]
+fn italic_star_and_under() {
+    assert!(tokenize("an *italic* word").contains(&InlineTok::Italic {
+        inner: "italic",
+        marker: '*'
+    }));
+    assert!(tokenize("an _italic_ word").contains(&InlineTok::Italic {
+        inner: "italic",
+        marker: '_'
+    }));
+}
+
+#[test]
+fn strike_and_code() {
+    assert!(tokenize("old ~~news~~").contains(&InlineTok::Strike { inner: "news" }));
+    assert!(tokenize("call `fn()`").contains(&InlineTok::Code { inner: "fn()" }));
+}
+
+#[test]
+fn md_link_extracts_text_and_url() {
+    let toks = tokenize("see [outl](https://outl.app) docs");
+    assert!(toks.contains(&InlineTok::Link {
+        text: "outl",
+        url: "https://outl.app"
+    }));
+}
+
+#[test]
+fn unclosed_marker_falls_back_to_plain() {
+    let toks = tokenize("a **brave");
+    assert!(matches!(toks.first(), Some(InlineTok::Plain(_))));
+    assert!(!toks.iter().any(|t| matches!(t, InlineTok::Bold { .. })));
+}
+
+#[test]
+fn multibyte_text_does_not_panic() {
+    let _ = tokenize("isso parece que está");
+    let _ = tokenize("ação não pára aí");
+    let _ = tokenize("ship it 🚀 today");
+    let _ = tokenize("こんにちは world");
+    let _ = tokenize("veja [[orçamento]] e #ação");
+}
+
+#[test]
+fn block_ref_is_recognized() {
+    let toks = tokenize("see ((blk-r6s4a1)) for context");
+    assert!(toks.contains(&InlineTok::BlockRef {
+        handle: "blk-r6s4a1"
+    }));
+}
+
+#[test]
+fn block_ref_with_seven_char_tail_is_recognized() {
+    let toks = tokenize("ref ((blk-r6s4a1z)) end");
+    assert!(toks.contains(&InlineTok::BlockRef {
+        handle: "blk-r6s4a1z"
+    }));
+}
+
+#[test]
+fn double_paren_prose_does_not_tokenize_as_block_ref() {
+    for bad in [
+        "((really))",
+        "((BLK-R6S4A1))",
+        "((blk-))",
+        "((blk_r6s4a1))",
+        "((nothandle))",
+        "(())",
+    ] {
+        let text = format!("see {bad} text");
+        let toks = tokenize(&text);
+        assert!(
+            !toks.iter().any(|t| matches!(t, InlineTok::BlockRef { .. })),
+            "{bad} should NOT tokenize as BlockRef; got {toks:?}"
+        );
+    }
+}
+
+#[test]
+fn embed_is_recognized() {
+    let toks = tokenize("expand !((blk-r6s4a1)) here");
+    assert!(toks.contains(&InlineTok::Embed {
+        handle: "blk-r6s4a1"
+    }));
+    assert!(!toks.iter().any(|t| matches!(t, InlineTok::Plain("!"))));
+}
+
+#[test]
+fn bang_without_double_paren_does_not_tokenize_as_embed() {
+    let toks = tokenize("watch out! really.");
+    assert!(!toks.iter().any(|t| matches!(t, InlineTok::Embed { .. })));
+}
+
+#[test]
+fn embed_with_invalid_handle_falls_through() {
+    let toks = tokenize("look !((really)) here");
+    assert!(!toks.iter().any(|t| matches!(t, InlineTok::Embed { .. })));
+}
+
+#[test]
+fn ref_at_cursor_finds_page_ref() {
+    let text = "see [[Avelino]] today";
+    let idx = "see [[Av".chars().count();
+    match ref_at_cursor(text, idx) {
+        Some(RefTarget::Page(n)) => assert_eq!(n, "Avelino"),
+        other => panic!("expected Page, got {other:?}"),
+    }
+}
+
+#[test]
+fn ref_at_cursor_finds_journal_date() {
+    let text = "[[2026-05-24]]";
+    match ref_at_cursor(text, 5) {
+        Some(RefTarget::Journal(d)) => assert_eq!(d.to_string(), "2026-05-24"),
+        other => panic!("expected Journal, got {other:?}"),
+    }
+}
+
+#[test]
+fn ref_at_cursor_finds_tag() {
+    let text = "tag #foo here";
+    let idx = "tag #f".chars().count();
+    match ref_at_cursor(text, idx) {
+        Some(RefTarget::Tag(t)) => assert_eq!(t, "foo"),
+        other => panic!("expected Tag, got {other:?}"),
+    }
+}
+
+#[test]
+fn ref_at_cursor_outside_ref_is_none() {
+    let text = "see [[Avelino]] later";
+    let idx = "see [[Avelino]] la".chars().count();
+    assert!(ref_at_cursor(text, idx).is_none());
+}
+
+#[test]
+fn ref_at_cursor_finds_block_ref() {
+    let text = "see ((blk-r6s4a1)) today";
+    let idx = "see ((blk-r".chars().count();
+    match ref_at_cursor(text, idx) {
+        Some(RefTarget::Block(h)) => assert_eq!(h, "blk-r6s4a1"),
+        other => panic!("expected Block, got {other:?}"),
+    }
+}
+
+#[test]
+fn ref_at_cursor_on_embed_resolves_to_block_target() {
+    let text = "see !((blk-r6s4a1)) today";
+    let on_bang = "see ".chars().count();
+    match ref_at_cursor(text, on_bang) {
+        Some(RefTarget::Block(h)) => assert_eq!(h, "blk-r6s4a1"),
+        other => panic!("cursor on `!`: expected Block, got {other:?}"),
+    }
+    let inside = "see !((blk-r".chars().count();
+    match ref_at_cursor(text, inside) {
+        Some(RefTarget::Block(h)) => assert_eq!(h, "blk-r6s4a1"),
+        other => panic!("cursor inside handle: expected Block, got {other:?}"),
+    }
+}
+
+#[test]
+fn ref_at_cursor_block_ref_ignores_invalid_handle() {
+    let text = "see ((really)) today";
+    let idx = "see ((re".chars().count();
+    assert!(
+        ref_at_cursor(text, idx).is_none(),
+        "invalid handle inside ((..)) must not resolve to a RefTarget"
+    );
+}
+
+#[test]
+fn ref_at_cursor_handles_multibyte() {
+    let text = "veja [[orçamento]] hoje";
+    let idx = "veja [[orç".chars().count();
+    match ref_at_cursor(text, idx) {
+        Some(RefTarget::Page(n)) => assert_eq!(n, "orçamento"),
+        other => panic!("expected Page, got {other:?}"),
+    }
+}
+
+#[test]
+fn byte_index_for_char_is_split_safe() {
+    let s = "está";
+    for c in 0..=s.chars().count() {
+        let b = byte_index_for_char(s, c);
+        let _ = s.split_at(b);
+    }
+    assert_eq!(byte_index_for_char(s, 0), 0);
+    assert_eq!(byte_index_for_char(s, 4), 5);
+}
+
+// --- bugfix regressions (review-driven) -----------------------------
+
+#[test]
+fn ref_at_cursor_recovers_after_invalid_handle() {
+    // `((((blk-r6s4a1))))` — the outer `((` captures `((blk-r6s4a1`
+    // (invalid). The scanner must advance ONE byte and pick up the
+    // inner valid handle at offset 2, not skip past the whole thing.
+    let text = "((((blk-r6s4a1))))";
+    let inside_valid = "((((blk-r".chars().count();
+    match ref_at_cursor(text, inside_valid) {
+        Some(RefTarget::Block(h)) => assert_eq!(h, "blk-r6s4a1"),
+        other => panic!("expected Block, got {other:?}"),
+    }
+}
+
+#[test]
+fn ref_at_cursor_finds_second_block_ref_after_invalid_first() {
+    // Invalid handle first, then a valid one. The greedy scan used
+    // to skip past the second handle when the first's `))` was
+    // consumed defensively.
+    let text = "look ((foo)) and then ((blk-r6s4a1)) yes";
+    let inside = "look ((foo)) and then ((blk-r".chars().count();
+    match ref_at_cursor(text, inside) {
+        Some(RefTarget::Block(h)) => assert_eq!(h, "blk-r6s4a1"),
+        other => panic!("expected Block, got {other:?}"),
+    }
+}

--- a/crates/outl-md/tests/workspace_index.rs
+++ b/crates/outl-md/tests/workspace_index.rs
@@ -1,0 +1,447 @@
+//! End-to-end tests for `WorkspaceIndex` (page + block index).
+//!
+//! Moved out of `src/index.rs` to keep that module under the
+//! file-size-guard limit. Every test here exercises only the public
+//! API surface (build / patch_page / remove_page / lookups), which is
+//! the contract any UI surface — TUI, Tauri, mobile — talks to.
+
+use outl_core::id::NodeId;
+use outl_md::index::WorkspaceIndex;
+use outl_md::parse::parse;
+use outl_md::sidecar::{
+    self, content_hash, derive_ref_handle, file_hash, write as write_sidecar, Sidecar, SidecarBlock,
+};
+use std::fs;
+use tempfile::TempDir;
+
+fn write_workspace(files: &[(&str, &str)]) -> TempDir {
+    let dir = TempDir::new().unwrap();
+    for (rel, content) in files {
+        let full = dir.path().join(rel);
+        if let Some(parent) = full.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(full, content).unwrap();
+    }
+    dir
+}
+
+#[test]
+fn patch_page_replaces_backlinks_for_that_slug_only() {
+    let dir = write_workspace(&[
+        ("pages/avelino.md", "title:: Avelino\n\n- author\n"),
+        (
+            "pages/projeto.md",
+            "title:: Projeto\n\n- led by [[Avelino]]\n",
+        ),
+        ("journals/2026-05-24.md", "- meeting with [[Avelino]]\n"),
+    ]);
+    let mut idx = WorkspaceIndex::build(dir.path());
+    assert_eq!(idx.backlinks("avelino").len(), 2);
+
+    let new_md = "title:: Projeto\n\n- led by [[Other Page]]\n";
+    let new_page = parse(new_md);
+    let proj_path = dir.path().join("pages/projeto.md");
+    idx.patch_page(&proj_path, &new_page);
+
+    let avelino_bls = idx.backlinks("avelino");
+    assert_eq!(avelino_bls.len(), 1, "journal backlink should survive");
+    assert_eq!(avelino_bls[0].source_slug, "2026-05-24");
+
+    let other_bls = idx.backlinks("other-page");
+    assert_eq!(other_bls.len(), 1);
+    assert_eq!(other_bls[0].source_slug, "projeto");
+}
+
+#[test]
+fn patch_page_updates_title_and_icon() {
+    let dir = write_workspace(&[("pages/x.md", "title:: Old Title\nicon:: 🦀\n\n- body\n")]);
+    let mut idx = WorkspaceIndex::build(dir.path());
+    assert_eq!(idx.by_slug("x").unwrap().title, "Old Title");
+    assert_eq!(idx.by_slug("x").unwrap().icon.as_deref(), Some("🦀"));
+
+    let new_page = parse("title:: New Title\nicon:: 🚀\n\n- body\n");
+    idx.patch_page(&dir.path().join("pages/x.md"), &new_page);
+
+    let entry = idx.by_slug("x").unwrap();
+    assert_eq!(entry.title, "New Title");
+    assert_eq!(entry.icon.as_deref(), Some("🚀"));
+    assert!(idx.by_title("Old Title").is_none());
+    assert_eq!(idx.by_title("New Title").unwrap().slug, "x");
+}
+
+#[test]
+fn remove_page_drops_entry_and_its_backlinks() {
+    let dir = write_workspace(&[
+        ("pages/avelino.md", "title:: Avelino\n\n- author\n"),
+        (
+            "pages/projeto.md",
+            "title:: Projeto\n\n- led by [[Avelino]]\n",
+        ),
+    ]);
+    let mut idx = WorkspaceIndex::build(dir.path());
+    assert_eq!(idx.backlinks("avelino").len(), 1);
+
+    idx.remove_page("projeto");
+    assert!(idx.by_slug("projeto").is_none());
+    assert!(idx.by_title("Projeto").is_none());
+    assert!(idx.backlinks("avelino").is_empty());
+}
+
+#[test]
+fn empty_workspace_indexes_to_nothing() {
+    let dir = TempDir::new().unwrap();
+    let idx = WorkspaceIndex::build(dir.path());
+    assert_eq!(idx.page_count(), 0);
+    assert_eq!(idx.block_count(), 0);
+}
+
+#[test]
+fn build_populates_block_index_from_sidecar() {
+    let dir = write_workspace(&[("pages/p.md", "- decide backend\n")]);
+    let page_path = dir.path().join("pages/p.md");
+
+    let page_id = NodeId::new();
+    let block_id = NodeId::new();
+    let mut sc = Sidecar::new_for_page(page_id, &file_hash("- decide backend\n"));
+    sc.blocks.push(SidecarBlock {
+        id: block_id,
+        line: 1,
+        indent: 0,
+        content_hash: content_hash("decide backend"),
+        ref_handle: derive_ref_handle(block_id),
+    });
+    write_sidecar(&sidecar::sidecar_path_for(&page_path), &sc).unwrap();
+
+    let idx = WorkspaceIndex::build(dir.path());
+    assert_eq!(idx.block_count(), 1);
+
+    let handle = derive_ref_handle(block_id);
+    let entry = idx
+        .resolve_block_ref(&handle)
+        .expect("block ref must resolve");
+    assert_eq!(entry.id, block_id);
+    assert_eq!(entry.text, "decide backend");
+    assert_eq!(entry.source_slug, "p");
+}
+
+#[test]
+fn patch_page_refreshes_block_index() {
+    let dir = write_workspace(&[("pages/p.md", "- one\n")]);
+    let page_path = dir.path().join("pages/p.md");
+    let page_id = NodeId::new();
+    let id_one = NodeId::new();
+
+    let mut sc = Sidecar::new_for_page(page_id, &file_hash("- one\n"));
+    sc.blocks.push(SidecarBlock {
+        id: id_one,
+        line: 1,
+        indent: 0,
+        content_hash: content_hash("one"),
+        ref_handle: derive_ref_handle(id_one),
+    });
+    write_sidecar(&sidecar::sidecar_path_for(&page_path), &sc).unwrap();
+
+    let mut idx = WorkspaceIndex::build(dir.path());
+    assert_eq!(idx.block_count(), 1);
+
+    fs::write(&page_path, "- one\n- two\n").unwrap();
+    let id_two = NodeId::new();
+    sc.blocks.push(SidecarBlock {
+        id: id_two,
+        line: 2,
+        indent: 0,
+        content_hash: content_hash("two"),
+        ref_handle: derive_ref_handle(id_two),
+    });
+    sc.last_synced_hash = file_hash("- one\n- two\n");
+    write_sidecar(&sidecar::sidecar_path_for(&page_path), &sc).unwrap();
+
+    let new_page = parse("- one\n- two\n");
+    idx.patch_page(&page_path, &new_page);
+
+    assert_eq!(idx.block_count(), 2);
+    assert!(idx.resolve_block_ref(&derive_ref_handle(id_two)).is_some());
+}
+
+#[test]
+fn patch_page_preserves_cross_page_reverse_refs() {
+    // Regression guard from the code review: in-process edits to a
+    // citing page (B) used to invalidate the reverse-ref bookkeeping
+    // for the target page (A). After patch_page, A's reverse-ref
+    // list must still include B's new citing block.
+    let dir = write_workspace(&[
+        ("pages/a.md", "- target block\n"),
+        ("pages/b.md", "- placeholder\n"),
+    ]);
+    let a_path = dir.path().join("pages/a.md");
+    let b_path = dir.path().join("pages/b.md");
+
+    // Sidecar A: one target block.
+    let id_target = NodeId::new();
+    let mut sc_a = Sidecar::new_for_page(NodeId::new(), &file_hash("- target block\n"));
+    sc_a.blocks.push(SidecarBlock {
+        id: id_target,
+        line: 1,
+        indent: 0,
+        content_hash: content_hash("target block"),
+        ref_handle: derive_ref_handle(id_target),
+    });
+    write_sidecar(&sidecar::sidecar_path_for(&a_path), &sc_a).unwrap();
+
+    // Sidecar B: one placeholder (no ref yet).
+    let id_placeholder = NodeId::new();
+    let mut sc_b = Sidecar::new_for_page(NodeId::new(), &file_hash("- placeholder\n"));
+    sc_b.blocks.push(SidecarBlock {
+        id: id_placeholder,
+        line: 1,
+        indent: 0,
+        content_hash: content_hash("placeholder"),
+        ref_handle: derive_ref_handle(id_placeholder),
+    });
+    write_sidecar(&sidecar::sidecar_path_for(&b_path), &sc_b).unwrap();
+
+    let mut idx = WorkspaceIndex::build(dir.path());
+    assert!(idx.block_refs_to(id_target).is_empty(), "no refs yet");
+
+    // Simulate B saving with a new citing block.
+    let target_handle = derive_ref_handle(id_target);
+    let b_md_after = format!("- placeholder\n- see (({target_handle})) here\n");
+    fs::write(&b_path, &b_md_after).unwrap();
+    let id_cite = NodeId::new();
+    sc_b.blocks.push(SidecarBlock {
+        id: id_cite,
+        line: 2,
+        indent: 0,
+        content_hash: content_hash(&format!("see (({target_handle})) here")),
+        ref_handle: derive_ref_handle(id_cite),
+    });
+    sc_b.last_synced_hash = file_hash(&b_md_after);
+    write_sidecar(&sidecar::sidecar_path_for(&b_path), &sc_b).unwrap();
+    idx.patch_page(&b_path, &parse(&b_md_after));
+
+    let refs = idx.block_refs_to(id_target);
+    assert_eq!(
+        refs.len(),
+        1,
+        "B's new citing block must show in A's reverse refs"
+    );
+    assert_eq!(refs[0].source_slug, "b");
+}
+
+#[test]
+fn block_at_location_returns_none_for_unknown_path() {
+    // Sanity guard for the O(1) location lookup: an out-of-range
+    // DFS path (deeper than the AST, or pointing at a sibling that
+    // doesn't exist) returns None rather than panicking.
+    let dir = write_workspace(&[("pages/p.md", "- alpha\n")]);
+    let page_path = dir.path().join("pages/p.md");
+    let id = NodeId::new();
+    let mut sc = Sidecar::new_for_page(NodeId::new(), &file_hash("- alpha\n"));
+    sc.blocks.push(SidecarBlock {
+        id,
+        line: 1,
+        indent: 0,
+        content_hash: content_hash("alpha"),
+        ref_handle: derive_ref_handle(id),
+    });
+    write_sidecar(&sidecar::sidecar_path_for(&page_path), &sc).unwrap();
+
+    let idx = WorkspaceIndex::build(dir.path());
+    assert!(
+        idx.block_at_location("p", &[0]).is_some(),
+        "real path resolves"
+    );
+    assert!(
+        idx.block_at_location("p", &[0, 7]).is_none(),
+        "deep path → None"
+    );
+    assert!(
+        idx.block_at_location("nope", &[0]).is_none(),
+        "unknown slug → None"
+    );
+}
+
+#[test]
+fn remove_page_drops_block_entries_too() {
+    let dir = write_workspace(&[("pages/p.md", "- alpha\n")]);
+    let page_path = dir.path().join("pages/p.md");
+    let page_id = NodeId::new();
+    let block_id = NodeId::new();
+
+    let mut sc = Sidecar::new_for_page(page_id, &file_hash("- alpha\n"));
+    sc.blocks.push(SidecarBlock {
+        id: block_id,
+        line: 1,
+        indent: 0,
+        content_hash: content_hash("alpha"),
+        ref_handle: derive_ref_handle(block_id),
+    });
+    write_sidecar(&sidecar::sidecar_path_for(&page_path), &sc).unwrap();
+
+    let mut idx = WorkspaceIndex::build(dir.path());
+    assert_eq!(idx.block_count(), 1);
+    idx.remove_page("p");
+    assert_eq!(idx.block_count(), 0);
+    assert!(idx
+        .resolve_block_ref(&derive_ref_handle(block_id))
+        .is_none());
+}
+
+#[test]
+fn pages_get_indexed_by_slug_and_title() {
+    let dir = write_workspace(&[
+        (
+            "pages/avelino.md",
+            "title:: Avelino\n\n- some note about me\n",
+        ),
+        ("pages/projeto.md", "title:: Meu Projeto\n\n- objetivo\n"),
+    ]);
+    let idx = WorkspaceIndex::build(dir.path());
+    assert_eq!(idx.page_count(), 2);
+    assert_eq!(idx.by_slug("avelino").unwrap().title, "Avelino");
+    assert_eq!(idx.by_title("Meu Projeto").unwrap().slug, "projeto");
+}
+
+#[test]
+fn missing_title_falls_back_to_slug() {
+    let dir = write_workspace(&[("pages/no-title.md", "- bare bullet\n")]);
+    let idx = WorkspaceIndex::build(dir.path());
+    assert_eq!(idx.by_slug("no-title").unwrap().title, "no-title");
+}
+
+#[test]
+fn icon_property_is_indexed_and_propagated_to_backlinks() {
+    let dir = write_workspace(&[
+        (
+            "pages/avelino.md",
+            "title:: Avelino\nicon:: 🦀\n\n- author\n",
+        ),
+        (
+            "pages/projeto.md",
+            "title:: Projeto\nicon:: 🚀\n\n- led by [[Avelino]]\n",
+        ),
+        ("pages/bare.md", "title:: Bare\n\n- nothing fancy\n"),
+    ]);
+    let idx = WorkspaceIndex::build(dir.path());
+
+    assert_eq!(idx.by_slug("avelino").unwrap().icon.as_deref(), Some("🦀"));
+    assert_eq!(idx.by_slug("projeto").unwrap().icon.as_deref(), Some("🚀"));
+    assert_eq!(idx.by_slug("bare").unwrap().icon, None);
+
+    let bls = idx.backlinks("avelino");
+    assert_eq!(bls.len(), 1);
+    assert_eq!(bls[0].source_slug, "projeto");
+    assert_eq!(bls[0].source_icon.as_deref(), Some("🚀"));
+}
+
+#[test]
+fn empty_icon_is_treated_as_none() {
+    let dir = write_workspace(&[("pages/x.md", "title:: X\nicon::\n\n- body\n")]);
+    let idx = WorkspaceIndex::build(dir.path());
+    assert_eq!(idx.by_slug("x").unwrap().icon, None);
+}
+
+#[test]
+fn backlinks_are_collected_across_pages() {
+    let dir = write_workspace(&[
+        ("pages/avelino.md", "title:: Avelino\n\n- I am the author\n"),
+        (
+            "pages/projeto.md",
+            "title:: Projeto\n\n- led by [[Avelino]]\n",
+        ),
+        (
+            "journals/2026-05-24.md",
+            "- meeting with [[Avelino]] and #urgent stuff\n",
+        ),
+    ]);
+    let idx = WorkspaceIndex::build(dir.path());
+    let bl = idx.backlinks("avelino");
+    assert_eq!(bl.len(), 2);
+    let slugs: Vec<_> = bl.iter().map(|b| b.source_slug.as_str()).collect();
+    assert!(slugs.contains(&"projeto"));
+    assert!(slugs.contains(&"2026-05-24"));
+
+    let urgent = idx.backlinks("urgent");
+    assert_eq!(urgent.len(), 1);
+}
+
+#[test]
+fn self_references_are_skipped() {
+    let dir = write_workspace(&[(
+        "pages/recursive.md",
+        "title:: Recursive\n\n- I link to [[Recursive]] myself\n",
+    )]);
+    let idx = WorkspaceIndex::build(dir.path());
+    assert!(idx.backlinks("recursive").is_empty());
+}
+
+#[test]
+fn journals_are_treated_as_pages_for_lookup() {
+    let dir = write_workspace(&[("journals/2026-05-24.md", "- entry\n")]);
+    let idx = WorkspaceIndex::build(dir.path());
+    let entry = idx.by_slug("2026-05-24").unwrap();
+    assert!(entry.is_journal);
+}
+
+#[test]
+fn source_block_carries_text_and_children() {
+    let dir = write_workspace(&[
+        ("pages/avelino.md", "title:: Avelino\n\n- author\n"),
+        (
+            "pages/projeto.md",
+            "title:: Projeto\n\n- led by [[Avelino]]\n  - milestone A\n  - milestone B\n",
+        ),
+    ]);
+    let idx = WorkspaceIndex::build(dir.path());
+    let bls = idx.backlinks("avelino");
+    assert_eq!(bls.len(), 1);
+    assert_eq!(bls[0].source_block.text, "led by [[Avelino]]");
+    assert_eq!(bls[0].source_block.children.len(), 2);
+    assert_eq!(bls[0].source_block.children[0].text, "milestone A");
+    assert_eq!(bls[0].source_block.children[1].text, "milestone B");
+}
+
+#[test]
+fn source_block_path_points_to_referencing_block() {
+    let dir = write_workspace(&[
+        ("pages/avelino.md", "title:: Avelino\n\n- author\n"),
+        (
+            "pages/projeto.md",
+            "title:: Projeto\n\n- root block\n  - nested ref to [[Avelino]]\n",
+        ),
+    ]);
+    let idx = WorkspaceIndex::build(dir.path());
+    let bls = idx.backlinks("avelino");
+    assert_eq!(bls.len(), 1);
+    assert_eq!(bls[0].source_block_path, vec![0, 0]);
+    assert_eq!(bls[0].source_block.text, "nested ref to [[Avelino]]");
+}
+
+#[test]
+fn block_with_repeated_reference_only_emits_one_backlink() {
+    let dir = write_workspace(&[
+        ("pages/avelino.md", "title:: Avelino\n\n- author\n"),
+        (
+            "pages/projeto.md",
+            "title:: Projeto\n\n- [[Avelino]] and again [[Avelino]] same block\n",
+        ),
+    ]);
+    let idx = WorkspaceIndex::build(dir.path());
+    assert_eq!(idx.backlinks("avelino").len(), 1);
+}
+
+#[test]
+fn title_prefix_lookup() {
+    let dir = write_workspace(&[
+        ("pages/a.md", "title:: Apple\n\n- a\n"),
+        ("pages/b.md", "title:: Apricot\n\n- a\n"),
+        ("pages/c.md", "title:: Banana\n\n- a\n"),
+    ]);
+    let idx = WorkspaceIndex::build(dir.path());
+    let hits = idx.pages_by_title_prefix("Ap", 10);
+    assert_eq!(hits.len(), 2);
+    let names: Vec<_> = hits.iter().map(|p| p.title.as_str()).collect();
+    assert!(names.contains(&"Apple"));
+    assert!(names.contains(&"Apricot"));
+}

--- a/crates/outl-tui/CLAUDE.md
+++ b/crates/outl-tui/CLAUDE.md
@@ -11,9 +11,18 @@ journal. That's the spec; don't change it.
   block's text).
 - Quick switcher (`Ctrl+P`) for fuzzy page/journal jumping.
 - Outline panel for current page with inline visible cursor.
+- Inline backlinks rendered below the outline (`B` toggles, `j/k`
+  crosses the separator).
+- Block references and embeds: `((blk-XXXXXX))` resolves to the source
+  block's text + page icon. `!((blk-XXXXXX))` (when the block contains a
+  single embed token) expands the source block **and its children**
+  read-only below the carrying block. `Enter` on either form opens the
+  source page and lands the cursor on the referenced block. The `y r`
+  chord plus `/refer` and `/refer-embed` slash commands copy the
+  current block's handle to the **OS clipboard** (via `arboard`) and
+  stash it in `App::last_yanked_ref` for in-app paste; the `((`
+  autocomplete fuzzy-matches block text in Insert.
 - Help popup.
-- Backlinks / tag panels and command palette are stubs (placeholder
-  modules under `ui/`) — phase 3+.
 
 ## Modes
 
@@ -38,12 +47,13 @@ we replace the AST node's `.text` and call `save()`, which writes the
 | `Tab` | indent current block |
 | `Shift-Tab` | outdent current |
 | `j` / `k` / arrows | move selection |
-| `Enter` | open `[[ref]]` / `#tag` / journal under cursor, else Insert |
+| `Enter` | open `[[ref]]` / `#tag` / journal / block ref (`((blk-X))` / `!((blk-X))`) under cursor, else Insert. On a block ref it jumps to the source page and positions the cursor on the referenced block; orphan handles surface a status message and stay put. |
 | `i` / `Enter` | enter Insert at end of current block |
 | `I` | enter Insert at start of current block |
 | `o` | new block below + Insert |
 | `O` | new block above + Insert |
 | `dd` | delete current block (chord) |
+| `y r` | copy current block's ref handle (`((blk-XXXXXX))`) to OS clipboard (via `arboard`) + `last_yanked_ref` (chord). Status flips to `yanked … (clipboard unavailable)` on headless / no-display environments. |
 | `?` | toggle help popup |
 | `q q` | quit (chord — single `q` arms; second `q` confirms) |
 | `Ctrl-C` | quit (commits pending Insert first) |
@@ -60,6 +70,10 @@ we replace the AST node's `.text` and call `save()`, which writes the
 | `Backspace` otherwise | delete previous char |
 | chars / arrows / Home / End | normal text editing |
 | `(`, `[`, `{` | auto-pair with closing |
+| `[[` | page-ref autocomplete (title fuzzy match) |
+| `#` | tag autocomplete |
+| `((` | block-ref autocomplete (block text fuzzy match → inserts `((blk-XXXXXX))`) |
+| `/` | slash command autocomplete (same registry as `:` palette) |
 
 ## Visual conventions
 
@@ -70,9 +84,27 @@ we replace the AST node's `.text` and call `save()`, which writes the
 - Other (non-focused) blocks render markdown prettily: `**bold**`
   shows as bold without asterisks, `*italic*` as italic, `~~strike~~`
   struck through, `` `code` `` in green, `[text](url)` blue-underlined,
-  `[[ref]]` cyan-underlined (no brackets), `#tag` magenta-underlined.
+  `[[ref]]` cyan-underlined (no brackets), `#tag` magenta-underlined,
+  `((blk-XXXXXX))` resolves to the source block's text + page icon
+  (orphan handles render dimmed).
+- `!((blk-XXXXXX))` — when a block contains a single embed token
+  (whitespace OK around it) — expands the source block **and its
+  children** read-only below the carrying block. Conventions:
+  - Every embed row carries a `↳ ` prefix (root + descendants) so the
+    expansion reads as one cohesive block.
+  - Descendants get `2 * (depth + 1)` spaces of padding before `↳ ` so
+    children align under the source root's *text*, not under its `↳ `.
+  - Outer indent (`│ ` guides) matches the carrying block's outline
+    depth.
+  - TODO/DONE checkboxes, page refs and tags render with their normal
+    styling inside the expansion (via `render_pretty_block_text`).
+  - Recursion is capped at depth 4 to break embed cycles.
+  - Expansion runs in every render mode — but the carrying block's
+    first row keeps the raw `!((…))` literal under the cursor so
+    column-byte alignment holds.
 - The selected/editing block renders **raw** (delimiters visible, dimmed)
-  so cursor columns map 1:1 to source bytes.
+  so cursor columns map 1:1 to source bytes — including the literal
+  `((blk-XXXXXX))` and `!((blk-XXXXXX))` forms.
 - IDs are **never** shown.
 - Mode tag (`NORMAL`/`INSERT`) appears in the header.
 
@@ -145,6 +177,7 @@ src/
 
 - `ratatui` + `crossterm` (UI).
 - `outl-core`, `outl-md` (workspace, parse/render/reconcile).
+- `arboard` (OS clipboard for `y r` / `/refer` / `/refer-embed`; degrades to status-line-only on headless).
 - `walkdir`, `toml`, `ulid`, `chrono`, `anyhow`.
 
 ## What this crate does NOT do

--- a/crates/outl-tui/Cargo.toml
+++ b/crates/outl-tui/Cargo.toml
@@ -35,6 +35,10 @@ clap = { workspace = true }
 walkdir = { workspace = true }
 toml = { workspace = true }
 ulid = { workspace = true }
+# Cross-platform OS clipboard for `yr` / `/refer` / `/refer-embed`.
+# `arboard` falls back to a no-op on headless environments (no display
+# server / no $DISPLAY), so test runs and CI stay green.
+arboard = { version = "3", default-features = false }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/outl-tui/src/actions/lifecycle.rs
+++ b/crates/outl-tui/src/actions/lifecycle.rs
@@ -50,6 +50,7 @@ impl App {
             autocomplete: None,
             last_search: None,
             yank_register: Vec::new(),
+            last_yanked_ref: None,
             index: WorkspaceIndex::default(),
             index_rx: None,
             show_backlinks: true,

--- a/crates/outl-tui/src/actions/nav.rs
+++ b/crates/outl-tui/src/actions/nav.rs
@@ -323,8 +323,64 @@ impl App {
             RefTarget::Page(name) | RefTarget::Tag(name) => {
                 self.open_page_by_name(&name)?;
             }
+            RefTarget::Block(handle) => {
+                self.open_block_ref(&handle)?;
+            }
         }
         Ok(true)
+    }
+
+    /// Open the source page of a `((blk-XXXXXX))` reference and put
+    /// the selection on the referenced block.
+    ///
+    /// Resolution path:
+    ///   1. Look the handle up in `WorkspaceIndex::resolve_block_ref`.
+    ///      Orphan handles (no resolution) leave a status message and
+    ///      otherwise no-op — the user keeps their current view.
+    ///   2. Switch `view` to the source page (journal or regular page,
+    ///      detected by the `journals/` ancestor segment in the path).
+    ///   3. Load the page and translate `source_block_path` (a DFS
+    ///      path) into a flat block index via
+    ///      [`crate::outline_ops::index_for_path`]. Falls back to the
+    ///      top of the page if the path no longer resolves (block
+    ///      moved/deleted since the index was built).
+    pub(crate) fn open_block_ref(&mut self, handle: &str) -> Result<()> {
+        let Some(entry) = self.index.resolve_block_ref(handle) else {
+            self.status = format!("ref (({handle})) does not resolve");
+            return Ok(());
+        };
+        let source_path = entry.source_path.clone();
+        let source_block_path = entry.source_block_path.clone();
+
+        // Detect journal vs page from the path layout. Workspace
+        // layout pins journals under `journals/` and pages under
+        // `pages/`; everything else falls back to a page view.
+        let is_journal = source_path
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            == Some("journals");
+        if is_journal {
+            if let Some(stem) = source_path.file_stem().and_then(|s| s.to_str()) {
+                if let Ok(date) = chrono::NaiveDate::parse_from_str(stem, "%Y-%m-%d") {
+                    self.view = View::Journal(date);
+                    self.selected = 0;
+                    self.cursor_col = 0;
+                    self.load_current();
+                    self.selected =
+                        crate::outline_ops::index_for_path(&self.page.blocks, &source_block_path)
+                            .unwrap_or(0);
+                    return Ok(());
+                }
+            }
+        }
+        self.view = View::Page(source_path);
+        self.selected = 0;
+        self.cursor_col = 0;
+        self.load_current();
+        self.selected =
+            crate::outline_ops::index_for_path(&self.page.blocks, &source_block_path).unwrap_or(0);
+        Ok(())
     }
 
     /// Open (or create) the page corresponding to a user-visible name.

--- a/crates/outl-tui/src/actions/overlay.rs
+++ b/crates/outl-tui/src/actions/overlay.rs
@@ -444,6 +444,15 @@ impl App {
                     selected: 0,
                 });
             }
+            Some((AutocompleteKind::BlockRef, query)) => {
+                let candidates = self.candidates_for_blockref(&query);
+                self.autocomplete = Some(AutocompleteState {
+                    kind: AutocompleteKind::BlockRef,
+                    query,
+                    candidates,
+                    selected: 0,
+                });
+            }
             Some((AutocompleteKind::SlashCommand, query)) => {
                 let candidates = self.candidates_for_slash(&query);
                 // No candidates → no popup. Keeps `/` typed in random
@@ -501,6 +510,35 @@ impl App {
         scored.into_iter().take(8).map(|(_, n)| n).collect()
     }
 
+    /// Block-ref candidates for the `((` autocomplete.
+    ///
+    /// Returns **handles** (`blk-XXXXXX`) — the popup looks each one
+    /// up in the index for its display text. Empty query shows the
+    /// most-recent blocks (ULID-sorted descending, so newest first),
+    /// which is deterministic across rebuilds. Non-empty query
+    /// delegates to `WorkspaceIndex::search_block_text` which is
+    /// case-insensitive substring + prefix-first ranking.
+    fn candidates_for_blockref(&self, q: &str) -> Vec<String> {
+        if q.is_empty() {
+            // HashMap iteration order is unstable; sort descending by
+            // NodeId (ULIDs are lexicographically time-sortable) so
+            // the popup shows the same eight rows every keystroke and
+            // newest-edited blocks surface at the top.
+            let mut entries: Vec<_> = self.index.iter_blocks().collect();
+            entries.sort_by_key(|b| std::cmp::Reverse(b.id));
+            return entries
+                .into_iter()
+                .take(8)
+                .map(|b| b.ref_handle.clone())
+                .collect();
+        }
+        self.index
+            .search_block_text(q, 8)
+            .into_iter()
+            .map(|b| b.ref_handle.clone())
+            .collect()
+    }
+
     /// Tag candidates — for now, every page title (tags resolve to pages).
     /// Filtered by fuzzy match on the query.
     fn candidates_for_tag(&self, q: &str) -> Vec<String> {
@@ -547,6 +585,7 @@ impl App {
         // completed token (closing the brackets for refs).
         let trigger_len = match ac.kind {
             AutocompleteKind::PageRef => 2 + ac.query.chars().count(), // `[[query`
+            AutocompleteKind::BlockRef => 2 + ac.query.chars().count(), // `((query`
             AutocompleteKind::Tag => 1 + ac.query.chars().count(),     // `#query`
             AutocompleteKind::SlashCommand => unreachable!("handled above"),
         };
@@ -557,6 +596,10 @@ impl App {
         match ac.kind {
             AutocompleteKind::PageRef => {
                 buffer.insert_str(&format!("[[{choice}]]"));
+            }
+            AutocompleteKind::BlockRef => {
+                // `choice` is the handle (e.g. `blk-r6s4a1`).
+                buffer.insert_str(&format!("(({choice}))"));
             }
             AutocompleteKind::Tag => {
                 buffer.insert_str(&format!("#{choice}"));
@@ -623,6 +666,16 @@ pub(crate) fn detect_trigger(chars: &[char], cursor: usize) -> Option<(Autocompl
                 return None;
             }
             return Some((AutocompleteKind::PageRef, query));
+        }
+        // `((blk-` — look for two `(` in a row. Same shape as PageRef
+        // but with parens — the trigger fires immediately after `((`
+        // so the popup is ready to filter by block text.
+        if prev == '(' && i >= 2 && chars[i - 2] == '(' {
+            let query: String = chars[i..cursor].iter().collect();
+            if query.contains(')') || query.contains('\n') {
+                return None;
+            }
+            return Some((AutocompleteKind::BlockRef, query));
         }
         if prev == '#' {
             // Tag must be word-initial: preceded by start-of-buffer or

--- a/crates/outl-tui/src/actions/yank.rs
+++ b/crates/outl-tui/src/actions/yank.rs
@@ -35,14 +35,14 @@ impl App {
     ///
     /// Looks up the block in the workspace index by `(source_slug,
     /// source_block_path)` and stashes its `((blk-XXXXXX))` form on
-    /// `last_yanked_ref` + the status line. UI clients with a real
-    /// OS clipboard can read `last_yanked_ref` and pipe it through;
-    /// the TUI today surfaces the handle visually so the user can
-    /// copy it with the terminal's own selection.
+    /// `last_yanked_ref` + the status line. `arboard` also writes it
+    /// to the OS clipboard so a regular paste works in other apps;
+    /// the status line falls back to `(clipboard unavailable)` on
+    /// headless / no-display environments.
     ///
-    /// Lookup is linear in the indexed block count. For the workspace
-    /// sizes we ship in phase 1 that's well under a millisecond — the
-    /// bench in #12 will revisit if profiling proves otherwise.
+    /// Lookup is O(1) — `WorkspaceIndex::block_at_location` uses the
+    /// `(slug, dfs_path) → NodeId` secondary index, so the chord stays
+    /// snappy regardless of workspace size.
     pub(crate) fn yank_current_ref(&mut self) {
         match self.current_block_ref_handle() {
             Some(h) => {

--- a/crates/outl-tui/src/actions/yank.rs
+++ b/crates/outl-tui/src/actions/yank.rs
@@ -2,9 +2,101 @@
 //! Visual `y` copies the range, `p` / `P` paste after / before.
 
 use crate::outline_ops::{flat_count, index_for_path, node_at_path, path_for_index, siblings_mut};
-use crate::state::{App, Mode};
+use crate::state::{App, Mode, View};
+
+/// Best-effort copy of `text` to the OS clipboard.
+///
+/// Returns `true` on success. Failures (no display server, missing
+/// clipboard daemon, sandboxed terminal, headless CI) are swallowed
+/// — the caller still has `last_yanked_ref` + status as the fallback
+/// surface. We never panic over clipboard plumbing.
+fn copy_to_os_clipboard(text: &str) -> bool {
+    arboard::Clipboard::new()
+        .and_then(|mut c| c.set_text(text.to_string()))
+        .is_ok()
+}
+
+/// Build the status-line message after a yank attempt.
+///
+/// `kind` is the human label (`"ref"`, `"embed"`); `token` is the
+/// thing that landed on the clipboard. `copied` flips the wording so
+/// the user knows whether to expect a paste to work.
+fn clipboard_message(kind: &str, token: &str, copied: bool) -> String {
+    if copied {
+        format!("copied {kind} {token} to clipboard")
+    } else {
+        format!("yanked {kind} {token} (clipboard unavailable)")
+    }
+}
 
 impl App {
+    /// `yr` — capture the block ref handle of the currently selected
+    /// block.
+    ///
+    /// Looks up the block in the workspace index by `(source_slug,
+    /// source_block_path)` and stashes its `((blk-XXXXXX))` form on
+    /// `last_yanked_ref` + the status line. UI clients with a real
+    /// OS clipboard can read `last_yanked_ref` and pipe it through;
+    /// the TUI today surfaces the handle visually so the user can
+    /// copy it with the terminal's own selection.
+    ///
+    /// Lookup is linear in the indexed block count. For the workspace
+    /// sizes we ship in phase 1 that's well under a millisecond — the
+    /// bench in #12 will revisit if profiling proves otherwise.
+    pub(crate) fn yank_current_ref(&mut self) {
+        match self.current_block_ref_handle() {
+            Some(h) => {
+                let token = format!("(({h}))");
+                self.last_yanked_ref = Some(token.clone());
+                self.status = clipboard_message("ref", &token, copy_to_os_clipboard(&token));
+            }
+            None => {
+                self.status = "no ref handle yet — save and retry".into();
+            }
+        }
+    }
+
+    /// Yank the **embed** form of the current block: `!((blk-XXXXXX))`.
+    ///
+    /// Same lookup as [`yank_current_ref`] but stores the embed
+    /// formatting so a downstream paste expands the source block
+    /// inline instead of linking to it.
+    pub(crate) fn yank_current_embed(&mut self) {
+        match self.current_block_ref_handle() {
+            Some(h) => {
+                let token = format!("!(({h}))");
+                self.last_yanked_ref = Some(token.clone());
+                self.status = clipboard_message("embed", &token, copy_to_os_clipboard(&token));
+            }
+            None => {
+                self.status = "no ref handle yet — save and retry".into();
+            }
+        }
+    }
+
+    /// Resolve the selected block's stable ref handle by looking up
+    /// `(source_slug, source_block_path)` in the workspace index.
+    ///
+    /// O(1) thanks to `WorkspaceIndex::block_at_location`. Returns
+    /// `None` when:
+    /// - the cursor isn't on a real block (empty page edge case), or
+    /// - the block was just created in-memory and the sidecar hasn't
+    ///   landed yet (no `BlockEntry` to find).
+    pub(crate) fn current_block_ref_handle(&self) -> Option<String> {
+        let path = path_for_index(&self.page.blocks, self.selected)?;
+        let slug = match &self.view {
+            View::Page(p) => p
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .map(|s| s.to_string())
+                .unwrap_or_default(),
+            View::Journal(d) => d.format("%Y-%m-%d").to_string(),
+        };
+        self.index
+            .block_at_location(&slug, &path)
+            .map(|b| b.ref_handle.clone())
+    }
+
     /// Copy the current block (with its subtree) into the yank
     /// register. Doesn't mutate the page.
     pub(crate) fn yank_current(&mut self) {

--- a/crates/outl-tui/src/commands/builtins/mod.rs
+++ b/crates/outl-tui/src/commands/builtins/mod.rs
@@ -27,6 +27,7 @@
 mod dates;
 mod exec;
 mod page;
+mod refer;
 mod workspace;
 
 use super::CommandRegistry;
@@ -40,6 +41,7 @@ use dates::{
 };
 use exec::{RunCommand, SearchCommand, ThemeCommand};
 use page::{PinCommand, PropBlockCommand, PropPageCommand};
+use refer::{ReferCommand, ReferEmbedCommand};
 use workspace::{
     HelpCommand, OpenCommand, QuitCommand, RefreshCommand, TodayCommand, WriteCommand,
 };
@@ -63,6 +65,10 @@ pub(super) fn register_all(reg: &mut CommandRegistry) {
     reg.register(SearchCommand);
     reg.register(RunCommand);
     reg.register(ThemeCommand);
+
+    // refer — capture block ref / embed handles
+    reg.register(ReferCommand);
+    reg.register(ReferEmbedCommand);
 
     // dates — Insert-mode inserters. The slash dispatcher uses
     // `inserts_inline()` (set true in each command) to skip

--- a/crates/outl-tui/src/commands/builtins/refer.rs
+++ b/crates/outl-tui/src/commands/builtins/refer.rs
@@ -1,0 +1,48 @@
+//! `/refer` and `/refer-embed` — capture the current block's ref/embed
+//! handle for later paste.
+//!
+//! These are normal-mode commands (palette `:refer` or slash `/refer`
+//! from outside Insert). They do **not** insert into the buffer — they
+//! stash `((handle))` / `!((handle))` in `App::last_yanked_ref` and
+//! surface the token on the status line so the user can copy it via
+//! the terminal's own selection or via a future clipboard binding.
+//!
+//! Lookup goes through `App::current_block_ref_handle`, which walks
+//! the workspace index for the selected `(slug, dfs_path)`. Identical
+//! semantics to the `yr` chord; these commands give the same
+//! capability a discoverable, typeable name.
+
+use anyhow::Result;
+
+use super::super::SlashCommand;
+use crate::state::App;
+
+/// `/refer` — capture `((blk-XXXXXX))` for the current block.
+pub struct ReferCommand;
+impl SlashCommand for ReferCommand {
+    fn name(&self) -> &'static str {
+        "refer"
+    }
+    fn description(&self) -> &'static str {
+        "Capture ((blk-XXXXXX)) of the current block (stash + status, no insert)"
+    }
+    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
+        app.yank_current_ref();
+        Ok(false)
+    }
+}
+
+/// `/refer-embed` — capture `!((blk-XXXXXX))` for the current block.
+pub struct ReferEmbedCommand;
+impl SlashCommand for ReferEmbedCommand {
+    fn name(&self) -> &'static str {
+        "refer-embed"
+    }
+    fn description(&self) -> &'static str {
+        "Capture !((blk-XXXXXX)) embed of the current block (stash + status, no insert)"
+    }
+    fn execute(&self, app: &mut App, _args: &str) -> Result<bool> {
+        app.yank_current_embed();
+        Ok(false)
+    }
+}

--- a/crates/outl-tui/src/input.rs
+++ b/crates/outl-tui/src/input.rs
@@ -360,6 +360,15 @@ pub(crate) fn handle_normal_key(app: &mut App, key: KeyEvent) -> Result<bool> {
                 app.yank_current();
                 return Ok(false);
             }
+            ('y', KeyCode::Char('r')) => {
+                // `yr` — yank the **block ref handle** of the
+                // currently selected block. Surfaces `((blk-XXXXXX))`
+                // in the status line and stashes it in
+                // `last_yanked_ref` so a later paste/insert command
+                // can use it.
+                app.yank_current_ref();
+                return Ok(false);
+            }
             ('q', KeyCode::Char('q')) => {
                 // Confirmed quit. The first `q` armed the chord; the
                 // second within one keystroke window seals the deal.

--- a/crates/outl-tui/src/state.rs
+++ b/crates/outl-tui/src/state.rs
@@ -292,6 +292,10 @@ pub(crate) enum AutocompleteKind {
     PageRef,
     /// User typed `#`; pick a tag (any existing page name).
     Tag,
+    /// User typed `((`; pick a block by its text. Candidates are
+    /// **handles** (`blk-XXXXXX`); the popup looks each handle's
+    /// `BlockEntry.text` up in the index for display.
+    BlockRef,
     /// User typed `/` at the start of a word; pick a slash command.
     /// On accept, the trigger + query are removed from the buffer
     /// and the command runs (or pops the `:` palette for arg entry).
@@ -365,6 +369,12 @@ pub(crate) struct App {
     /// Yank register — one or more blocks copied via `yy` (Normal) or
     /// `y` (Visual). `p` / `P` paste these.
     pub(crate) yank_register: Vec<OutlineNode>,
+
+    /// Last `((blk-XXXXXX))` token yanked via the `yr` chord. Lets the
+    /// user pick a block ref handle without leaving the keyboard:
+    /// `yr` to capture, then type / paste manually somewhere else.
+    /// `None` means the chord was never invoked in this session.
+    pub(crate) last_yanked_ref: Option<String>,
 
     /// Derived index of pages, titles and backlinks. Used by the
     /// backlinks panel, quick switcher, autocomplete, icon decoration.

--- a/crates/outl-tui/src/view/inline.rs
+++ b/crates/outl-tui/src/view/inline.rs
@@ -34,23 +34,47 @@ pub(crate) fn render_pretty_block_text(
     theme: &Theme,
     index: &outl_md::index::WorkspaceIndex,
 ) -> Vec<Span<'static>> {
+    render_pretty_block_text_impl(text, theme, index, true)
+}
+
+/// Internal variant that controls whether `InlineTok::Embed` tokens
+/// inside `text` are expanded again. Set `expand_embed = false` when
+/// the caller is *already* rendering an embed's body — otherwise
+/// `A` embedding `B` while `B` embeds `A` (or even `A` itself) would
+/// recurse forever and blow the stack.
+fn render_pretty_block_text_impl(
+    text: &str,
+    theme: &Theme,
+    index: &outl_md::index::WorkspaceIndex,
+    expand_embed: bool,
+) -> Vec<Span<'static>> {
     let (todo_state, body) = split_todo_prefix(text);
     let mut out: Vec<Span<'static>> = Vec::new();
     match todo_state {
         Some(false) => {
             out.push(Span::styled("☐ ", theme.todo_open));
-            out.extend(render_markdown_inline(body, theme, index));
+            out.extend(render_markdown_inline_impl(
+                body,
+                theme,
+                index,
+                expand_embed,
+            ));
         }
         Some(true) => {
             out.push(Span::styled("☑ ", theme.todo_done));
-            for sp in render_markdown_inline(body, theme, index) {
+            for sp in render_markdown_inline_impl(body, theme, index, expand_embed) {
                 out.push(Span::styled(
                     sp.content.into_owned(),
                     sp.style.patch(theme.todo_done_body),
                 ));
             }
         }
-        None => out.extend(render_markdown_inline(text, theme, index)),
+        None => out.extend(render_markdown_inline_impl(
+            text,
+            theme,
+            index,
+            expand_embed,
+        )),
     }
     out
 }
@@ -71,6 +95,20 @@ pub(crate) fn render_markdown_inline(
     text: &str,
     theme: &Theme,
     index: &outl_md::index::WorkspaceIndex,
+) -> Vec<Span<'static>> {
+    render_markdown_inline_impl(text, theme, index, true)
+}
+
+/// Internal variant: when `expand_embed = false`, `InlineTok::Embed`
+/// renders as its raw `!((handle))` form (dim) instead of recursing
+/// into the source block. The Embed arm passes `false` to its own
+/// recursive call so an A → B → A cycle terminates after a single
+/// expansion. Doctor still surfaces the citation in either direction.
+fn render_markdown_inline_impl(
+    text: &str,
+    theme: &Theme,
+    index: &outl_md::index::WorkspaceIndex,
+    expand_embed: bool,
 ) -> Vec<Span<'static>> {
     let mut out = Vec::new();
     for tok in tokenize(text) {
@@ -121,12 +159,20 @@ pub(crate) fn render_markdown_inline(
                 }
             }
             InlineTok::Embed { handle } => {
+                // Cycle / recursion guard: when this call is itself
+                // rendering an embedded block's body, treat the inner
+                // embed as raw text. That breaks `A → B → A` cycles
+                // and bounds rendering work at one level of expansion.
+                if !expand_embed {
+                    out.push(Span::styled(format!("!(({handle}))"), theme.dim));
+                    continue;
+                }
                 // Inline read-only render: `↳ ` prefix marks "this row
                 // belongs to an embed", and the source block's text is
-                // pushed through `render_pretty_block_text` so TODO /
-                // DONE prefixes, `[[refs]]`, `#tags`, bold etc. all
-                // render properly — same affordance the carrying
-                // block would get if it lived in the outline directly.
+                // pushed through `render_pretty_block_text_impl` (with
+                // `expand_embed = false`) so TODO / DONE prefixes,
+                // `[[refs]]`, `#tags`, bold etc. render but a nested
+                // `!((blk-Y))` inside `entry.text` doesn't recurse.
                 // The subtree below this row (rendered by
                 // `emit_embedded_children`) uses the same `↳ ` prefix
                 // so the whole embed reads as one visual block.
@@ -139,7 +185,15 @@ pub(crate) fn render_markdown_inline(
                             out.push(Span::styled(format!("{icon} "), theme.dim));
                         }
                         out.push(Span::styled("↳ ".to_string(), theme.dim));
-                        out.extend(render_pretty_block_text(&entry.text, theme, index));
+                        // `expand_embed = false`: stop recursive embed
+                        // expansion at this depth so a nested embed in
+                        // `entry.text` shows up raw and doesn't cycle.
+                        out.extend(render_pretty_block_text_impl(
+                            &entry.text,
+                            theme,
+                            index,
+                            false,
+                        ));
                     }
                     None => {
                         out.push(Span::styled(format!("!(({handle}))"), theme.dim));

--- a/crates/outl-tui/src/view/inline.rs
+++ b/crates/outl-tui/src/view/inline.rs
@@ -21,6 +21,40 @@ pub(crate) fn split_todo_prefix(text: &str) -> (Option<bool>, &str) {
     (None, text)
 }
 
+/// Render a block's body the way the outline renders it in read-only
+/// mode: strip and visualize a `TODO`/`DONE` prefix, then pass the
+/// remainder through [`render_markdown_inline`].
+///
+/// Used by the outline (for single-line bullets) **and** by the embed
+/// expansion (which needs the same affordance — a `TODO` inside an
+/// embedded block should still render as `☐` so the reader sees
+/// state, not the raw word).
+pub(crate) fn render_pretty_block_text(
+    text: &str,
+    theme: &Theme,
+    index: &outl_md::index::WorkspaceIndex,
+) -> Vec<Span<'static>> {
+    let (todo_state, body) = split_todo_prefix(text);
+    let mut out: Vec<Span<'static>> = Vec::new();
+    match todo_state {
+        Some(false) => {
+            out.push(Span::styled("☐ ", theme.todo_open));
+            out.extend(render_markdown_inline(body, theme, index));
+        }
+        Some(true) => {
+            out.push(Span::styled("☑ ", theme.todo_done));
+            for sp in render_markdown_inline(body, theme, index) {
+                out.push(Span::styled(
+                    sp.content.into_owned(),
+                    sp.style.patch(theme.todo_done_body),
+                ));
+            }
+        }
+        None => out.extend(render_markdown_inline(text, theme, index)),
+    }
+    out
+}
+
 /// Render with markdown stripped — bold/italic/code/strike applied as
 /// styles, `[[ref]]` / `#tag` / `[text](url)` shown without their
 /// delimiters. Used when the block is read-only (not selected, not in
@@ -61,6 +95,57 @@ pub(crate) fn render_markdown_inline(
             InlineTok::Strike { inner } => out.push(Span::styled(inner.to_string(), theme.strike)),
             InlineTok::Code { inner } => out.push(Span::styled(inner.to_string(), theme.code)),
             InlineTok::Link { text, .. } => out.push(Span::styled(text.to_string(), theme.md_link)),
+            InlineTok::BlockRef { handle } => {
+                // Resolve the handle to the source block's text and
+                // surface it inline, Roam-style. Citing-block readers
+                // see content, not a UUID-ish handle.
+                //
+                // Unresolved handles (orphan reference: source block
+                // deleted or never indexed) render dimmed with the
+                // handle visible so `outl doctor` (#10) has something
+                // to point at and the user understands what broke.
+                match index.resolve_block_ref(handle) {
+                    Some(entry) => {
+                        // Source page icon — same affordance as PageRef.
+                        if let Some(icon) = index
+                            .by_slug(&entry.source_slug)
+                            .and_then(|p| p.icon.as_deref())
+                        {
+                            out.push(Span::styled(format!("{icon} "), theme.dim));
+                        }
+                        out.push(Span::styled(entry.text.clone(), theme.ref_link));
+                    }
+                    None => {
+                        out.push(Span::styled(format!("(({handle}))"), theme.dim));
+                    }
+                }
+            }
+            InlineTok::Embed { handle } => {
+                // Inline read-only render: `↳ ` prefix marks "this row
+                // belongs to an embed", and the source block's text is
+                // pushed through `render_pretty_block_text` so TODO /
+                // DONE prefixes, `[[refs]]`, `#tags`, bold etc. all
+                // render properly — same affordance the carrying
+                // block would get if it lived in the outline directly.
+                // The subtree below this row (rendered by
+                // `emit_embedded_children`) uses the same `↳ ` prefix
+                // so the whole embed reads as one visual block.
+                match index.resolve_block_ref(handle) {
+                    Some(entry) => {
+                        if let Some(icon) = index
+                            .by_slug(&entry.source_slug)
+                            .and_then(|p| p.icon.as_deref())
+                        {
+                            out.push(Span::styled(format!("{icon} "), theme.dim));
+                        }
+                        out.push(Span::styled("↳ ".to_string(), theme.dim));
+                        out.extend(render_pretty_block_text(&entry.text, theme, index));
+                    }
+                    None => {
+                        out.push(Span::styled(format!("!(({handle}))"), theme.dim));
+                    }
+                }
+            }
         }
     }
     out
@@ -107,6 +192,22 @@ pub(crate) fn highlight_inline(text: &str, theme: &Theme) -> Vec<Span<'static>> 
                 out.push(Span::styled("[".to_string(), dim));
                 out.push(Span::styled(text.to_string(), theme.md_link));
                 out.push(Span::styled(format!("]({url})"), dim));
+            }
+            InlineTok::BlockRef { handle } => {
+                // Cursor-bearing render keeps the `((...))` delimiters
+                // dimmed so column-to-byte alignment for the visible
+                // cursor stays 1:1 with the source bytes.
+                out.push(Span::styled("((".to_string(), dim));
+                out.push(Span::styled(handle.to_string(), theme.ref_link));
+                out.push(Span::styled("))".to_string(), dim));
+            }
+            InlineTok::Embed { handle } => {
+                // Cursor-bearing render: full raw source so column
+                // accounting stays exact while the user is editing
+                // the embed token itself.
+                out.push(Span::styled("!((".to_string(), dim));
+                out.push(Span::styled(handle.to_string(), theme.ref_link));
+                out.push(Span::styled("))".to_string(), dim));
             }
         }
     }

--- a/crates/outl-tui/src/view/outline.rs
+++ b/crates/outl-tui/src/view/outline.rs
@@ -5,12 +5,28 @@
 use crate::outline_ops::path_for_index;
 use crate::state::{App, Focus, Mode};
 use crate::theme::Theme;
-use crate::view::inline::{highlight_inline, render_markdown_inline, split_todo_prefix};
-use outl_md::inline::byte_index_for_char;
+use crate::view::inline::{
+    highlight_inline, render_markdown_inline, render_pretty_block_text, split_todo_prefix,
+};
+use outl_md::inline::{byte_index_for_char, tokenize, InlineTok};
 use outl_md::parse::{OutlineNode, ParsedPage};
 use outl_md::view::{block_to_rows, BlockRowKind};
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
+
+/// Maximum AST nesting depth we'll render inside a single embed
+/// expansion. Caps the size of the visual block we draw under one
+/// `!((blk-XXXXXX))` — a deeply nested source subtree gets truncated
+/// instead of flooding the outline.
+///
+/// **Not a cycle protector.** Embed-of-embed (a source block whose
+/// own text is another `!((blk-Y))`) is rendered inline with the `↳ `
+/// marker by `render_pretty_block_text`; it is *not* recursively
+/// expanded here. So an `A → B → A` cycle never enters this recursion
+/// and the cap doesn't need to defend against it. If recursive embed
+/// expansion ever lands, add a `visited: &HashSet<&str>` argument and
+/// short-circuit when the current handle is already in the set.
+const EMBED_MAX_DEPTH: u32 = 4;
 
 /// Render the outline into a flat list of `Line`s for ratatui, and
 /// report the visual line index where the *selected* block's bullet
@@ -106,9 +122,103 @@ pub(crate) fn render_block(
         prop_spans.push(Span::styled(v.clone(), app.theme.property_value));
         out.push(Line::from(prop_spans));
     }
+
+    // Expand `!((blk-XXXXXX))` embeds as a read-only subtree under
+    // the carrying block. Triggered when:
+    //   - the block's text resolves to a single Embed token
+    //     (mixed prose keeps the inline `↳ <text>` render);
+    //   - the handle resolves through the workspace index.
+    // The expanded rows are visual-only — they don't move `cursor`
+    // (the flat index used for navigation), so `j` / `k` cross them
+    // in one step instead of paging through borrowed content. The
+    // carrying block's own row keeps whatever render `mode` chose
+    // (raw with cursor, raw with caret, or pretty) so column-to-byte
+    // alignment is never broken by the expansion.
+    if let Some(handle) = embed_only_handle(&b.text) {
+        if let Some(entry) = app.index.resolve_block_ref(handle) {
+            // `outer_indent` matches the carrying block's own indent so
+            // the `│ ` guides line up with the outline's normal indent
+            // pattern. Embed-internal nesting comes from `depth`.
+            emit_embedded_children(&entry.children, indent, 1, app, out);
+        }
+    }
+
     *cursor += 1;
     for child in &b.children {
         render_block(child, indent + 1, cursor, app, out, selected_line);
+    }
+}
+
+/// Return the handle if `text` is a single `!((blk-XXXXXX))` token
+/// surrounded only by whitespace; `None` otherwise.
+///
+/// Mixed content (`prelude !((blk-X)) postlude`) keeps the inline
+/// `↳ <text>` render — we only expand when the user clearly meant
+/// the whole block to *be* the embed.
+fn embed_only_handle(text: &str) -> Option<&str> {
+    let mut handle: Option<&str> = None;
+    for tok in tokenize(text.trim()) {
+        match tok {
+            InlineTok::Plain(s) if s.trim().is_empty() => continue,
+            InlineTok::Embed { handle: h } if handle.is_none() => handle = Some(h),
+            _ => return None,
+        }
+    }
+    handle
+}
+
+/// Emit a source block's subtree underneath the embedding block.
+///
+/// Each row gets the same `↳ ` prefix the embed's first row carries
+/// so the whole expansion reads as one cohesive block visually. Two
+/// indent layers are stacked per row:
+///
+/// 1. `│ ` per ancestor indent of the carrying block (matches the
+///    outline's own indent guides so the embed sits under the right
+///    parent at a glance);
+/// 2. two spaces per embed-subtree depth, so a child of the embed's
+///    root lands visually under the root's `↳ ` instead of next to
+///    it (otherwise the reader can't tell whether the row is a
+///    sibling of the carrying block or a child of the source).
+///
+/// Depth-capped at [`EMBED_MAX_DEPTH`] so an embed cycle can't run
+/// forever.
+fn emit_embedded_children(
+    children: &[OutlineNode],
+    outer_indent: u32,
+    depth: u32,
+    app: &App,
+    out: &mut Vec<Line<'static>>,
+) {
+    if depth > EMBED_MAX_DEPTH {
+        return;
+    }
+    for child in children {
+        let mut spans: Vec<Span<'static>> = Vec::new();
+        // 1. Outline indent guides (mirrors what `emit_block_lines`
+        //    draws for a regular block at the same depth in the doc).
+        for _ in 0..outer_indent {
+            spans.push(Span::styled("│ ", app.theme.dim));
+        }
+        // 2. Embed-internal indent so children land **below the source
+        //    root's text**, not alongside its `↳ `. The carrying
+        //    block's first row reads `- ↳ <root-text>`: bullet + space
+        //    + `↳` + space = four cells before the root text starts.
+        //    A child needs to clear those four cells plus one more
+        //    embed-indent step (two cells) before its own `↳ `, then
+        //    another two per nested level. `(depth + 1) * 2` spaces
+        //    keeps the geometry: depth 1 → 4 spaces, depth 2 → 6, etc.
+        for _ in 0..(depth + 1) {
+            spans.push(Span::raw("  "));
+        }
+        spans.push(Span::styled("↳ ", app.theme.dim));
+        spans.extend(render_pretty_block_text(
+            &child.text,
+            &app.theme,
+            &app.index,
+        ));
+        out.push(Line::from(spans));
+        emit_embedded_children(&child.children, outer_indent, depth + 1, app, out);
     }
 }
 
@@ -280,4 +390,39 @@ fn emit_row_with_cursor(
 enum CursorStyle {
     Caret,
     Block,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embed_only_handle_detects_bare_token() {
+        assert_eq!(embed_only_handle("!((blk-r6s4a1))"), Some("blk-r6s4a1"));
+    }
+
+    #[test]
+    fn embed_only_handle_ignores_surrounding_whitespace() {
+        assert_eq!(embed_only_handle("  !((blk-r6s4a1))  "), Some("blk-r6s4a1"));
+    }
+
+    #[test]
+    fn embed_only_handle_rejects_mixed_text() {
+        assert_eq!(embed_only_handle("see !((blk-r6s4a1)) context"), None);
+    }
+
+    #[test]
+    fn embed_only_handle_rejects_inline_ref() {
+        // `((blk-X))` (no leading `!`) is a ref, not an embed —
+        // must not trigger expansion.
+        assert_eq!(embed_only_handle("((blk-r6s4a1))"), None);
+    }
+
+    #[test]
+    fn embed_only_handle_rejects_two_embeds_on_one_block() {
+        // Two embeds in the same block is ambiguous (which one expands
+        // first?) — phase 1 keeps the rule strict: exactly one token,
+        // surrounded by whitespace.
+        assert_eq!(embed_only_handle("!((blk-aaaaaa)) !((blk-bbbbbb))"), None);
+    }
 }

--- a/crates/outl-tui/src/view/overlays.rs
+++ b/crates/outl-tui/src/view/overlays.rs
@@ -36,6 +36,7 @@ pub(crate) fn render_autocomplete(
     let title = match ac.kind {
         AutocompleteKind::PageRef => format!("[[{}]]", ac.query),
         AutocompleteKind::Tag => format!("#{}", ac.query),
+        AutocompleteKind::BlockRef => format!("(({}))", ac.query),
         AutocompleteKind::SlashCommand => format!("/{}", ac.query),
     };
     let items: Vec<ListItem<'_>> = ac
@@ -66,6 +67,20 @@ pub(crate) fn render_autocomplete(
                         None => c.clone(),
                     };
                     ListItem::new(Line::from(Span::styled(label, style)))
+                }
+                AutocompleteKind::BlockRef => {
+                    // `c` is the handle. Resolve to the block's text
+                    // for display — that's what the user is hunting
+                    // for; the raw handle would be unreadable.
+                    let text = app
+                        .index
+                        .resolve_block_ref(c)
+                        .map(|b| b.text.clone())
+                        .unwrap_or_else(|| c.clone());
+                    ListItem::new(Line::from(vec![
+                        Span::styled(text, style),
+                        Span::styled(format!("  {c}"), app.theme.dim),
+                    ]))
                 }
                 AutocompleteKind::SlashCommand => {
                     let cmd = app.command_registry.get(c);

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -96,13 +96,13 @@ content hashes:
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "page_id": "01J...",
   "last_synced_hash": "sha256:...",
   "last_synced_at": "2026-05-25T...",
   "blocks": [
-    {"id": "01J...", "line": 3, "indent": 0, "content_hash": "sha256:..."},
-    {"id": "01J...", "line": 4, "indent": 1, "content_hash": "sha256:..."}
+    {"id": "01J...", "line": 3, "indent": 0, "content_hash": "sha256:...", "ref_handle": "blk-r6s4a1"},
+    {"id": "01J...", "line": 4, "indent": 1, "content_hash": "sha256:...", "ref_handle": "blk-r6s4a2"}
   ]
 }
 ```
@@ -110,6 +110,10 @@ content hashes:
 Filename is a dotfile: `pages/avelino.md` ↔ `pages/.avelino.outl`.
 Hidden from `ls` by default; gitignorable if you want (but you'd lose
 ID stability across devices).
+
+`ref_handle` is the short, stable handle used by inline block
+references (`((blk-XXXXXX))`) and embeds (`!((blk-XXXXXX))`). See
+[`docs/markdown-format.md`](markdown-format.md#block-refs-and-embeds).
 
 ### Op log
 

--- a/docs/markdown-format.md
+++ b/docs/markdown-format.md
@@ -134,9 +134,46 @@ The third line (`- this is a regular child block`) is a real child.
 | `[[name]]` | Reference to page named "name" |
 | `[[2026-05-24]]` | Reference to journal "2026-05-24" (rendered as date) |
 | `#name` | Tag (page reference with classification semantics) |
-| `((block-id))` | Embed of block with given ID |
+| `((blk-XXXXXX))` | Block reference — renders as the source block's text, links to it |
+| `!((blk-XXXXXX))` | Block embed — renders the source block expanded with its subtree |
 | `{{query: ...}}` | Saved query (phase 3 — parse as opaque) |
 | `**bold**`, `*italic*`, `\`code\`` | Standard CommonMark |
+
+#### Block refs and embeds
+
+`((blk-XXXXXX))` is an inline reference to another block. The handle is
+short, lowercase, and human-typeable — it's the last 6 Crockford base32
+characters of the block's ULID, prefixed with `blk-`. Renderers resolve
+the handle through the workspace index and display the source block's
+text in place; the on-disk `.md` keeps the literal `((blk-XXXXXX))`.
+
+`!((blk-XXXXXX))` is the embed form. Same lookup, but the consumer
+expands the source block **and its subtree** inline. Mirrors the markdown
+image syntax (`![alt](url)` → "expand") so the `!` reads as the visual
+hint for inflation.
+
+```
+- decide which database to use #decision
+- in [[Project X]], see ((blk-r6s4a1)) for context
+- the whole thread: !((blk-r6s4a1))
+```
+
+Handles are persisted in the sidecar (see [§sidecar](#the-outl-sidecar))
+so a future change to the derivation scheme cannot break references
+already living in `.md` files. An orphaned handle (citation points at a
+block that no longer exists) renders dimmed in the TUI and is flagged
+by `outl doctor`.
+
+Handle collisions are vanishingly unlikely — 6 lowercase base32 chars is
+~30 bits, ~5×10⁻⁶ birthday probability at 100k blocks. When two blocks
+do land on the same base handle, the second block's handle is lazily
+expanded one character at a time (from the ULID's Crockford base32 tail)
+until unique within the workspace, so both the winner and the loser stay
+resolvable through their own (distinct) handles. The on-disk sidecar
+still records the deterministic 6-char handle — the divergence lives in
+memory until a future reconcile rewrites it. Workspaces that ever
+expanded a handle to 7+ characters keep working forever because lookup
+goes through the in-memory handle, not the literal sidecar field.
 
 ### What is **not** in the file
 
@@ -156,7 +193,7 @@ Format: JSON.
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "page_id": "01HXY8KJZQ9T8M7VN3P2R6S4A0",
   "last_synced_hash": "sha256:e3b0c44298fc1c14...",
   "last_synced_at": "2026-05-24T11:22:00-03:00",
@@ -165,13 +202,15 @@ Format: JSON.
       "id": "01HXY8KJZQ9T8M7VN3P2R6S4A1",
       "line": 7,
       "indent": 0,
-      "content_hash": "sha256:abc123..."
+      "content_hash": "sha256:abc123...",
+      "ref_handle": "blk-r6s4a1"
     },
     {
       "id": "01HXY8KJZQ9T8M7VN3P2R6S4A2",
       "line": 8,
       "indent": 1,
-      "content_hash": "sha256:def456..."
+      "content_hash": "sha256:def456...",
+      "ref_handle": "blk-r6s4a2"
     }
   ]
 }
@@ -190,6 +229,11 @@ Format: JSON.
   - `indent`: 0 for top-level outline items, 1 for first child, etc.
   - `content_hash`: SHA-256 of the block's **textual content only**,
     not including children or property lines that belong to it.
+  - `ref_handle`: short, stable, user-typeable handle for
+    `((blk-XXXXXX))` references. Default-derived from the id (last 6
+    chars of the ULID's Crockford base32, lowercased, with the `blk-`
+    prefix). Persisted verbatim so future changes to the derivation
+    cannot invalidate references already in the wild.
 
 ### Content hash
 
@@ -206,13 +250,19 @@ matching.
 
 ### Sidecar versioning
 
-When we ship a `version: 2` someday:
+Current version is **`2`** (added `ref_handle` per block to power
+`((blk-XXXXXX))` references). Reading is backward-compatible:
 
-- Always be able to **read** v1 (forward compat).
-- New writes use the latest version.
-- `outl doctor --migrate` can rewrite v1 → v2 in place.
+- A v1 sidecar (no `ref_handle` field) loads fine; the field is
+  backfilled in memory by deriving it from the block id.
+- The first write after a load upgrades the on-disk payload to the
+  current version.
+- Sidecars below `MIN_READABLE_SIDECAR_VERSION` (currently `1`) fail
+  loudly — old workspaces in the wild stay supported until that
+  constant moves.
 
-Never delete v1 read support — old workspaces in the wild stay supported.
+When v3 ever ships, v1 + v2 read paths stay until they're explicitly
+retired. Silent format drops are not allowed.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,9 +40,12 @@ device. Edit in VS Code or in the TUI, doesn't matter. Journal works.
 ### `outl-md`
 - Parse `.md` (clean, no IDs) → AST.
 - Render AST → `.md` (clean).
-- Read/write `.outl` sidecar (JSON).
+- Read/write `.outl` sidecar (JSON, version `2`, reads v1).
 - 3-level matching algorithm.
-- Diff (old AST + new AST) → minimal `Op` sequence.
+- Diff (old AST + new AST + old sidecar blocks) → minimal `Op`
+  sequence; preserves `ref_handle` verbatim on level-1/2 matches.
+- Block-level index (`((blk-XXXXXX))` + reverse refs) under
+  `WorkspaceIndex` — O(1) resolve, linear `search_block_text`.
 - Tests: `roundtrip`, `external_edit`, `duplicate_block`,
   `identical_blocks_swap`, `heavy_edit`.
 
@@ -58,9 +61,14 @@ device. Edit in VS Code or in the TUI, doesn't matter. Journal works.
 - Sidebar of pages.
 - Navigation between journals (`[`, `]`, `t`, `g j`).
 - Tag panel.
-- Outline panel (read-only first pass).
-- Backlinks panel.
-- Command palette (basic).
+- Outline panel (read/write — text editing, indent/outdent, move, delete).
+- Inline backlinks below the outline (`B` toggle).
+- Command palette + slash menu sharing one registry.
+- Block-reference workflow: inline render of `((blk-XXXXXX))`,
+  embed expansion (source block + children with `↳ ` prefix) for
+  `!((blk-XXXXXX))`, `Enter` jumps to source block, `((` autocomplete
+  in Insert, `y r` / `/refer` / `/refer-embed` copy handles to the OS
+  clipboard (via `arboard`).
 - Page properties visible and editable.
 - Visual distinction page vs tag (different colors).
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -29,7 +29,7 @@ characters insert themselves — every key is a command.
 | `i` | Edit current block (Insert mode) |
 | `I` | Edit, cursor at start of block |
 | `o` / `O` | New block below / above |
-| `Enter` | Open `[[ref]]` / `#tag` / journal under cursor (otherwise edit) |
+| `Enter` | Open `[[ref]]` / `#tag` / journal / block ref (`((blk-X))` / `!((blk-X))`) under cursor (otherwise edit). On a block ref it opens the source page and lands the cursor on the referenced block; orphan handles surface a status message and stay put. |
 | `j` / `k` / `↑` / `↓` | Move between blocks |
 | `h` / `l` / `←` / `→` | Move cursor inside the current block |
 | `w` / `b` | Cursor to next / previous word |
@@ -37,6 +37,7 @@ characters insert themselves — every key is a command.
 | `Tab` / `Shift-Tab` | Indent / outdent the current block |
 | `K` / `J` (or `Alt+↑/↓`) | Move block up / down |
 | `dd` | Delete the current block (chord) |
+| `y r` | Yank the current block's ref handle (`((blk-XXXXXX))`) to the OS clipboard + `last_yanked_ref` (chord). On headless / no-clipboard environments it falls back to the status line only. |
 | `Ctrl+Enter` / `Ctrl+T` | Cycle the block's TODO / DONE / none prefix (`Ctrl+T` is the portable fallback for tmux / Terminal.app, which collapse `Ctrl+Enter` into plain `Enter`) |
 | `u` / `Ctrl+R` | Undo / redo |
 | `V` | Enter Visual mode (multi-block select) |
@@ -69,6 +70,7 @@ Text input goes into the buffer. Esc commits (writes back to the
 | `(`, `[`, `{` | Auto-pair with closing |
 | `[[` | Page reference autocomplete (titles indexed across workspace) |
 | `#` | Tag autocomplete |
+| `((` | Block reference autocomplete — fuzzy-match on block text, inserts `((blk-XXXXXX))`. Empty query lists newest-first (NodeId descending = ULID time order) so the popup is deterministic and the same eight rows show on every keystroke. |
 | `↑` / `↓` in popup | Navigate completion |
 | `Enter` / `Tab` in popup | Accept completion |
 | `Esc` in popup | Cancel completion |
@@ -158,6 +160,20 @@ Unknown commands surface in the status line as `unknown command:
 | `prop-block <key> <value>` | `prop` | Set property on current block (empty value deletes) |
 | `prop-page <key> <value>` | — | Set page-level property (`title::`, `icon::`, …) |
 
+#### Block references
+
+| Command | Aliases | Action |
+|---------|---------|--------|
+| `refer` | — | Copy `((blk-XXXXXX))` of the current block to the OS clipboard + `last_yanked_ref`. Same as the `y r` chord. |
+| `refer-embed` | — | Copy the embed form `!((blk-XXXXXX))` of the current block to the OS clipboard + `last_yanked_ref`. |
+
+> **Clipboard fallback**: `y r` / `/refer` / `/refer-embed` use
+> [`arboard`](https://crates.io/crates/arboard) to talk to the OS
+> clipboard. The status line reads `copied … to clipboard` on success
+> and `yanked … (clipboard unavailable)` on terminals / SSH sessions
+> without a clipboard backend — the token still lives in
+> `last_yanked_ref` so the in-app paste path keeps working.
+
 #### Code execution
 
 | Command | Aliases | Action |
@@ -240,7 +256,20 @@ Garbage input (`/date nope`, `/date +3x`, invalid date) shows
 
 - **Outline** — the current view (journal or named page). Markdown
   renders inline (bold/italic/code/strike); the selected/editing block
-  is shown raw so cursor columns align with source bytes.
+  is shown raw so cursor columns align with source bytes. Block
+  references (`((blk-XXXXXX))`) resolve to the source block's text
+  plus its page icon; orphaned handles render dimmed. Embeds
+  (`!((blk-XXXXXX))`) — when the block contains a single embed token
+  (whitespace OK) — render the source block **and its children**
+  expanded read-only below the carrying block. Every embed row carries
+  a `↳ ` prefix (root + descendants), so the expansion reads as one
+  cohesive block; descendants are indented by `2 * (depth + 1)` spaces
+  before their `↳ ` so children align under the source's *text*, not
+  under the parent's `↳ `. TODO/DONE checkboxes, page refs, and tags
+  render with their normal styling inside the expansion. Recursion is
+  capped at depth 4 to break embed cycles. The cursor-bearing block
+  always keeps the raw `((…))` / `!((…))` literal on its first row so
+  column counting stays exact.
 - **Backlinks (inline)** — rendered below the outline, separated by a
   full-width `─` rule. Every block in any other page that contains
   `[[this]]` or `#this` shows up with its children, grouped by source
@@ -324,8 +353,6 @@ and how to set a theme via config or CLI.
 Phase 1 lands the core editor and most-used surfaces. Some things are
 explicitly deferred:
 
-- **Embed `((block-id))`** — recognized as opaque text for now;
-  inline render of the target block is phase 3.
 - **`{{query: ...}}`** — inline saved queries; phase 3.
 - **Visual mode batch indent / yank / paste** — only delete is wired
   today.

--- a/docs/why-outl.md
+++ b/docs/why-outl.md
@@ -40,7 +40,7 @@ storage that's an interface instead of a hardcoded SQLite blob.
 | **TUI** | No | No | Yes — first-class |
 | **Daily journal** | Yes | Yes | Yes |
 | **`[[refs]]` / `#tags`** | Yes | Yes | Yes |
-| **Block embeds `((id))`** | Yes | Yes | Recognized, rendered in phase 3 |
+| **Block refs `((blk-XXXXXX))` + embeds `!((blk-XXXXXX))`** | Yes (long uids) | Yes (long uids) | Short, sidecar-backed handles; clean `.md` |
 | **Queries** | `{{query: ...}}` rich | Datalog-ish | `{{query: ...}}` DSL — phase 3 |
 
 [i1]: https://github.com/avelino/outl/issues/1


### PR DESCRIPTION
Migrating from Roam wasn't viable without block-level addressing. Citing one block from N places, with embed expansion, is core to how an outliner works.

Adds `((blk-XXXXXX))` inline refs and `!((blk-XXXXXX))` embeds to the markdown dialect, bumps the sidecar to v2 with a stable ref_handle derived from the block's ULID tail (lazy 7+ char expansion on collision). The TUI wires (( autocomplete on block text, inline ref render, expanded embed (source root + children with ↳ marker), Enter navigation to the source block, `/refer` and `/refer-embed` slash commands, and the yr chord copies the handle through arboard to the OS clipboard. outl doctor flags orphan handles for both forms.

fixed: #8

## What this PR does

One paragraph. The *why* first, then the *what*.

## How to verify

```bash
cargo test --workspace --all-targets
cargo clippy --workspace --all-targets -- -D warnings
cargo fmt --all -- --check
```

Plus any feature-specific checks (manual smoke, fixture files,
screenshot of TUI state, ...).

## Related issues / docs

Closes #...
Related to #...
Updated docs: `docs/...`

## Anything reviewers should look at carefully

- Is there a CRDT-correctness implication? Did `crdt-invariant-checker`
  pass?
- Is there a markdown-format implication? Did `markdown-roundtrip-tester`
  pass?
- New public API on `outl-core` / `outl-md`? Is it
  documented in the per-crate CLAUDE.md?
- Any change to keymaps in `outl-tui`? Updated `docs/tui.md` and the
  in-app help popup?

## Out of scope for this PR

What this PR is *not* doing, even if related. Helps reviewers not
nudge for scope creep.
