### PR TITLE
Add block collapse with sync via op log

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -52,12 +52,22 @@ jobs:
   upload:
     name: Upload IPA to TestFlight
     runs-on: macos-latest
-    # workflow_run fires on every conclusion; only proceed on
-    # success. workflow_dispatch is gated by the human pressing
-    # the button.
+    # workflow_run fires on every conclusion; only proceed when:
+    #   1. a human triggered us manually (workflow_dispatch), or
+    #   2. the Mobile workflow finished `success` AND was triggered
+    #      by an event that actually runs the `ios-release` job —
+    #      `push` or `workflow_dispatch`. On `pull_request` the
+    #      Mobile workflow's `ios-release` step is skipped (PRs
+    #      never sign IPAs), the workflow still reports `success`,
+    #      and we'd come down here to download an artifact that was
+    #      never uploaded. Mirror the `ios-release` gate from
+    #      `mobile.yml` so we only fire when there's actually a
+    #      signed IPA waiting for us.
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' &&
+       (github.event.workflow_run.event == 'push' ||
+        github.event.workflow_run.event == 'workflow_dispatch'))
 
     environment:
       name: release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,19 @@ These are the non-negotiables. Violating any one breaks user trust irreversibly.
 6. **Delete is `Move(node, TRASH_ROOT)`, not physical removal.** Simplifies the
    algorithm and preserves history.
 
+7. **Any state that must converge between devices goes through the op log.**
+   If two users (or one user on two devices) can disagree about a value
+   and you want them to reconcile, the state belongs in an `Op` — *never*
+   in a shared file with last-write-wins semantics. The op log gives each
+   actor its own `ops-<actor>.jsonl`, lets iCloud / Syncthing / shared FS
+   sync per-file (no merge conflicts), and replays through the CRDT with
+   HLC ordering for deterministic convergence. Writing the state into the
+   sidecar (or any single shared file) bypasses all of that and loses
+   concurrent writes silently. **Default position: model it as an Op.**
+   `Op::SetCollapsed` for the fold flag is the canonical example. The
+   sidecar carries only **structural matching metadata** (ids, position,
+   content hash, ref handle) — it is not a sync surface.
+
 ## Repo layout
 
 ```

--- a/crates/outl-actions/CLAUDE.md
+++ b/crates/outl-actions/CLAUDE.md
@@ -24,6 +24,7 @@ outl-cli / outl-tui / outl-mobile / future clients
 | Module      | What it owns                                                                 |
 |-------------|-------------------------------------------------------------------------------|
 | `block`     | `append_block`, `create_after`, `create_under`, `edit_text`, `toggle_todo`, `delete`, `indent`, `outdent`, `move_up`, `move_down` |
+| `collapsed` | `set_block_collapsed`, `toggle_block_collapsed`. Both generate `Op::SetCollapsed` and route it through `Workspace::apply`, so the fold flag converges between devices on top of the existing per-actor jsonl + HLC infrastructure. **Never** write fold state to the sidecar — that's last-write-wins per file under iCloud and loses concurrent flips. See the root `CLAUDE.md` invariants. |
 | `tree`      | Read-only helper: `children_of`. Sibling / fractional-position helpers (`previous_sibling`, `next_sibling`, `position_after`, `position_for_new_last_child`) are `pub(crate)` — promote them to `pub` when a real caller asks for them. |
 | `todo`      | `TodoState`, `split_todo`, `cycle_todo` — TODO/DONE encoded as text prefix     |
 | `outline`   | `OutlineNode` DTO + `project_outline` — UI-friendly tree projection            |

--- a/crates/outl-actions/src/collapsed.rs
+++ b/crates/outl-actions/src/collapsed.rs
@@ -1,0 +1,108 @@
+//! Block fold (collapsed) state — Op-driven sync.
+//!
+//! Folding a block is a user-meaningful state mutation that must
+//! converge between devices. Every flip goes through the op log
+//! (`Op::SetCollapsed` in `outl-core`), exactly like Move / Edit /
+//! SetProp. Each device writes to its own `ops-<actor>.jsonl`; iCloud
+//! / Syncthing / shared FS sync those per-actor files; the CRDT
+//! merges concurrent flips by HLC ordering.
+//!
+//! **Do not bring back the "write a flag to the sidecar" path.** That
+//! was the previous design and it lost flips under iCloud's
+//! last-write-wins-per-file semantics. The sidecar is for structural
+//! `.md` ↔ tree matching only; any cross-device state belongs in the
+//! op log. The root `CLAUDE.md` invariant codifies this.
+
+use outl_core::hlc::HlcGenerator;
+use outl_core::id::NodeId;
+use outl_core::op::{LogOp, Op};
+use outl_core::workspace::Workspace;
+
+use crate::error::ActionError;
+
+/// Set `node`'s collapsed flag to `value`. Generates `Op::SetCollapsed`
+/// with a fresh HLC and applies it through `Workspace::apply`.
+///
+/// Returns `true` when the materialised state actually changed (the
+/// flag flipped), `false` when the op was a no-op against the current
+/// state. Either way the op enters the log — the CRDT needs every
+/// flip to converge across devices, and idempotent re-apply is cheap.
+pub fn set_block_collapsed(
+    workspace: &mut Workspace,
+    hlc: &HlcGenerator,
+    node: NodeId,
+    value: bool,
+) -> Result<bool, ActionError> {
+    let was = workspace.tree().is_collapsed(node);
+    let ts = hlc.next();
+    let op = LogOp {
+        ts,
+        actor: ts.actor,
+        op: Op::SetCollapsed {
+            node,
+            value,
+            // Filled by `do_op`. The value we pass here is irrelevant
+            // beyond the type contract.
+            old_value: false,
+        },
+    };
+    workspace.apply(op)?;
+    Ok(was != value)
+}
+
+/// Flip `node`'s collapsed flag. Returns the new value.
+pub fn toggle_block_collapsed(
+    workspace: &mut Workspace,
+    hlc: &HlcGenerator,
+    node: NodeId,
+) -> Result<bool, ActionError> {
+    let new_value = !workspace.tree().is_collapsed(node);
+    set_block_collapsed(workspace, hlc, node, new_value)?;
+    Ok(new_value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use outl_core::id::ActorId;
+
+    fn make_ws() -> (Workspace, HlcGenerator) {
+        let actor = ActorId::new();
+        let ws = Workspace::open_in_memory(actor).unwrap();
+        let hlc = HlcGenerator::new(actor);
+        (ws, hlc)
+    }
+
+    #[test]
+    fn set_then_read_round_trip() {
+        let (mut ws, hlc) = make_ws();
+        let node = NodeId::new();
+        assert!(!ws.tree().is_collapsed(node));
+        let changed = set_block_collapsed(&mut ws, &hlc, node, true).unwrap();
+        assert!(changed);
+        assert!(ws.tree().is_collapsed(node));
+    }
+
+    #[test]
+    fn set_block_collapsed_reports_no_change_when_already_equal() {
+        // Idempotency at the action level: flipping `true` twice
+        // reports `false` on the second call even though the op was
+        // still appended to the log (the CRDT needs it for cross-
+        // device convergence).
+        let (mut ws, hlc) = make_ws();
+        let node = NodeId::new();
+        assert!(set_block_collapsed(&mut ws, &hlc, node, true).unwrap());
+        assert!(!set_block_collapsed(&mut ws, &hlc, node, true).unwrap());
+        assert!(ws.tree().is_collapsed(node));
+    }
+
+    #[test]
+    fn toggle_flips_value() {
+        let (mut ws, hlc) = make_ws();
+        let node = NodeId::new();
+        assert!(toggle_block_collapsed(&mut ws, &hlc, node).unwrap());
+        assert!(ws.tree().is_collapsed(node));
+        assert!(!toggle_block_collapsed(&mut ws, &hlc, node).unwrap());
+        assert!(!ws.tree().is_collapsed(node));
+    }
+}

--- a/crates/outl-actions/src/journal.rs
+++ b/crates/outl-actions/src/journal.rs
@@ -261,7 +261,7 @@ fn build_sidecar_from_ast(
         &mut blocks,
     );
     Sidecar {
-        version: 2,
+        version: outl_md::sidecar::SIDECAR_VERSION,
         page_id,
         last_synced_hash: file_hash(md),
         last_synced_at: chrono::Local::now().fixed_offset(),

--- a/crates/outl-actions/src/lib.rs
+++ b/crates/outl-actions/src/lib.rs
@@ -51,6 +51,7 @@
 
 pub mod backlinks;
 pub mod block;
+pub mod collapsed;
 pub mod error;
 pub mod journal;
 pub mod outline;
@@ -64,12 +65,13 @@ pub use block::{
     append_block, append_forest, append_tree, create_after, create_under, delete, edit_text,
     indent, move_down, move_up, outdent, toggle_todo, BlockTreeOutcome, BlockTreeSpec,
 };
+pub use collapsed::{set_block_collapsed, toggle_block_collapsed};
 pub use error::ActionError;
 pub use journal::{
     apply_all_pages_md, apply_page_md, apply_page_md_with_sidecar, journals_dir, mutate_page_md,
     page_md_path, pages_dir, render_page_md, write_md_atomic,
 };
-pub use outline::{project_outline, read_page_view, OutlineNode};
+pub use outline::{project_outline, read_page_view, read_page_view_with_workspace, OutlineNode};
 pub use page::{
     date_from_slug, find_by_slug, is_valid_slug, journal_slug, journal_title,
     list_all as list_pages, migrate_legacy_into_today, next_journal_date, open_journal,

--- a/crates/outl-actions/src/outline.rs
+++ b/crates/outl-actions/src/outline.rs
@@ -8,6 +8,7 @@
 //! materialise straight from the op log (e.g. doctor, debug dumps).
 
 use std::path::Path;
+use std::str::FromStr;
 
 use outl_core::id::NodeId;
 use outl_core::workspace::Workspace;
@@ -34,6 +35,15 @@ pub struct OutlineNode {
     /// `None` for a plain bullet, `Some(Todo)` / `Some(Done)` otherwise.
     #[serde(serialize_with = "serialize_todo_state")]
     pub todo: Option<TodoState>,
+    /// Whether the block is rendered collapsed (children hidden) in
+    /// the outline. UI-state echoed from the sidecar; clients SHOULD
+    /// still send `children` so the renderer can show a "(N hidden)"
+    /// hint without a second round trip.
+    ///
+    /// Mutated via `outl_actions::block::toggle_block_collapsed` /
+    /// `set_block_collapsed`, which write directly to the sidecar
+    /// (no `Op` — UI state never enters the op log).
+    pub collapsed: bool,
     /// Children, in their fractional-index order.
     pub children: Vec<OutlineNode>,
 }
@@ -60,6 +70,7 @@ pub fn project_outline(workspace: &Workspace, parent: NodeId) -> Vec<OutlineNode
                 id: id.to_string(),
                 text: body.to_string(),
                 todo,
+                collapsed: workspace.tree().is_collapsed(id),
                 children: project_outline(workspace, id),
             }
         })
@@ -97,6 +108,36 @@ pub fn read_page_view(root: &Path, meta: &PageMeta) -> Result<Vec<OutlineNode>, 
     Ok(nodes)
 }
 
+/// Same as [`read_page_view`] but overlays the workspace's
+/// `Op::SetCollapsed` state so each [`OutlineNode`] reports the
+/// authoritative `collapsed` flag. UI clients (TUI, mobile) **must**
+/// use this variant — the bare `read_page_view` leaves `collapsed`
+/// at `false` because it has no op log in scope.
+pub fn read_page_view_with_workspace(
+    root: &Path,
+    meta: &PageMeta,
+    workspace: &Workspace,
+) -> Result<Vec<OutlineNode>, ActionError> {
+    let mut nodes = read_page_view(root, meta)?;
+    overlay_collapsed(&mut nodes, workspace);
+    Ok(nodes)
+}
+
+/// Walk `nodes` in place, setting `collapsed` from
+/// `workspace.tree().is_collapsed(id)` for every node whose id parses
+/// as a valid `NodeId`. Transient ids (the ones minted by
+/// `outline_from_parsed` when the sidecar is missing / short) skip
+/// the overlay — they're not in the op log yet.
+fn overlay_collapsed(nodes: &mut [OutlineNode], workspace: &Workspace) {
+    for node in nodes {
+        if let Ok(ulid) = ulid::Ulid::from_str(&node.id) {
+            let id = NodeId(ulid);
+            node.collapsed = workspace.tree().is_collapsed(id);
+        }
+        overlay_collapsed(&mut node.children, workspace);
+    }
+}
+
 enum SidecarBlockCursor<'a> {
     Some(std::slice::Iter<'a, SidecarBlock>),
     None,
@@ -132,10 +173,15 @@ fn outline_from_parsed(
         .iter()
         .map(|child| outline_from_parsed(child, iter))
         .collect();
+    // `collapsed` is overlaid by the caller using the workspace as the
+    // source of truth (`Op::SetCollapsed` lives in the op log). The
+    // bare `read_page_view` path leaves it `false`; the workspace-
+    // aware `read_page_view_with_workspace` patches it.
     OutlineNode {
         id,
         text: body.to_string(),
         todo,
+        collapsed: false,
         children,
     }
 }

--- a/crates/outl-actions/src/outline.rs
+++ b/crates/outl-actions/src/outline.rs
@@ -36,13 +36,20 @@ pub struct OutlineNode {
     #[serde(serialize_with = "serialize_todo_state")]
     pub todo: Option<TodoState>,
     /// Whether the block is rendered collapsed (children hidden) in
-    /// the outline. UI-state echoed from the sidecar; clients SHOULD
-    /// still send `children` so the renderer can show a "(N hidden)"
-    /// hint without a second round trip.
+    /// the outline. Overlaid from the workspace via
+    /// [`Op::SetCollapsed`][outl_core::op::Op::SetCollapsed]; the op
+    /// log is the source of truth. Clients SHOULD still send
+    /// `children` so the renderer can show a "(N hidden)" hint
+    /// without a second round trip.
     ///
-    /// Mutated via `outl_actions::block::toggle_block_collapsed` /
-    /// `set_block_collapsed`, which write directly to the sidecar
-    /// (no `Op` — UI state never enters the op log).
+    /// **Use `read_page_view_with_workspace` to populate this.** The
+    /// bare [`read_page_view`] has no workspace in scope and leaves
+    /// every entry at `false`.
+    ///
+    /// Mutated via [`crate::collapsed::set_block_collapsed`] /
+    /// [`crate::collapsed::toggle_block_collapsed`], which generate
+    /// `Op::SetCollapsed` and apply it through `Workspace::apply` —
+    /// never via the sidecar.
     pub collapsed: bool,
     /// Children, in their fractional-index order.
     pub children: Vec<OutlineNode>,
@@ -125,9 +132,12 @@ pub fn read_page_view_with_workspace(
 
 /// Walk `nodes` in place, setting `collapsed` from
 /// `workspace.tree().is_collapsed(id)` for every node whose id parses
-/// as a valid `NodeId`. Transient ids (the ones minted by
-/// `outline_from_parsed` when the sidecar is missing / short) skip
-/// the overlay — they're not in the op log yet.
+/// as a valid ULID. Transient ids (the ones minted by
+/// `outline_from_parsed` when the sidecar is missing or shorter than
+/// the AST) parse fine but the workspace has never seen them, so
+/// `is_collapsed` returns the default `false` — same result as
+/// leaving the field untouched, which keeps the contract "every
+/// node with no op log presence renders expanded".
 fn overlay_collapsed(nodes: &mut [OutlineNode], workspace: &Workspace) {
     for node in nodes {
         if let Ok(ulid) = ulid::Ulid::from_str(&node.id) {

--- a/crates/outl-cli/src/cmd/doctor.rs
+++ b/crates/outl-cli/src/cmd/doctor.rs
@@ -176,7 +176,8 @@ fn collect_internal(path: &Path, probe_lock: bool) -> Result<DoctorReport, ApiEr
                             outl_core::op::Op::Move { node, .. }
                             | outl_core::op::Op::Edit { node, .. }
                             | outl_core::op::Op::SetProp { node, .. }
-                            | outl_core::op::Op::Create { node, .. } => *node,
+                            | outl_core::op::Op::Create { node, .. }
+                            | outl_core::op::Op::SetCollapsed { node, .. } => *node,
                         };
                         ids.insert(node);
                     }

--- a/crates/outl-cli/tests/e2e_full.rs
+++ b/crates/outl-cli/tests/e2e_full.rs
@@ -69,6 +69,10 @@ fn full_workspace_lifecycle() {
             handle.to_lowercase(),
             "handle must be lowercase: {handle}"
         );
+        assert!(
+            b.get("collapsed").is_none(),
+            "default-false `collapsed` must be omitted on write: {b:?}"
+        );
     }
 
     // 5. assertions on the .md — must stay CLEAN (no id::, no UUIDs)

--- a/crates/outl-core/CLAUDE.md
+++ b/crates/outl-core/CLAUDE.md
@@ -41,6 +41,28 @@ proven in Kleppmann et al. 2022.
 5. **No silent loss.** Every op stays in the log, even ones turned into no-ops
    by cycle detection.
 
+## Op log is the only sync surface
+
+Any per-block (or per-page) state that must converge between devices —
+fold flags, pinned status, whatever ships next — lands as an `Op`
+variant on this enum. Never as a field of `SidecarBlock`, a key in a
+shared JSON file, or anything else that depends on iCloud / Syncthing
+to merge file contents. Those transports are last-write-wins per file
+and lose concurrent writes silently.
+
+`Op::SetCollapsed` is the canonical example. Anatomy of a new
+"per-block UI state that needs to sync" Op:
+
+- A variant with `node`, the desired value, and an `old_*` field.
+- `do_op` captures the old value and applies the new one to a side
+  table (`HashMap` / `HashSet`) inside `Tree`.
+- `undo_op` restores the captured `old_*`.
+- A read accessor on `Tree` (e.g. `is_collapsed(node) -> bool`).
+- Storage `op_touches_node` covers the new variant.
+
+Anything cheaper than this in the design discussion is wrong —
+correctness across devices is not optional.
+
 The test battery in `tests/` is the operational expression of these. If you
 change `tree.rs`, every one of those tests must still pass.
 

--- a/crates/outl-core/src/op.rs
+++ b/crates/outl-core/src/op.rs
@@ -72,6 +72,31 @@ pub enum Op {
         /// Initial position among siblings.
         position: Fractional,
     },
+
+    /// Set the **collapsed** (folded) flag of a node.
+    ///
+    /// Controls whether the block's children are hidden in the outline
+    /// view. UI presentation, but globally meaningful — folding a
+    /// block on one device shows up folded on every other device.
+    ///
+    /// **Going through `Op` is the canonical path for any per-block
+    /// state that must converge between devices.** Writing such state
+    /// straight to a sidecar would lose under iCloud / Syncthing's
+    /// last-write-wins-per-file semantics; the op log gives each
+    /// device its own `ops-<actor>.jsonl` and lets the CRDT merge
+    /// concurrent flips by HLC ordering. Idempotent re-apply of the
+    /// same `LogOp` is a no-op (the HLC dedup at the top of
+    /// [`crate::tree::Tree::apply_op`] guarantees this).
+    ///
+    /// `old_value` is populated by `do_op` for `undo_op`.
+    SetCollapsed {
+        /// The node being folded / unfolded.
+        node: NodeId,
+        /// Desired flag.
+        value: bool,
+        /// Filled by `do_op` for `undo_op`.
+        old_value: bool,
+    },
 }
 
 /// An op wrapped with its HLC and actor.

--- a/crates/outl-core/src/storage/jsonl.rs
+++ b/crates/outl-core/src/storage/jsonl.rs
@@ -164,7 +164,8 @@ fn op_touches_node(op: &Op, id: NodeId) -> bool {
         Op::Move { node, .. }
         | Op::Edit { node, .. }
         | Op::SetProp { node, .. }
-        | Op::Create { node, .. } => *node == id,
+        | Op::Create { node, .. }
+        | Op::SetCollapsed { node, .. } => *node == id,
     }
 }
 

--- a/crates/outl-core/src/storage/memory.rs
+++ b/crates/outl-core/src/storage/memory.rs
@@ -44,7 +44,8 @@ fn op_touches_node(op: &Op, id: NodeId) -> bool {
         Op::Move { node, .. }
         | Op::Edit { node, .. }
         | Op::SetProp { node, .. }
-        | Op::Create { node, .. } => *node == id,
+        | Op::Create { node, .. }
+        | Op::SetCollapsed { node, .. } => *node == id,
     }
 }
 

--- a/crates/outl-core/src/tree.rs
+++ b/crates/outl-core/src/tree.rs
@@ -743,4 +743,97 @@ mod tests {
         assert!(snapshot.contains(&b));
         assert!(!snapshot.contains(&c));
     }
+
+    #[test]
+    fn set_collapsed_converges_across_three_replicas() {
+        // Strong Eventual Consistency for `Op::SetCollapsed`.
+        //
+        // Three replicas observe the same five flips on the same two
+        // nodes but in three different delivery orders. After every
+        // op has been applied to every replica, the final
+        // `collapsed_ids` set must be identical on all three.
+        //
+        // The fixture deliberately mixes:
+        //   - flips on different nodes (independent — order shouldn't
+        //     matter for the final state of either)
+        //   - flips on the *same* node (HLC + actor tiebreak decides
+        //     the winner; every replica must agree on the same winner)
+        let actor_a = ActorId::new();
+        let actor_b = ActorId::new();
+        let g_a = HlcGenerator::new(actor_a);
+        let g_b = HlcGenerator::new(actor_b);
+        let n1 = NodeId::new();
+        let n2 = NodeId::new();
+
+        // Author the canonical sequence on actor A's generator (so
+        // every LogOp has a monotonic ts from A), with two contender
+        // ops minted by B against n1 to force a same-node race.
+        let ops = [
+            make_op(
+                &g_a,
+                Op::SetCollapsed {
+                    node: n1,
+                    value: true,
+                    old_value: false,
+                },
+            ),
+            make_op(
+                &g_b,
+                Op::SetCollapsed {
+                    node: n1,
+                    value: false,
+                    old_value: false,
+                },
+            ),
+            make_op(
+                &g_a,
+                Op::SetCollapsed {
+                    node: n2,
+                    value: true,
+                    old_value: false,
+                },
+            ),
+            make_op(
+                &g_a,
+                Op::SetCollapsed {
+                    node: n1,
+                    value: true,
+                    old_value: false,
+                },
+            ),
+            make_op(
+                &g_b,
+                Op::SetCollapsed {
+                    node: n2,
+                    value: false,
+                    old_value: false,
+                },
+            ),
+        ];
+
+        // Three permutations: forward, reverse, and "interleaved"
+        // (B's ops first, A's ops second).
+        let perm_forward: Vec<usize> = (0..ops.len()).collect();
+        let perm_reverse: Vec<usize> = (0..ops.len()).rev().collect();
+        let perm_interleaved = vec![1, 4, 0, 2, 3];
+
+        fn run(ops: &[LogOp], order: &[usize]) -> Tree {
+            let mut tree = Tree::new();
+            let mut log = OpLog::new();
+            for &i in order {
+                tree.apply_op(&mut log, ops[i].clone());
+            }
+            tree
+        }
+
+        let r1 = run(&ops, &perm_forward);
+        let r2 = run(&ops, &perm_reverse);
+        let r3 = run(&ops, &perm_interleaved);
+
+        let set1: std::collections::HashSet<NodeId> = r1.collapsed_ids().collect();
+        let set2: std::collections::HashSet<NodeId> = r2.collapsed_ids().collect();
+        let set3: std::collections::HashSet<NodeId> = r3.collapsed_ids().collect();
+        assert_eq!(set1, set2, "forward vs reverse delivery must converge");
+        assert_eq!(set1, set3, "forward vs interleaved delivery must converge");
+    }
 }

--- a/crates/outl-core/src/tree.rs
+++ b/crates/outl-core/src/tree.rs
@@ -24,7 +24,7 @@ use crate::id::NodeId;
 use crate::log::OpLog;
 use crate::op::{LogOp, Op};
 use crate::property::PropValue;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Materialized outline tree.
 ///
@@ -37,6 +37,16 @@ use std::collections::HashMap;
 pub struct Tree {
     nodes: HashMap<NodeId, (NodeId, Fractional)>,
     properties: HashMap<(NodeId, String), PropValue>,
+    /// Nodes whose [`Op::SetCollapsed`] last resolved to `true`.
+    /// Absence means expanded (the default for every node, including
+    /// ones the op log has never set explicitly).
+    ///
+    /// Stored as a set rather than a `HashMap<_, bool>` so the "no
+    /// entry" / "false" cases share representation and serialised
+    /// projections (the sidecar, the wire JSON Mobile receives) don't
+    /// distinguish "we know it's expanded" from "we never heard about
+    /// this node".
+    collapsed: HashSet<NodeId>,
 }
 
 impl Tree {
@@ -66,6 +76,20 @@ impl Tree {
     /// Current value of a property, or `None` if unset.
     pub fn property(&self, node: NodeId, key: &str) -> Option<&PropValue> {
         self.properties.get(&(node, key.to_string()))
+    }
+
+    /// Whether `node` is currently rendered collapsed (children
+    /// hidden in the outline view). Defaults to `false` for any node
+    /// the op log has never explicitly set.
+    pub fn is_collapsed(&self, node: NodeId) -> bool {
+        self.collapsed.contains(&node)
+    }
+
+    /// Iterator over every node currently flagged collapsed. Used by
+    /// projection layers (sidecar render, mobile wire format) to
+    /// snapshot the fold state in one pass.
+    pub fn collapsed_ids(&self) -> impl Iterator<Item = NodeId> + '_ {
+        self.collapsed.iter().copied()
     }
 
     /// Iterate every (node, parent, position) triple. Useful for tests.
@@ -198,6 +222,21 @@ impl Tree {
                     .entry(*node)
                     .or_insert_with(|| (*parent, position.clone()));
             }
+            Op::SetCollapsed {
+                node,
+                value,
+                old_value,
+            } => {
+                // Capture previous state for `undo_op`. Membership in
+                // `self.collapsed` is the source of truth (presence =
+                // collapsed, absence = expanded).
+                *old_value = self.collapsed.contains(node);
+                if *value {
+                    self.collapsed.insert(*node);
+                } else {
+                    self.collapsed.remove(node);
+                }
+            }
         }
     }
 
@@ -247,6 +286,20 @@ impl Tree {
             }
             Op::Create { node, .. } => {
                 self.nodes.remove(node);
+            }
+            Op::SetCollapsed {
+                node, old_value, ..
+            } => {
+                // Restore the previous membership captured by `do_op`.
+                // `undo_op` on a never-applied `LogOp` (one whose
+                // `old_value` is still the default `false`) reduces to
+                // "make sure the node is not collapsed", which is a
+                // no-op when the materialised state matches.
+                if *old_value {
+                    self.collapsed.insert(*node);
+                } else {
+                    self.collapsed.remove(node);
+                }
             }
         }
     }
@@ -524,5 +577,170 @@ mod tests {
             tree.property(n, "priority"),
             Some(&PropValue::Text("high".into()))
         );
+    }
+
+    #[test]
+    fn set_collapsed_round_trip() {
+        // Plain forward apply: SetCollapsed(true) flips the flag and
+        // SetCollapsed(false) clears it. `is_collapsed` is the
+        // canonical accessor.
+        let actor = ActorId::new();
+        let g = HlcGenerator::new(actor);
+        let mut tree = Tree::new();
+        let mut log = OpLog::new();
+        let n = NodeId::new();
+
+        assert!(!tree.is_collapsed(n), "default is expanded");
+        tree.apply_op(
+            &mut log,
+            make_op(
+                &g,
+                Op::SetCollapsed {
+                    node: n,
+                    value: true,
+                    old_value: false,
+                },
+            ),
+        );
+        assert!(tree.is_collapsed(n));
+        tree.apply_op(
+            &mut log,
+            make_op(
+                &g,
+                Op::SetCollapsed {
+                    node: n,
+                    value: false,
+                    old_value: false,
+                },
+            ),
+        );
+        assert!(!tree.is_collapsed(n));
+        assert_eq!(log.len(), 2, "every op stays in the log");
+    }
+
+    #[test]
+    fn set_collapsed_late_op_replays_correctly() {
+        // Concurrent flip on the same node: a late op with smaller ts
+        // forces undo+replay. Final state must match the op with the
+        // larger HLC (the "winner" of the total order).
+        let actor = ActorId::new();
+        let g = HlcGenerator::new(actor);
+        let mut tree = Tree::new();
+        let mut log = OpLog::new();
+        let n = NodeId::new();
+
+        // Larger ts first: collapse to `true`.
+        tree.apply_op(
+            &mut log,
+            make_op(
+                &g,
+                Op::SetCollapsed {
+                    node: n,
+                    value: true,
+                    old_value: false,
+                },
+            ),
+        );
+        // Late-arriving op with ts==0 trying to set `false`. Reorder
+        // pops the later op, applies the early one, then replays the
+        // later — so `true` still wins.
+        let late = LogOp {
+            ts: Hlc::new(0, 0, actor),
+            actor,
+            op: Op::SetCollapsed {
+                node: n,
+                value: false,
+                old_value: false,
+            },
+        };
+        tree.apply_op(&mut log, late);
+        assert!(tree.is_collapsed(n), "the larger-ts op wins after reorder");
+        assert_eq!(log.len(), 2);
+    }
+
+    #[test]
+    fn set_collapsed_idempotent_replay() {
+        // Re-applying the same `LogOp` (same ts) is a no-op — the HLC
+        // dedup at the top of `apply_op` guards against double-applying
+        // a peer's op we already saw.
+        let actor = ActorId::new();
+        let g = HlcGenerator::new(actor);
+        let mut tree = Tree::new();
+        let mut log = OpLog::new();
+        let n = NodeId::new();
+
+        let op = make_op(
+            &g,
+            Op::SetCollapsed {
+                node: n,
+                value: true,
+                old_value: false,
+            },
+        );
+        tree.apply_op(&mut log, op.clone());
+        let len_before = log.len();
+        tree.apply_op(&mut log, op);
+        assert_eq!(log.len(), len_before, "duplicate ts must not append");
+        assert!(tree.is_collapsed(n));
+    }
+
+    #[test]
+    fn set_collapsed_undo_restores_previous_state() {
+        // Direct exercise of `undo_op`: after applying SetCollapsed
+        // with `value=true` (captured `old_value=false`), undoing the
+        // op must restore the expanded state.
+        let actor = ActorId::new();
+        let g = HlcGenerator::new(actor);
+        let mut tree = Tree::new();
+        let mut log = OpLog::new();
+        let n = NodeId::new();
+
+        let mut applied = make_op(
+            &g,
+            Op::SetCollapsed {
+                node: n,
+                value: true,
+                old_value: false,
+            },
+        );
+        tree.do_op(&mut applied);
+        log.append(applied.clone());
+        assert!(tree.is_collapsed(n));
+        tree.undo_op(&applied);
+        assert!(
+            !tree.is_collapsed(n),
+            "undo must restore the pre-apply flag"
+        );
+    }
+
+    #[test]
+    fn collapsed_ids_snapshots_current_set() {
+        // Projection layers iterate `collapsed_ids()` to ship the fold
+        // state to UIs / sidecars. Two nodes flipped collapsed must
+        // both appear; a third (untouched) must not.
+        let actor = ActorId::new();
+        let g = HlcGenerator::new(actor);
+        let mut tree = Tree::new();
+        let mut log = OpLog::new();
+        let a = NodeId::new();
+        let b = NodeId::new();
+        let c = NodeId::new();
+        for node in [a, b] {
+            tree.apply_op(
+                &mut log,
+                make_op(
+                    &g,
+                    Op::SetCollapsed {
+                        node,
+                        value: true,
+                        old_value: false,
+                    },
+                ),
+            );
+        }
+        let snapshot: std::collections::HashSet<NodeId> = tree.collapsed_ids().collect();
+        assert!(snapshot.contains(&a));
+        assert!(snapshot.contains(&b));
+        assert!(!snapshot.contains(&c));
     }
 }

--- a/crates/outl-md/CLAUDE.md
+++ b/crates/outl-md/CLAUDE.md
@@ -12,7 +12,10 @@ same paranoia as the CRDT.
 - Parse `.md` (clean, no IDs) → outline AST
 - Render outline AST → `.md` (clean, no IDs)
 - Read/write `.outl` sidecar (JSON, dotfile) — current version `2`,
-  reads v1 transparently (handles backfilled on load)
+  reads v1 transparently (handles backfilled on load). The sidecar
+  is **structural metadata only** (id, line, indent, content hash,
+  ref handle). State that must converge between devices (fold flags,
+  pinned, etc.) goes through the op log in `outl-core`, never here.
 - The 3-level matching algorithm (external edit → reconstruct IDs)
 - Diff (old AST + new AST + old sidecar blocks) → minimal sequence of
   `Op`s, preserving `ref_handle` verbatim on level-1/2 matches. The
@@ -125,6 +128,15 @@ Current version: `2`. Full spec in
   sidecars (no field) load fine — the handle is backfilled in memory
   via `derive_ref_handle`. The next write persists v2. On collision,
   expansion may produce a 7+ char form (see `derive_ref_handle` above).
+
+**Sidecar is not a sync surface.** UI state that must converge between
+devices — fold flags, pinned, selection, anything user-meaningful —
+goes through the op log (`outl-core`), not here. iCloud / Syncthing
+sync the sidecar file as one blob with last-write-wins semantics, so
+two devices flipping different fields in the same window lose data.
+The op log gives each actor its own jsonl, lets the FS sync per-file
+without conflict, and reconverges through the CRDT. See the root
+`CLAUDE.md` invariant 7.
 - Sidecar lives next to the `.md` as `pages/<slug>.outl` (no leading
   dot). Replicated between devices alongside the `.md`. Don't
   gitignore by default. The dotfile form (`.foo.outl`) was abandoned

--- a/crates/outl-md/src/sidecar.rs
+++ b/crates/outl-md/src/sidecar.rs
@@ -17,6 +17,13 @@ use std::path::{Path, PathBuf};
 /// - **2** — added `ref_handle` on every block to power `((blk-XXXXXX))`
 ///   inline references. Backward-compatible read: v1 sidecars load fine
 ///   and their handles are derived on the fly from the block id.
+///
+/// Note: the sidecar is intentionally **only structural metadata**
+/// (ids, position, content hashes, ref handles). Any state that needs
+/// to *converge between devices* — collapsed/folded blocks, future
+/// per-block flags — goes through the `Op` log in `outl-core`, not
+/// here. The sidecar is a projection cache for matching `.md` ↔ tree;
+/// it is not a sync surface. See the root `CLAUDE.md` invariants.
 pub const SIDECAR_VERSION: u32 = 2;
 
 /// Lowest sidecar version this crate is willing to read.

--- a/crates/outl-mobile/src-tauri/src/lib.rs
+++ b/crates/outl-mobile/src-tauri/src/lib.rs
@@ -37,8 +37,8 @@ use outl_actions::{
     delete, edit_text, find_by_slug, indent, journal_slug, journal_title, list_pages,
     migrate_legacy_into_today, move_down, move_up, next_journal_date, open_journal,
     open_or_create_page, open_today, outdent, page_meta as page_meta_action, previous_journal_date,
-    read_page_view, today, toggle_todo as action_toggle_todo, ActionError, Backlink, OutlineNode,
-    PageKind, PageMeta,
+    read_page_view_with_workspace, set_block_collapsed as action_set_block_collapsed, today,
+    toggle_todo as action_toggle_todo, ActionError, Backlink, OutlineNode, PageKind, PageMeta,
 };
 use outl_core::hlc::HlcGenerator;
 use outl_core::id::{ActorId, NodeId};
@@ -164,7 +164,13 @@ fn build_page_view(
     // is still available for tools that need to materialise from the
     // op log, but the UI must not use it — it would silently disagree
     // with what the user sees in Files.app or any other editor.
-    let outline = read_page_view(storage_root, &meta).unwrap_or_else(|_| Vec::new());
+    //
+    // The workspace-aware variant overlays `Op::SetCollapsed` so the
+    // returned `OutlineNode.collapsed` reflects the op log (the only
+    // place that state legitimately lives — sidecars LWW under iCloud
+    // and would lose flips).
+    let outline = read_page_view_with_workspace(storage_root, &meta, workspace)
+        .unwrap_or_else(|_| Vec::new());
     let backlinks = backlinks_for_page(workspace, &meta);
     Ok(PageView {
         page: meta,
@@ -440,6 +446,28 @@ fn move_block_down(
     finish_in_page(&state, page, |ws| move_down(ws, &state.hlc, node))
 }
 
+/// Set or flip the `collapsed` flag on a block.
+///
+/// Routes through `outl_actions::set_block_collapsed` which generates
+/// an `Op::SetCollapsed` and applies it via `Workspace::apply`. The
+/// op enters the device's `ops-<actor>.jsonl`, iCloud propagates the
+/// file to peers, and the CRDT merges concurrent flips by HLC order.
+/// Returns a freshly built page view so the frontend re-renders in a
+/// single round trip.
+#[tauri::command]
+fn set_block_collapsed(
+    page_id: String,
+    id: String,
+    collapsed: bool,
+    state: State<'_, AppState>,
+) -> Result<PageView, String> {
+    let page = parse_node_id(&page_id)?;
+    let node = parse_node_id(&id)?;
+    finish_in_page(&state, page, |ws| {
+        action_set_block_collapsed(ws, &state.hlc, node, collapsed).map(|_| ())
+    })
+}
+
 #[tauri::command]
 fn reload_workspace(state: State<'_, AppState>) -> Result<(), String> {
     let engine = outl_actions::SyncEngine::new(state.storage_root.clone(), state.hlc.actor());
@@ -490,7 +518,7 @@ fn list_outline(state: State<'_, AppState>) -> Result<Vec<OutlineNode>, String> 
         let meta = page_meta_action(ws, today_id)
             .ok_or_else(|| ActionError::NotInTree(today_id.to_string()))
             .map_err(|e| e.to_string())?;
-        read_page_view(&state.storage_root, &meta).map_err(|e| e.to_string())
+        read_page_view_with_workspace(&state.storage_root, &meta, ws).map_err(|e| e.to_string())
     })
 }
 
@@ -672,6 +700,7 @@ pub fn run() {
             outdent_block,
             move_block_up,
             move_block_down,
+            set_block_collapsed,
             reload_workspace,
             // Legacy
             list_outline,

--- a/crates/outl-mobile/src-tauri/src/lib.rs
+++ b/crates/outl-mobile/src-tauri/src/lib.rs
@@ -454,6 +454,16 @@ fn move_block_down(
 /// file to peers, and the CRDT merges concurrent flips by HLC order.
 /// Returns a freshly built page view so the frontend re-renders in a
 /// single round trip.
+///
+/// **Deliberately bypasses `finish_in_page`.** Every other mutation
+/// reprojects `.md` + sidecar at the end because it changed the
+/// outline structure or text. `Op::SetCollapsed` changes neither —
+/// the `.md` body stays byte-identical, the sidecar's structural
+/// fields (id, position, hash, ref_handle) are untouched, and only
+/// the workspace-internal `Tree.collapsed` set moves. Reprojecting
+/// would write two files to disk and bump iCloud upload metadata
+/// for every fold gesture; we skip both and just rebuild the page
+/// view from the freshly-mutated workspace.
 #[tauri::command]
 fn set_block_collapsed(
     page_id: String,
@@ -463,8 +473,9 @@ fn set_block_collapsed(
 ) -> Result<PageView, String> {
     let page = parse_node_id(&page_id)?;
     let node = parse_node_id(&id)?;
-    finish_in_page(&state, page, |ws| {
-        action_set_block_collapsed(ws, &state.hlc, node, collapsed).map(|_| ())
+    with_ws_mut(&state, |ws| {
+        action_set_block_collapsed(ws, &state.hlc, node, collapsed).map_err(|e| e.to_string())?;
+        build_page_view(ws, &state.storage_root, page).map_err(|e| e.to_string())
     })
 }
 

--- a/crates/outl-mobile/src/components/BlockRow.tsx
+++ b/crates/outl-mobile/src/components/BlockRow.tsx
@@ -27,6 +27,13 @@ interface BlockRowProps {
   onIndent: (id: string) => void;
   onOutdent: (id: string) => void;
   onCreateAfter: (id: string) => void;
+  /**
+   * Flip the block's collapsed flag. Implemented by the parent so
+   * the persistence path (Tauri → sidecar) is shared with every
+   * other block-mutating action and the parent can re-render with
+   * the fresh `PageView`.
+   */
+  onToggleCollapse: (id: string, next: boolean) => void;
   onRefClick?: (target: string) => void;
   onTagClick?: (tag: string) => void;
   onTextareaMount?: (el: HTMLTextAreaElement) => void;
@@ -41,6 +48,7 @@ const INDENT_PX = 22;
 
 export function BlockRow(props: BlockRowProps): JSX.Element {
   const isEditing = () => props.editingId === props.block.id;
+  const hasChildren = () => props.block.children.length > 0;
 
   return (
     <div class="relative">
@@ -56,6 +64,11 @@ export function BlockRow(props: BlockRowProps): JSX.Element {
           editing={isEditing()}
           draftText={props.draftText}
           depth={props.depth}
+          hasChildren={hasChildren()}
+          onToggleCollapse={() => {
+            haptic("light");
+            props.onToggleCollapse(props.block.id, !props.block.collapsed);
+          }}
           onStartEdit={() =>
             props.onStartEdit(props.block.id, rawTextWithTodo(props.block))
           }
@@ -80,7 +93,7 @@ export function BlockRow(props: BlockRowProps): JSX.Element {
         />
       </SwipeRow>
 
-      <Show when={props.block.children.length > 0}>
+      <Show when={hasChildren() && !props.block.collapsed}>
         <div class="relative">
           {/* Guide line connecting parent bullet to children */}
           <span
@@ -103,6 +116,7 @@ export function BlockRow(props: BlockRowProps): JSX.Element {
                 onIndent={props.onIndent}
                 onOutdent={props.onOutdent}
                 onCreateAfter={props.onCreateAfter}
+                onToggleCollapse={props.onToggleCollapse}
                 onRefClick={props.onRefClick}
                 onTagClick={props.onTagClick}
                 onTextareaMount={props.onTextareaMount}
@@ -122,6 +136,12 @@ function BlockBody(props: {
    *  editing rows don't subscribe to `draft()`. */
   draftText: () => string;
   depth: number;
+  /** `true` when the block has at least one child. Drives the
+   *  triangle marker (▶/▼). */
+  hasChildren: boolean;
+  /** Flip `block.collapsed`. No-op visually when `hasChildren` is
+   *  `false`; the tap target hides itself in that case. */
+  onToggleCollapse: () => void;
   onStartEdit: () => void;
   onDraftChange: (text: string) => void;
   onCommitEdit: () => void;
@@ -211,6 +231,14 @@ function BlockBody(props: {
       onPointerCancel={onPointerUp}
       onClick={onClick}
     >
+      <CollapseTriangle
+        visible={props.hasChildren}
+        collapsed={props.block.collapsed}
+        onToggle={() => {
+          props.onToggleCollapse();
+        }}
+      />
+
       <BulletOrCheckbox
         todo={props.editing ? null : props.block.todo}
         onToggle={() => {
@@ -255,6 +283,37 @@ function BlockBody(props: {
         </Show>
       </div>
     </div>
+  );
+}
+
+function CollapseTriangle(props: {
+  visible: boolean;
+  collapsed: boolean;
+  onToggle: () => void;
+}) {
+  // Always reserve the slot — even on leaves — so the bullet column
+  // stays put regardless of whether a sibling has children. Width
+  // matches the bullet (`w-[26px]`).
+  return (
+    <Show
+      when={props.visible}
+      fallback={<span aria-hidden="true" class="w-[18px] shrink-0" />}
+    >
+      <button
+        type="button"
+        aria-label={props.collapsed ? "Expand block" : "Collapse block"}
+        aria-expanded={!props.collapsed}
+        onClick={(e) => {
+          e.stopPropagation();
+          props.onToggle();
+        }}
+        class="relative z-10 -my-1.5 -ml-1 flex h-[30px] w-[18px] shrink-0 items-center justify-center text-(--color-ios-text-tertiary) dark:text-(--color-iosd-text-tertiary)"
+      >
+        <span aria-hidden="true" class="text-[10px] leading-none">
+          {props.collapsed ? "▶" : "▼"}
+        </span>
+      </button>
+    </Show>
   );
 }
 

--- a/crates/outl-mobile/src/components/Journal.tsx
+++ b/crates/outl-mobile/src/components/Journal.tsx
@@ -26,6 +26,7 @@ import {
   reloadWorkspace,
   resolveRef,
   searchPages,
+  setBlockCollapsed,
   todaySlug,
   toggleTodo,
   workspaceStats,
@@ -506,6 +507,19 @@ export function Journal() {
     if (next) applyView(next);
   }
 
+  /**
+   * Flip the collapsed flag on a block. UI state — does not enter
+   * the op log; the backend writes the sidecar directly and returns
+   * a fresh page view so the renderer picks up the new flag in the
+   * same frame the user tapped the triangle.
+   */
+  async function handleToggleCollapse(id: string, next: boolean) {
+    const pid = pageId();
+    if (!pid) return;
+    const updated = await withError(() => setBlockCollapsed(pid, id, next));
+    if (updated) applyView(updated);
+  }
+
   async function handleIndent(id: string) {
     const pid = pageId();
     if (!pid) return;
@@ -903,6 +917,7 @@ export function Journal() {
                   onIndent={handleIndent}
                   onOutdent={handleOutdent}
                   onCreateAfter={handleCreateAfter}
+                  onToggleCollapse={handleToggleCollapse}
                   onRefClick={handleRefClick}
                   onTagClick={handleTagClick}
                   onTextareaMount={(el) => {

--- a/crates/outl-mobile/src/components/Journal.tsx
+++ b/crates/outl-mobile/src/components/Journal.tsx
@@ -508,10 +508,12 @@ export function Journal() {
   }
 
   /**
-   * Flip the collapsed flag on a block. UI state — does not enter
-   * the op log; the backend writes the sidecar directly and returns
-   * a fresh page view so the renderer picks up the new flag in the
-   * same frame the user tapped the triangle.
+   * Flip the collapsed flag on a block. The backend generates
+   * `Op::SetCollapsed`, applies it through the op log (same path as
+   * every other mutation), and returns a fresh page view so the
+   * renderer picks up the new flag in the same frame the user tapped
+   * the triangle. The sidecar is not touched — fold state syncs
+   * device-to-device via the per-actor jsonl, not the `.outl` file.
    */
   async function handleToggleCollapse(id: string, next: boolean) {
     const pid = pageId();

--- a/crates/outl-mobile/src/lib/api.ts
+++ b/crates/outl-mobile/src/lib/api.ts
@@ -7,6 +7,13 @@ export interface BlockNode {
   id: string;
   text: string;
   todo: TodoState | null;
+  /**
+   * UI fold state echoed from the sidecar. `true` means the children
+   * are hidden in the outline. Mutated via `setBlockCollapsed` —
+   * persists in `.outl` so the state survives across sessions and
+   * (since the sidecar syncs through iCloud) across devices.
+   */
+  collapsed: boolean;
   children: BlockNode[];
 }
 
@@ -139,4 +146,18 @@ export function moveBlockDown(pageId: string, id: string): Promise<PageView> {
 
 export function reloadWorkspace(): Promise<void> {
   return invoke<void>("reload_workspace");
+}
+
+/**
+ * Persist the collapsed flag on a single block. The backend writes
+ * straight to the sidecar (no `Op` is generated — collapsed is UI
+ * state). Returns the refreshed page view so the caller can re-render
+ * in one round trip.
+ */
+export function setBlockCollapsed(
+  pageId: string,
+  id: string,
+  collapsed: boolean,
+): Promise<PageView> {
+  return invoke<PageView>("set_block_collapsed", { pageId, id, collapsed });
 }

--- a/crates/outl-mobile/src/lib/api.ts
+++ b/crates/outl-mobile/src/lib/api.ts
@@ -8,10 +8,13 @@ export interface BlockNode {
   text: string;
   todo: TodoState | null;
   /**
-   * UI fold state echoed from the sidecar. `true` means the children
-   * are hidden in the outline. Mutated via `setBlockCollapsed` —
-   * persists in `.outl` so the state survives across sessions and
-   * (since the sidecar syncs through iCloud) across devices.
+   * UI fold state overlaid from the backend's op log. `true` means
+   * the children are hidden in the outline. Mutated via
+   * `setBlockCollapsed`, which generates `Op::SetCollapsed` and
+   * appends it to the device's `ops-<actor>.jsonl`; iCloud /
+   * Syncthing propagate the per-actor file and every peer's CRDT
+   * replays the op in HLC order. The sidecar is never written for
+   * this flag.
    */
   collapsed: boolean;
   children: BlockNode[];

--- a/crates/outl-mobile/src/lib/outline.test.ts
+++ b/crates/outl-mobile/src/lib/outline.test.ts
@@ -9,7 +9,7 @@ import {
 } from "./outline";
 
 function block(id: string, text = "", children: BlockNode[] = []): BlockNode {
-  return { id, text, todo: null, children };
+  return { id, text, todo: null, collapsed: false, children };
 }
 
 describe("findBlock", () => {
@@ -76,12 +76,24 @@ describe("rawTextWithTodo", () => {
   });
 
   it("reattaches TODO prefix", () => {
-    const b: BlockNode = { id: "x", text: "ship it", todo: "TODO", children: [] };
+    const b: BlockNode = {
+      id: "x",
+      text: "ship it",
+      todo: "TODO",
+      collapsed: false,
+      children: [],
+    };
     expect(rawTextWithTodo(b)).toBe("TODO ship it");
   });
 
   it("reattaches DONE prefix", () => {
-    const b: BlockNode = { id: "x", text: "ship it", todo: "DONE", children: [] };
+    const b: BlockNode = {
+      id: "x",
+      text: "ship it",
+      todo: "DONE",
+      collapsed: false,
+      children: [],
+    };
     expect(rawTextWithTodo(b)).toBe("DONE ship it");
   });
 });

--- a/crates/outl-tui/CLAUDE.md
+++ b/crates/outl-tui/CLAUDE.md
@@ -53,6 +53,7 @@ we replace the AST node's `.text` and call `save()`, which writes the
 | `o` | new block below + Insert |
 | `O` | new block above + Insert |
 | `dd` | delete current block (chord) |
+| `c` | fold / unfold the current block. Bullet row shows `▼ `/`▶ ` for parents (two-space gap on leaves so columns stay flush). Hidden subtrees are skipped by `j`/`k`. Persisted as `Op::SetCollapsed` in the op log — converges across devices through the CRDT, no per-file last-write-wins. |
 | `y r` | copy current block's ref handle (`((blk-XXXXXX))`) to OS clipboard (via `arboard`) + `last_yanked_ref` (chord). Status flips to `yanked … (clipboard unavailable)` on headless / no-display environments. |
 | `?` | toggle help popup |
 | `q q` | quit (chord — single `q` arms; second `q` confirms) |

--- a/crates/outl-tui/src/actions/collapsed.rs
+++ b/crates/outl-tui/src/actions/collapsed.rs
@@ -39,9 +39,9 @@ impl App {
     /// on the backlinks pane.
     ///
     /// The local mirror (`App.collapsed`) is patched optimistically
-    /// before the sidecar write so the next frame already reflects
-    /// the new state. On disk-write failure we roll back the mirror
-    /// and surface a toast.
+    /// before the op log apply so the next frame already reflects
+    /// the new state. On apply failure we roll the mirror back to
+    /// what the workspace believes and surface a toast.
     pub(crate) fn toggle_collapse_selected(&mut self) {
         // Only the outline owns this chord. Backlinks render their
         // own view of source blocks, not the local fold state.
@@ -100,7 +100,6 @@ impl App {
                 self.toast(ToastKind::Error, format!("collapse failed: {e}"));
             }
         }
-        let _ = was_collapsed; // documented for the read above
         self.recompute_hidden_by_collapse();
     }
 }

--- a/crates/outl-tui/src/actions/collapsed.rs
+++ b/crates/outl-tui/src/actions/collapsed.rs
@@ -1,0 +1,136 @@
+//! `c` chord — fold / unfold the selected block.
+//!
+//! `App::toggle_collapse_selected` flips the block via
+//! `outl_actions::toggle_block_collapsed`, which generates an
+//! `Op::SetCollapsed` and routes it through `Workspace::apply`. The
+//! op enters the local `ops-<actor>.jsonl`, iCloud / Syncthing
+//! propagate the file, and every peer's CRDT replays it in HLC
+//! order. The local mirror (`App.collapsed`) is patched to keep the
+//! renderer reacting in the same frame the chord fired.
+
+use crate::state::{App, Focus, Mode, ToastKind};
+use outl_md::parse::OutlineNode;
+
+impl App {
+    /// Rebuild `hidden_by_collapse` from the current `page.blocks`,
+    /// `collapsed`, and `id_by_flat`. The vector is the same length
+    /// as `id_by_flat`; entry `i` is `true` when block `i` (DFS
+    /// preorder) sits under at least one collapsed ancestor.
+    ///
+    /// O(N) — called every load and every toggle. With N typically
+    /// under a few hundred blocks per page, this is in the same noise
+    /// as the existing reparse work.
+    pub(crate) fn recompute_hidden_by_collapse(&mut self) {
+        let mut hidden: Vec<bool> = Vec::with_capacity(self.id_by_flat.len());
+        let mut cursor = 0usize;
+        walk_hidden(
+            &self.page.blocks,
+            false,
+            &self.collapsed,
+            &self.id_by_flat,
+            &mut cursor,
+            &mut hidden,
+        );
+        self.hidden_by_collapse = hidden;
+    }
+
+    /// Toggle the collapsed flag on the currently selected outline
+    /// block. No-op when the cursor is in Insert / Visual or focused
+    /// on the backlinks pane.
+    ///
+    /// The local mirror (`App.collapsed`) is patched optimistically
+    /// before the sidecar write so the next frame already reflects
+    /// the new state. On disk-write failure we roll back the mirror
+    /// and surface a toast.
+    pub(crate) fn toggle_collapse_selected(&mut self) {
+        // Only the outline owns this chord. Backlinks render their
+        // own view of source blocks, not the local fold state.
+        if !matches!(self.focus, Focus::Outline) {
+            return;
+        }
+        if !matches!(self.mode, Mode::Normal) {
+            return;
+        }
+
+        let Some(&id) = self.id_by_flat.get(self.selected) else {
+            // No sidecar entry for this flat index yet — most likely
+            // a brand-new bullet that the next `save()` will reconcile.
+            self.toast(
+                ToastKind::Info,
+                "block has no sidecar entry yet; save first",
+            );
+            return;
+        };
+
+        // Optimistic local flip — the renderer reacts in this frame.
+        // We re-sync from the workspace below in case the CRDT
+        // resolution differs (e.g. a peer's flip arrived in the same
+        // tick).
+        let was_collapsed = self.collapsed.contains(&id);
+        if was_collapsed {
+            self.collapsed.remove(&id);
+        } else {
+            self.collapsed.insert(id);
+        }
+
+        match outl_actions::toggle_block_collapsed(&mut self.workspace, &self.hlc, id) {
+            Ok(new_value) => {
+                // Adopt the workspace's authoritative value (paranoia:
+                // protects against a stale mirror after a peer op
+                // arrived between the read and the apply).
+                if new_value {
+                    self.collapsed.insert(id);
+                } else {
+                    self.collapsed.remove(&id);
+                }
+                self.status = if new_value {
+                    "collapsed".into()
+                } else {
+                    "expanded".into()
+                };
+            }
+            Err(e) => {
+                // Roll the optimistic mirror back to what the workspace
+                // believes — that's still authoritative.
+                if self.workspace.tree().is_collapsed(id) {
+                    self.collapsed.insert(id);
+                } else {
+                    self.collapsed.remove(&id);
+                }
+                self.toast(ToastKind::Error, format!("collapse failed: {e}"));
+            }
+        }
+        let _ = was_collapsed; // documented for the read above
+        self.recompute_hidden_by_collapse();
+    }
+}
+
+/// DFS walk over `blocks` populating `hidden` (in flat preorder).
+/// `ancestor_hidden` carries down whether any ancestor is collapsed.
+fn walk_hidden(
+    blocks: &[OutlineNode],
+    ancestor_hidden: bool,
+    collapsed: &std::collections::HashSet<outl_core::id::NodeId>,
+    id_by_flat: &[outl_core::id::NodeId],
+    cursor: &mut usize,
+    hidden: &mut Vec<bool>,
+) {
+    for b in blocks {
+        let id = id_by_flat.get(*cursor).copied();
+        hidden.push(ancestor_hidden);
+        *cursor += 1;
+        // A block is itself a collapsed ancestor for its descendants
+        // when its id is in `collapsed`. We OR with `ancestor_hidden`
+        // so a child of a child of a collapsed node stays hidden too.
+        let am_collapsed = id.is_some_and(|i| collapsed.contains(&i));
+        let child_hidden = ancestor_hidden || am_collapsed;
+        walk_hidden(
+            &b.children,
+            child_hidden,
+            collapsed,
+            id_by_flat,
+            cursor,
+            hidden,
+        );
+    }
+}

--- a/crates/outl-tui/src/actions/lifecycle.rs
+++ b/crates/outl-tui/src/actions/lifecycle.rs
@@ -460,17 +460,15 @@ impl App {
         // stale `Focus::Backlink { idx, … }` across pages would point
         // at the wrong backlink list (the new page has its own).
         self.focus = Focus::Outline;
-        // Hydrate the per-page collapsed mirror from the sidecar.
-        // Sidecar blocks are already DFS-preorder, so they line up
-        // with the render walk's `cursor`. A missing or unreadable
-        // sidecar yields an empty mirror (everything renders expanded
-        // until the next reconcile populates `.outl`).
-        // Rebuild the flat-index → NodeId mapping from the sidecar so
-        // the render walk + collapse helpers can reach each block by
-        // id. The collapsed flag itself comes from
-        // `workspace.tree().is_collapsed(id)` — the op log is the
-        // single source of truth across devices (see
-        // `outl_core::op::Op::SetCollapsed`).
+        // Rebuild the flat-index → NodeId mapping from the sidecar
+        // (sidecar blocks are already DFS-preorder, so they line up
+        // with the render walk's `cursor`) and hydrate the collapsed
+        // mirror from `workspace.tree().is_collapsed(_)`. The op log
+        // is the single source of truth across devices — see
+        // `outl_core::op::Op::SetCollapsed`. The sidecar contributes
+        // only the id mapping; a missing or unreadable sidecar
+        // leaves both structures empty until the next reconcile
+        // populates `.outl`.
         self.id_by_flat.clear();
         self.collapsed.clear();
         let sidecar_path = outl_md::resolve_sidecar_path(&path);

--- a/crates/outl-tui/src/actions/lifecycle.rs
+++ b/crates/outl-tui/src/actions/lifecycle.rs
@@ -74,6 +74,9 @@ impl App {
             theme,
             exec_registry: RuntimeRegistry::with_builtins(),
             command_registry: CommandRegistry::with_builtins(),
+            collapsed: std::collections::HashSet::new(),
+            id_by_flat: Vec::new(),
+            hidden_by_collapse: Vec::new(),
         };
         s.refresh_page_list();
         s.ensure_view_file_exists()?;
@@ -457,6 +460,30 @@ impl App {
         // stale `Focus::Backlink { idx, … }` across pages would point
         // at the wrong backlink list (the new page has its own).
         self.focus = Focus::Outline;
+        // Hydrate the per-page collapsed mirror from the sidecar.
+        // Sidecar blocks are already DFS-preorder, so they line up
+        // with the render walk's `cursor`. A missing or unreadable
+        // sidecar yields an empty mirror (everything renders expanded
+        // until the next reconcile populates `.outl`).
+        // Rebuild the flat-index → NodeId mapping from the sidecar so
+        // the render walk + collapse helpers can reach each block by
+        // id. The collapsed flag itself comes from
+        // `workspace.tree().is_collapsed(id)` — the op log is the
+        // single source of truth across devices (see
+        // `outl_core::op::Op::SetCollapsed`).
+        self.id_by_flat.clear();
+        self.collapsed.clear();
+        let sidecar_path = outl_md::resolve_sidecar_path(&path);
+        if let Ok(sc) = outl_md::sidecar::read(&sidecar_path) {
+            self.id_by_flat.reserve(sc.blocks.len());
+            for b in &sc.blocks {
+                self.id_by_flat.push(b.id);
+                if self.workspace.tree().is_collapsed(b.id) {
+                    self.collapsed.insert(b.id);
+                }
+            }
+        }
+        self.recompute_hidden_by_collapse();
         // Snapshot the file's mtime so the polling loop can tell when
         // an *external* edit lands (vs. our own save).
         self.last_mtime = file_mtime(&path);

--- a/crates/outl-tui/src/actions/mod.rs
+++ b/crates/outl-tui/src/actions/mod.rs
@@ -20,6 +20,7 @@
 //! consumed by `input` / `view`) is re-exported from this file.
 
 pub(crate) mod block;
+pub(crate) mod collapsed;
 pub(crate) mod exec;
 pub(crate) mod history;
 pub(crate) mod lifecycle;

--- a/crates/outl-tui/src/actions/nav.rs
+++ b/crates/outl-tui/src/actions/nav.rs
@@ -119,8 +119,17 @@ impl App {
     fn step_forward(&mut self) -> bool {
         match self.focus.clone() {
             Focus::Outline => {
-                if self.selected + 1 < self.flat_len {
-                    self.selected += 1;
+                // Walk forward until we hit a visible block (not
+                // hidden under a collapsed ancestor) or fall off the
+                // end of the outline.
+                let mut next = self.selected + 1;
+                while next < self.flat_len
+                    && self.hidden_by_collapse.get(next).copied().unwrap_or(false)
+                {
+                    next += 1;
+                }
+                if next < self.flat_len {
+                    self.selected = next;
                     self.cursor_col = 0;
                     return true;
                 }
@@ -173,12 +182,23 @@ impl App {
     fn step_backward(&mut self) -> bool {
         match self.focus.clone() {
             Focus::Outline => {
-                if self.selected > 0 {
-                    self.selected -= 1;
-                    self.cursor_col = 0;
-                    return true;
+                // Walk backward over hidden subtree entries the same
+                // way `step_forward` skips them going down.
+                if self.selected == 0 {
+                    return false;
                 }
-                false
+                let mut prev = self.selected - 1;
+                while prev > 0 && self.hidden_by_collapse.get(prev).copied().unwrap_or(false) {
+                    prev -= 1;
+                }
+                if self.hidden_by_collapse.get(prev).copied().unwrap_or(false) {
+                    // Reached the top still inside a collapsed
+                    // subtree — no visible previous block.
+                    return false;
+                }
+                self.selected = prev;
+                self.cursor_col = 0;
+                true
             }
             Focus::Backlink { idx, sub_path } => {
                 let slug = self.current_slug();

--- a/crates/outl-tui/src/input.rs
+++ b/crates/outl-tui/src/input.rs
@@ -412,6 +412,11 @@ pub(crate) fn handle_normal_key(app: &mut App, key: KeyEvent) -> Result<bool> {
         }
         KeyCode::Char('d') => app.pending_chord = Some('d'),
         KeyCode::Char('y') => app.pending_chord = Some('y'),
+        // Fold / unfold the selected block. The renderer's triangle
+        // marker (▶/▼) is the visual confirmation. No-op when the
+        // block has no sidecar entry yet (see
+        // `App::toggle_collapse_selected`).
+        KeyCode::Char('c') => app.toggle_collapse_selected(),
         // Paste from the yank register. Plain `p`/`P` (no Ctrl, no
         // Alt) — Ctrl+P is the quick switcher and must beat this.
         KeyCode::Char('p') if key.modifiers.is_empty() => app.paste_after(),

--- a/crates/outl-tui/src/state.rs
+++ b/crates/outl-tui/src/state.rs
@@ -466,13 +466,17 @@ pub(crate) struct App {
     pub(crate) toasts: Vec<Toast>,
 
     /// Block ids currently rendered collapsed (children hidden) in
-    /// the outline. Mirrors the sidecar's `collapsed` flag for every
-    /// block on the active page; populated on every `load_current`.
+    /// the outline. Hydrated from `workspace.tree().is_collapsed(_)`
+    /// on every `load_current`, so the local mirror always tracks
+    /// the op log's authoritative view.
     ///
-    /// Source of truth lives in the sidecar — this is just the
-    /// fast-path the renderer consults to skip subtrees. Toggling
-    /// goes through `outl_actions::toggle_block_collapsed`, which
-    /// writes the sidecar; the local HashSet is patched optimistically.
+    /// Source of truth is the op log (`Op::SetCollapsed`); this
+    /// `HashSet` is the fast-path the renderer + nav helpers consult
+    /// to skip hidden subtrees. Toggling goes through
+    /// `outl_actions::toggle_block_collapsed`, which generates an
+    /// `Op::SetCollapsed` and applies it via `Workspace::apply`. We
+    /// patch this `HashSet` optimistically and re-sync from the
+    /// workspace after the apply returns.
     pub(crate) collapsed: HashSet<NodeId>,
 
     /// Flat DFS-preorder map from the outline's flat index (the

--- a/crates/outl-tui/src/state.rs
+++ b/crates/outl-tui/src/state.rs
@@ -13,15 +13,17 @@ use crate::edit_buffer::EditBuffer;
 use crate::theme::Theme;
 use chrono::NaiveDate;
 use outl_core::hlc::HlcGenerator;
+use outl_core::id::NodeId;
 use outl_core::workspace::Workspace;
 use outl_exec::RuntimeRegistry;
 use outl_md::index::WorkspaceIndex;
 use outl_md::parse::{OutlineNode, ParsedPage};
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::time::{Instant, SystemTime};
 
 pub(crate) const HELP_HINT_NORMAL: &str =
-    "i edit  o new  h/l cursor  Enter open ref  K/J move  C-T TODO  u undo  ? help  q";
+    "i edit  o new  c fold  Enter open ref  K/J move  C-T TODO  u undo  ? help  q";
 pub(crate) const HELP_HINT_INSERT: &str =
     "Esc commit  Enter new block  Ctrl+T TODO  Tab indent  Shift-Tab outdent";
 pub(crate) const HELP_HINT_VISUAL: &str =
@@ -462,6 +464,40 @@ pub(crate) struct App {
     /// from `status`, which still drives the single-line footer
     /// message (e.g. chord prompts).
     pub(crate) toasts: Vec<Toast>,
+
+    /// Block ids currently rendered collapsed (children hidden) in
+    /// the outline. Mirrors the sidecar's `collapsed` flag for every
+    /// block on the active page; populated on every `load_current`.
+    ///
+    /// Source of truth lives in the sidecar — this is just the
+    /// fast-path the renderer consults to skip subtrees. Toggling
+    /// goes through `outl_actions::toggle_block_collapsed`, which
+    /// writes the sidecar; the local HashSet is patched optimistically.
+    pub(crate) collapsed: HashSet<NodeId>,
+
+    /// Flat DFS-preorder map from the outline's flat index (the
+    /// `cursor` the render walk maintains, also `App.selected`) to
+    /// the block's `NodeId`. Populated on every `load_current` from
+    /// the freshly-read sidecar's `blocks` list (which is itself in
+    /// DFS preorder by construction).
+    ///
+    /// The render walk needs an id-by-position lookup to consult
+    /// `collapsed`; `outl-md::parse::OutlineNode` does not carry the
+    /// id, and going through the workspace index every step would be
+    /// O(N) per render. This vector is cheap to (re)build and stays
+    /// in sync with `page.blocks` because both are reconstructed
+    /// together in `load_current_no_autorun`.
+    pub(crate) id_by_flat: Vec<NodeId>,
+
+    /// `hidden_by_collapse[i]` is `true` when the i-th flat block
+    /// has at least one ancestor whose id is in [`Self::collapsed`].
+    /// Used by `step_forward`/`step_backward` to skip past folded
+    /// subtrees so `j`/`k` never leave the user pointing at an
+    /// invisible block.
+    ///
+    /// Recomputed whenever `collapsed` changes
+    /// (`recompute_hidden_by_collapse`).
+    pub(crate) hidden_by_collapse: Vec<bool>,
 
     /// Where the cursor lives — outline (default) or inside the inline
     /// backlinks section. Reset to `Focus::Outline` whenever the view

--- a/crates/outl-tui/src/view/backlinks.rs
+++ b/crates/outl-tui/src/view/backlinks.rs
@@ -160,7 +160,18 @@ fn render_backlink_node(
     };
 
     let has_auto_run = node.properties.iter().any(|(k, _)| k == "auto-run");
-    emit_block_lines(indent, bullet_style, &mode, has_auto_run, app, out);
+    // Backlinks render a *projection* of a source block — fold state
+    // belongs to the source page's outline, not here. Always pass
+    // `None` so the layout stays flush.
+    emit_block_lines(
+        indent,
+        bullet_style,
+        &mode,
+        has_auto_run,
+        crate::view::outline::FoldMarker::None,
+        app,
+        out,
+    );
 
     for (k, v) in &node.properties {
         let mut spans: Vec<Span<'_>> = Vec::new();

--- a/crates/outl-tui/src/view/outline.rs
+++ b/crates/outl-tui/src/view/outline.rs
@@ -109,8 +109,33 @@ pub(crate) fn render_block(
         }
     };
 
+    // Fold indicator for the bullet row.
+    //   - `▼ ` when the block has children and is expanded
+    //   - `▶ ` when it has children and is collapsed
+    //   - `  ` (two spaces) when it has no children — keeps column
+    //     alignment with the other two cases so the bullet column
+    //     never jitters across blocks on the same indent.
+    let block_id = app.id_by_flat.get(*cursor).copied();
+    let is_collapsed = block_id
+        .map(|id| app.collapsed.contains(&id))
+        .unwrap_or(false);
+    let has_children = !b.children.is_empty();
+    let fold_marker = match (has_children, is_collapsed) {
+        (false, _) => FoldMarker::None,
+        (true, false) => FoldMarker::Expanded,
+        (true, true) => FoldMarker::Collapsed,
+    };
+
     let has_auto_run = b.properties.iter().any(|(k, _)| k == "auto-run");
-    emit_block_lines(indent, bullet_style, &mode, has_auto_run, app, out);
+    emit_block_lines(
+        indent,
+        bullet_style,
+        &mode,
+        has_auto_run,
+        fold_marker,
+        app,
+        out,
+    );
 
     for (k, v) in &b.properties {
         let mut prop_spans: Vec<Span<'_>> = Vec::new();
@@ -144,8 +169,17 @@ pub(crate) fn render_block(
     }
 
     *cursor += 1;
-    for child in &b.children {
-        render_block(child, indent + 1, cursor, app, out, selected_line);
+    if is_collapsed {
+        // Children are hidden — but the flat cursor still has to
+        // skip past them because `App.selected` and friends index
+        // the full DFS preorder (collapsed or not). Without this
+        // bump, selection bookkeeping for blocks *below* the
+        // collapsed subtree would shift up by `flat_count(children)`.
+        *cursor += outl_md::outline_ops::flat_count(&b.children);
+    } else {
+        for child in &b.children {
+            render_block(child, indent + 1, cursor, app, out, selected_line);
+        }
     }
 }
 
@@ -222,6 +256,21 @@ fn emit_embedded_children(
     }
 }
 
+/// Fold indicator drawn before the bullet on the bullet row.
+///
+/// `None` keeps a two-cell gap so leaf rows align with their parent
+/// at the same indent — without it, a leaf's `-` would slide left
+/// the moment a sibling grew children.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FoldMarker {
+    /// Block has no children — no marker, gap only.
+    None,
+    /// Block has children and they're visible. `▼ ` prefix.
+    Expanded,
+    /// Block has children but they're folded away. `▶ ` prefix.
+    Collapsed,
+}
+
 /// Where the cursor sits on a block being rendered, and what style
 /// the renderer should use for it. The UI-agnostic decomposition
 /// lives in [`outl_md::view`]; this enum carries the *TUI-flavored*
@@ -250,6 +299,7 @@ pub(crate) fn emit_block_lines(
     bullet_style: Style,
     mode: &RenderMode,
     has_auto_run: bool,
+    fold: FoldMarker,
     app: &App,
     out: &mut Vec<Line<'static>>,
 ) {
@@ -276,6 +326,15 @@ pub(crate) fn emit_block_lines(
         }
         match row.kind {
             BlockRowKind::Bullet => {
+                // Fold indicator goes first — two-cell slot whether
+                // the marker is visible or not. Keeps the bullet `-`
+                // column stable across siblings (leaf next to a
+                // parent must line up).
+                match fold {
+                    FoldMarker::None => spans.push(Span::raw("  ")),
+                    FoldMarker::Expanded => spans.push(Span::styled("▼ ", app.theme.dim)),
+                    FoldMarker::Collapsed => spans.push(Span::styled("▶ ", app.theme.hint)),
+                }
                 // Blocks with `auto-run::` get a ⚡ before the bullet
                 // so the user can see at a glance which cells re-run
                 // themselves on page open.
@@ -287,8 +346,11 @@ pub(crate) fn emit_block_lines(
             BlockRowKind::Continuation
             | BlockRowKind::CodeFenceMarker
             | BlockRowKind::CodeFenceBody => {
-                // Indent the continuation rows by the same width
-                // the ⚡ added on the bullet row so columns align.
+                // Mirror the bullet-row's pre-bullet padding so
+                // continuation rows stay aligned with the bullet
+                // column above them (two cells for the fold slot,
+                // one extra cell when `⚡` is present).
+                spans.push(Span::raw("  "));
                 if has_auto_run {
                     spans.push(Span::raw(" "));
                 }

--- a/crates/outl-tui/src/view/overlays.rs
+++ b/crates/outl-tui/src/view/overlays.rs
@@ -695,6 +695,8 @@ fn help_tab_body(tab: usize, app: &App) -> Vec<Line<'static>> {
             Line::from("  dd          delete block"),
             Line::from("  yy / p / P  yank · paste after · paste before"),
             Line::from("  Ctrl+T      cycle TODO / DONE / none"),
+            Line::from("  c           fold / unfold the selected block"),
+            Line::from("              (▼ expanded · ▶ collapsed · synced via sidecar)"),
             Line::from("  u / Ctrl+R  undo / redo"),
             Line::from("  g p         toggle pinned:: on this page (chord)"),
             Line::from(""),

--- a/crates/outl-tui/src/view/overlays.rs
+++ b/crates/outl-tui/src/view/overlays.rs
@@ -696,7 +696,7 @@ fn help_tab_body(tab: usize, app: &App) -> Vec<Line<'static>> {
             Line::from("  yy / p / P  yank · paste after · paste before"),
             Line::from("  Ctrl+T      cycle TODO / DONE / none"),
             Line::from("  c           fold / unfold the selected block"),
-            Line::from("              (▼ expanded · ▶ collapsed · synced via sidecar)"),
+            Line::from("              (▼ expanded · ▶ collapsed · synced via op log)"),
             Line::from("  u / Ctrl+R  undo / redo"),
             Line::from("  g p         toggle pinned:: on this page (chord)"),
             Line::from(""),

--- a/docs/crdt.md
+++ b/docs/crdt.md
@@ -92,6 +92,12 @@ enum Op {
         parent: NodeId,
         position: Fractional,
     },
+    SetCollapsed {
+        node: NodeId,
+        value: bool,
+        // Populated by do_op; needed for undo.
+        old_value: bool,
+    },
 }
 
 struct LogOp {
@@ -108,6 +114,17 @@ exactly to the pre-op state.
 **`Delete` is intentionally not an op.** Deleting node `N` is `Move(N, TRASH_ROOT)`.
 This simplifies the algorithm — concurrent edit + delete becomes concurrent
 edit + move — and preserves the deleted subtree for history/undo.
+
+**`SetCollapsed` carries UI fold state through the op log.** The flag controls
+whether a block renders with its children hidden in the outline view —
+presentation state, but globally meaningful across devices. Routing it
+through an `Op` (rather than a sidecar field) is what gives concurrent
+flips a real merge semantics: each device appends to its own
+`ops-<actor>.jsonl`, HLC + actor tiebreak resolves any timing collision
+deterministically, and idempotent re-apply of the same `LogOp` is a no-op.
+This is the canonical pattern for any future per-block UI state that
+must converge — pin status, custom colour, whatever. The sidecar carries
+only structural matching metadata; sync state belongs on the op log.
 
 ---
 

--- a/docs/markdown-format.md
+++ b/docs/markdown-format.md
@@ -220,6 +220,12 @@ Format: JSON.
 }
 ```
 
+> The sidecar is **structural matching metadata only** — block id,
+> position, content hash, ref handle. State that must converge
+> between devices (fold flags, etc.) lives in the op log
+> (`outl-core`), never here. iCloud syncs the sidecar with LWW
+> per-file, which would silently drop concurrent writes.
+
 ### Fields
 
 - `version`: always present, integer. Future migrations check this.

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -37,6 +37,7 @@ characters insert themselves — every key is a command.
 | `Tab` / `Shift-Tab` | Indent / outdent the current block |
 | `K` / `J` (or `Alt+↑/↓`) | Move block up / down |
 | `dd` | Delete the current block (chord) |
+| `c` | Fold / unfold the current block. The bullet row shows `▼ ` (expanded) or `▶ ` (collapsed) when the block has children, two spaces otherwise. Children are hidden from the outline while collapsed and `j` / `k` skip past them, but the underlying tree is untouched. State is persisted as an `Op::SetCollapsed` in the op log — every device replays the same sequence, so the fold layout converges across iCloud / Syncthing peers without relying on file-level last-write-wins (which would lose concurrent flips). No-op on a block whose sidecar entry hasn't been written yet (save first). |
 | `y r` | Yank the current block's ref handle (`((blk-XXXXXX))`) to the OS clipboard + `last_yanked_ref` (chord). On headless / no-clipboard environments it falls back to the status line only. |
 | `Ctrl+Enter` / `Ctrl+T` | Cycle the block's TODO / DONE / none prefix (`Ctrl+T` is the portable fallback for tmux / Terminal.app, which collapse `Ctrl+Enter` into plain `Enter`) |
 | `u` / `Ctrl+R` | Undo / redo |


### PR DESCRIPTION
The TUI and mobile needed fold/unfold for blocks, and the state had to converge across devices. First pass stored the flag in the sidecar, but that file syncs through iCloud with last-write-wins per file, so two devices flipping different blocks in the same window would silently lose one.

Modeled the flag as Op::SetCollapsed in outl-core, materialized into a HashSet on the tree. Each actor appends to its own ops jsonl, HLC ordering merges concurrent flips deterministically, and idempotent re-apply is a no-op. TUI presses `c` to toggle and the row marker shows ▼ for expanded and ▶ for collapsed (two-space slot on leaves so the bullet column stays flush). Mobile gets a tappable triangle on the bullet, same op path through set_block_collapsed in outl-actions. Sidecar goes back to v2, structural metadata only.

Documented the rule across root, outl-core, outl-md and outl-actions CLAUDE.md: any per-block state that needs to converge between devices goes through an Op, never a shared file. Sidecar is not a sync surface.