### PR TITLE
feat: read OUTL_WORKSPACE env var for workspace resolution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ ratatui = "0.30"
 crossterm = "0.29"
 
 # CLI
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 
 # Filesystem
 notify = "8"

--- a/crates/outl-cli/CLAUDE.md
+++ b/crates/outl-cli/CLAUDE.md
@@ -14,6 +14,23 @@ and see their notes, not a help screen.
 The TUI library is reused via `use outl_tui;` (the crate exposes both
 a library and a binary). Don't fork the TUI logic into the CLI.
 
+## Workspace resolution
+
+Every command resolves its workspace path through `resolve_path` in
+`main.rs`, in precedence order: subcommand positional > `--workspace`
+flag > `OUTL_WORKSPACE` env var > current dir. The env var is wired
+through clap's `env` feature on the global `workspace` arg, so the
+flag transparently wins over the env.
+
+`outl init` uses `resolve_init_path` instead: it accepts a positional
+or an explicit `--workspace`, but **ignores `OUTL_WORKSPACE`** so a
+stray env var never scaffolds a workspace by accident. That distinction
+needs the value's origin, which `main` reads via
+`ArgMatches::value_source` (a `CommandLine` source means the flag was
+passed; `EnvVariable` means it came from the env) — hence `main` parses
+through `Cli::command().get_matches()` + `from_arg_matches` rather than
+plain `Cli::parse()`.
+
 ## Commands
 
 ### Lifecycle / one-shot

--- a/crates/outl-cli/src/main.rs
+++ b/crates/outl-cli/src/main.rs
@@ -13,7 +13,8 @@
 //!   that lets Claude Desktop reach the same handlers over stdio.
 
 use anyhow::{Context, Result};
-use clap::{Parser, Subcommand};
+use clap::parser::ValueSource;
+use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 use std::path::{Path, PathBuf};
 
 mod cmd;
@@ -37,8 +38,15 @@ mod ws;
 struct Cli {
     /// Workspace path. Used by every subcommand that needs one;
     /// defaults to the current directory. Subcommand-level positional
-    /// path, when provided, takes precedence.
-    #[arg(short = 'w', long, global = true, value_name = "DIR")]
+    /// path, when provided, takes precedence. Reads `OUTL_WORKSPACE`
+    /// when the flag is absent (the flag still wins over the env var).
+    #[arg(
+        short = 'w',
+        long,
+        global = true,
+        env = "OUTL_WORKSPACE",
+        value_name = "DIR"
+    )]
     workspace: Option<PathBuf>,
 
     /// TUI theme preset (default-dark, light, dracula, solarized-dark,
@@ -182,7 +190,13 @@ pub enum McpSubcommand {
 }
 
 fn main() -> Result<()> {
-    let cli = Cli::parse();
+    // Parse via `ArgMatches` so we can ask where `--workspace` came from.
+    // `outl init` accepts the flag/positional but must ignore the
+    // `OUTL_WORKSPACE` env var, and the only way to tell a flag value
+    // apart from an env value is `ArgMatches::value_source`.
+    let matches = Cli::command().get_matches();
+    let workspace_from_cli = matches.value_source("workspace") == Some(ValueSource::CommandLine);
+    let cli = Cli::from_arg_matches(&matches).unwrap_or_else(|e| e.exit());
 
     // The TUI installs its own silent subscriber that captures
     // dependency logs (Steel, wasmtime, ...) into
@@ -208,7 +222,7 @@ fn main() -> Result<()> {
             outl_tui::run_with_theme_override(&p, cli.theme.as_deref())
         }
         Some(Command::Init { path }) => {
-            let p = resolve_init_path(cli.workspace.as_ref(), path.as_ref())?;
+            let p = resolve_init_path(cli.workspace.as_ref(), path.as_ref(), workspace_from_cli)?;
             cmd::init::run(&p)
         }
         Some(Command::Serve { path, once }) => {
@@ -337,15 +351,29 @@ fn ensure_workspace_or_prompt(path: &Path) -> Result<()> {
     }
 }
 
-/// Same as [`resolve_path`] but errors out when neither flag nor positional
-/// was given (init refuses to create a workspace at the cwd by accident).
-fn resolve_init_path(global: Option<&PathBuf>, local: Option<&PathBuf>) -> Result<PathBuf> {
-    match local.or(global) {
-        Some(p) => Ok(p.clone()),
-        None => Err(anyhow::anyhow!(
-            "`outl init` needs an explicit path: pass a positional argument or `--workspace <DIR>`"
-        )),
+/// Same as [`resolve_path`] but errors out when neither the positional
+/// nor an explicit `--workspace` flag was given (init refuses to create a
+/// workspace at the cwd by accident). The `OUTL_WORKSPACE` env var is
+/// deliberately ignored here — `global_from_cli` is false when `global`
+/// was filled from the environment — so `init` never creates a workspace
+/// at a directory inherited from the shell.
+fn resolve_init_path(
+    global: Option<&PathBuf>,
+    local: Option<&PathBuf>,
+    global_from_cli: bool,
+) -> Result<PathBuf> {
+    if let Some(p) = local {
+        return Ok(p.clone());
     }
+    if global_from_cli {
+        if let Some(p) = global {
+            return Ok(p.clone());
+        }
+    }
+    Err(anyhow::anyhow!(
+        "`outl init` needs an explicit path: pass a positional argument or `--workspace <DIR>` \
+         (OUTL_WORKSPACE is ignored for init)"
+    ))
 }
 
 fn init_tracing(verbosity: u8) {

--- a/crates/outl-cli/tests/cli_machine.rs
+++ b/crates/outl-cli/tests/cli_machine.rs
@@ -241,3 +241,122 @@ fn workspace_info_returns_summary() {
     assert!(info["data"]["actor"].is_string());
     assert!(info["data"]["ops"].is_number());
 }
+
+// --- OUTL_WORKSPACE env var resolution -------------------------------
+//
+// Precedence: positional > `--workspace` flag > `OUTL_WORKSPACE` env >
+// cwd. `init` is the one exception — it ignores the env var so it never
+// scaffolds a workspace at a directory inherited from the shell.
+
+/// With no flag and no positional, the env var alone targets the
+/// workspace.
+#[test]
+fn workspace_from_env() {
+    let ws = init_workspace();
+    let env = ok(outl()
+        .env("OUTL_WORKSPACE", ws.path())
+        .args(["page", "create", "from-env", "--title", "FromEnv", "--json"])
+        .output()
+        .unwrap());
+    assert_eq!(env["ok"], true);
+    assert_eq!(env["data"]["meta"]["slug"], "from-env");
+
+    // And the page is readable from the same env-resolved workspace.
+    let got = ok(outl()
+        .env("OUTL_WORKSPACE", ws.path())
+        .args(["page", "get", "from-env", "--json"])
+        .output()
+        .unwrap());
+    assert_eq!(got["data"]["meta"]["title"], "FromEnv");
+}
+
+/// The `--workspace` flag wins over `OUTL_WORKSPACE`: the page lands in
+/// the flag's workspace, and the env's workspace stays empty.
+#[test]
+fn flag_beats_env() {
+    let flag_ws = init_workspace();
+    let env_ws = init_workspace();
+
+    let created = ok(outl()
+        .env("OUTL_WORKSPACE", env_ws.path())
+        .args(["--workspace"])
+        .arg(flag_ws.path())
+        .args([
+            "page", "create", "flagwins", "--title", "FlagWins", "--json",
+        ])
+        .output()
+        .unwrap());
+    assert_eq!(created["ok"], true);
+
+    // Present in the flag workspace...
+    let in_flag = ok(outl()
+        .args(["--workspace"])
+        .arg(flag_ws.path())
+        .args(["page", "get", "flagwins", "--json"])
+        .output()
+        .unwrap());
+    assert_eq!(in_flag["data"]["meta"]["slug"], "flagwins");
+
+    // ...and absent from the env workspace.
+    let in_env = outl()
+        .args(["--workspace"])
+        .arg(env_ws.path())
+        .args(["page", "get", "flagwins", "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        !in_env.status.success(),
+        "page must not exist in env workspace"
+    );
+}
+
+/// `init` deliberately ignores `OUTL_WORKSPACE`: with the env set but no
+/// positional/flag, it must refuse rather than scaffold at the env path.
+#[test]
+fn init_ignores_env() {
+    let dir = TempDir::new().unwrap();
+    let out = outl()
+        .env("OUTL_WORKSPACE", dir.path())
+        .arg("init")
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "init must fail when only the env var is set"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("needs an explicit path"),
+        "unexpected stderr: {stderr}"
+    );
+    // No workspace layout was created at the env path.
+    assert!(!dir.path().join("pages").exists());
+}
+
+/// `init --workspace <dir>` works even with the env set and the flag
+/// placed *after* the subcommand — covers `value_source` correctly
+/// reporting `CommandLine` for the global arg.
+#[test]
+fn init_with_flag_after_subcommand_beats_env() {
+    let env_dir = TempDir::new().unwrap();
+    let target = TempDir::new().unwrap();
+    let status = outl()
+        .env("OUTL_WORKSPACE", env_dir.path())
+        .arg("init")
+        .args(["--workspace"])
+        .arg(target.path())
+        .status()
+        .unwrap();
+    assert!(
+        status.success(),
+        "init with explicit --workspace must succeed"
+    );
+    assert!(
+        target.path().join("pages").exists(),
+        "init must scaffold the flag path"
+    );
+    assert!(
+        !env_dir.path().join("pages").exists(),
+        "env path must stay untouched"
+    );
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -98,6 +98,27 @@ either a pretty-printed payload or, for markdown-first tools
 `outl_daily_get`), the raw `.md` string. Clients should read
 `structuredContent.data` for typed access.
 
+## Selecting the workspace
+
+Every command that touches a workspace resolves its path the same way.
+In precedence order (first match wins):
+
+1. The subcommand's positional `path` argument, when it has one
+   (`outl tui ~/notes`, `outl serve ~/notes`).
+2. The global `--workspace`/`-w <DIR>` flag.
+3. The `OUTL_WORKSPACE` environment variable.
+4. The current working directory.
+
+So `OUTL_WORKSPACE=~/notes outl page list` and
+`outl --workspace ~/notes page list` are equivalent, and an explicit
+flag always overrides the env var.
+
+**Exception — `outl init`.** Scaffolding a workspace requires an
+explicit target: a positional path or `--workspace`. `init`
+deliberately ignores `OUTL_WORKSPACE` (and the cwd) so an env var
+left in your shell can never cause it to create a workspace where you
+didn't mean to.
+
 ## Commands by domain
 
 The CLI column is what you type at the terminal. The MCP tool


### PR DESCRIPTION
## What

Wire `OUTL_WORKSPACE` into the CLI's workspace resolution. Until now
the env var was never read despite the docs implying it survived the
`--path` → `--workspace` rename, so any non-cwd invocation had to pass
`--workspace` explicitly.

## Resolution order

`subcommand positional > --workspace flag > OUTL_WORKSPACE env > current dir`

Implemented via clap's `env` feature on the global `workspace` arg, so
the flag transparently wins over the env var, and `--help` now shows
`[env: OUTL_WORKSPACE=]`.

## `outl init` exception

`init` deliberately **ignores** `OUTL_WORKSPACE` and still requires an
explicit positional or `--workspace`. A stray env var left in the
shell must never scaffold a workspace by accident. The value's origin
is read via `ArgMatches::value_source` (`CommandLine` vs `EnvVariable`),
which is why `main` parses through `Cli::command().get_matches()` +
`from_arg_matches` instead of plain `Cli::parse()`.

## Tests

New cases in `crates/outl-cli/tests/cli_machine.rs`:

- `workspace_from_env` — env alone targets the workspace
- `flag_beats_env` — `--workspace` overrides the env var
- `init_ignores_env` — `init` with only the env set fails
- `init_with_flag_after_subcommand_beats_env` — covers `value_source`
  reporting `CommandLine` for the global arg passed *after* the subcommand

## Verification

`cargo fmt --check`, `cargo clippy -p outl-cli -D warnings`,
`cargo test -p outl-cli`, and `RUSTDOCFLAGS=-D warnings cargo doc` all pass.

Closes #31
