### PR TITLE
Paste external markdown as block tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4441,7 +4441,7 @@ dependencies = [
 
 [[package]]
 name = "outl-actions"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "chrono",
  "outl-core",
@@ -4457,7 +4457,7 @@ dependencies = [
 
 [[package]]
 name = "outl-cli"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4481,7 +4481,7 @@ dependencies = [
 
 [[package]]
 name = "outl-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bincode 2.0.1",
  "chrono",
@@ -4501,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "outl-exec"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "boa_engine",
@@ -4522,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "outl-md"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "chrono",
  "comrak",
@@ -4541,7 +4541,7 @@ dependencies = [
 
 [[package]]
 name = "outl-mobile"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "chrono",
  "objc2",
@@ -4562,7 +4562,7 @@ dependencies = [
 
 [[package]]
 name = "outl-tui"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9369,7 +9369,7 @@ checksum = "0637d3a5566a82fa5214bae89087bc8c9fb94cd8e8a3c07feb691bb8d9c632db"
 
 [[package]]
 name = "xtask"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "clap",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 rust-version = "1.95"
 license = "MIT"
@@ -23,11 +23,11 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Internal crates
-outl-core = { path = "crates/outl-core", version = "0.5.1" }
-outl-md = { path = "crates/outl-md", version = "0.5.1" }
-outl-actions = { path = "crates/outl-actions", version = "0.5.1" }
-outl-exec = { path = "crates/outl-exec", version = "0.5.1" }
-outl-tui = { path = "crates/outl-tui", version = "0.5.1" }
+outl-core = { path = "crates/outl-core", version = "0.5.2" }
+outl-md = { path = "crates/outl-md", version = "0.5.2" }
+outl-actions = { path = "crates/outl-actions", version = "0.5.2" }
+outl-exec = { path = "crates/outl-exec", version = "0.5.2" }
+outl-tui = { path = "crates/outl-tui", version = "0.5.2" }
 
 # IDs and time
 ulid = { version = "1", features = ["serde"] }

--- a/crates/outl-actions/CLAUDE.md
+++ b/crates/outl-actions/CLAUDE.md
@@ -32,6 +32,7 @@ outl-cli / outl-tui / outl-mobile / future clients
 | `backlinks` | `Backlink`, `backlinks_for_target`, `backlinks_for_page`, `extract_refs` (parse `[[ref]]` tokens) |
 | `journal`   | `render_page_md`, `apply_page_md`, `apply_page_md_with_sidecar`, `apply_all_pages_md`, `mutate_page_md`, `journals_dir`, `pages_dir`, `page_md_path`, `write_md_atomic` |
 | `sync`      | `SyncEngine`, `OpsFileSnapshot`. Reload workspace from disk, re-project a page's `.md` + sidecar, snapshot peer jsonls (skipping own), scan for orphan `.md` files (no sidecar / stale hash). Shared by TUI poller + mobile iCloud watcher. |
+| `paste`     | `paste_markdown`, `PasteAnchor`, `PasteOutcome`, `normalize_external_syntax`. Converts external clipboard markdown (Roam `{{[[TODO]]}}`, GitHub `[ ]/[x]`, Logseq `id::`, 4-space indent) into outl syntax and grafts the bullet structure as blocks. Drives `Event::Paste` in the TUI and the mobile `paste_markdown_at` Tauri command. |
 | `error`     | `ActionError`                                                                  |
 
 ## Contract

--- a/crates/outl-actions/src/lib.rs
+++ b/crates/outl-actions/src/lib.rs
@@ -56,6 +56,7 @@ pub mod error;
 pub mod journal;
 pub mod outline;
 pub mod page;
+pub mod paste;
 pub mod sync;
 pub mod todo;
 pub mod tree;
@@ -78,6 +79,7 @@ pub use page::{
     open_or_create as open_or_create_page, open_today, page_meta, previous_journal_date,
     read_text_prop, set_property, today, PageKind, PageMeta,
 };
+pub use paste::{normalize_external_syntax, paste_markdown, PasteAnchor, PasteOutcome};
 pub use sync::{OpsFileSnapshot, SyncEngine};
 pub use todo::{cycle_todo, split_todo, TodoState, DONE_PREFIX, TODO_PREFIX};
 pub use tree::{

--- a/crates/outl-actions/src/lib.rs
+++ b/crates/outl-actions/src/lib.rs
@@ -79,7 +79,9 @@ pub use page::{
     open_or_create as open_or_create_page, open_today, page_meta, previous_journal_date,
     read_text_prop, set_property, today, PageKind, PageMeta,
 };
-pub use paste::{normalize_external_syntax, paste_markdown, PasteAnchor, PasteOutcome};
+pub use paste::{
+    looks_like_outline, normalize_external_syntax, paste_markdown, PasteAnchor, PasteOutcome,
+};
 pub use sync::{OpsFileSnapshot, SyncEngine};
 pub use todo::{cycle_todo, split_todo, TodoState, DONE_PREFIX, TODO_PREFIX};
 pub use tree::{

--- a/crates/outl-actions/src/paste/anchors.rs
+++ b/crates/outl-actions/src/paste/anchors.rs
@@ -1,0 +1,260 @@
+//! Anchor-specific paste implementations.
+//!
+//! `paste_markdown` (in [`super`]) decides which anchor variant the
+//! caller asked for and dispatches to one of the functions here.
+//! Splitting them out keeps the entry point small and each variant
+//! single-purpose.
+
+use outl_core::hlc::HlcGenerator;
+use outl_core::id::NodeId;
+use outl_core::property::PropValue;
+use outl_core::workspace::Workspace;
+use outl_md::parse::OutlineNode as ParsedNode;
+
+use super::{collect_ids, push_ids, PasteAnchor, PasteOutcome};
+use crate::block::{
+    append_forest, create_after, create_under, edit_text, BlockTreeOutcome, BlockTreeSpec,
+};
+use crate::error::ActionError;
+use crate::page::set_property;
+
+/// Append every parsed block as a new last child of `parent`.
+pub(super) fn paste_as_children(
+    workspace: &mut Workspace,
+    hlc: &HlcGenerator,
+    parent: NodeId,
+    blocks: &[ParsedNode],
+) -> Result<PasteOutcome, ActionError> {
+    let specs: Vec<BlockTreeSpec> = blocks.iter().map(to_spec).collect();
+    let outcomes = append_forest(workspace, hlc, parent, &specs)?;
+    apply_properties_forest(workspace, hlc, blocks, &outcomes)?;
+    Ok(PasteOutcome {
+        new_blocks: collect_ids(&outcomes),
+        host_text: None,
+        root_count: blocks.len(),
+    })
+}
+
+/// Insert each parsed block as a sibling after the previous one,
+/// starting with `after`.
+pub(super) fn paste_after(
+    workspace: &mut Workspace,
+    hlc: &HlcGenerator,
+    after: NodeId,
+    blocks: &[ParsedNode],
+) -> Result<PasteOutcome, ActionError> {
+    let mut new_blocks: Vec<NodeId> = Vec::new();
+    let mut prev = after;
+    for parsed in blocks {
+        let id = create_after(workspace, hlc, prev, Some(&parsed.text))?;
+        new_blocks.push(id);
+        apply_properties_node(workspace, hlc, parsed, id)?;
+        attach_children(workspace, hlc, parsed, id, &mut new_blocks)?;
+        prev = id;
+    }
+    Ok(PasteOutcome {
+        new_blocks,
+        host_text: None,
+        root_count: blocks.len(),
+    })
+}
+
+/// Caret-aware paste: the first parsed bullet merges into the host's
+/// text at the caret; remaining bullets become siblings; the host's
+/// right-hand text becomes one more sibling at the end.
+pub(super) fn paste_at_caret(
+    workspace: &mut Workspace,
+    hlc: &HlcGenerator,
+    block: NodeId,
+    caret: usize,
+    blocks: &[ParsedNode],
+) -> Result<PasteOutcome, ActionError> {
+    let original = workspace
+        .block_text(block)
+        .ok_or_else(|| ActionError::NotInTree(block.to_string()))?;
+    let (left, right) = split_at_char(&original, caret);
+
+    // First parsed bullet merges into the host's left-side text.
+    let first = &blocks[0];
+    let host_text = join_caret_left_with(&left, &first.text);
+    edit_text(workspace, hlc, block, &host_text)?;
+
+    let mut new_blocks: Vec<NodeId> = Vec::new();
+
+    // Children of the first bullet become children of the host block.
+    if !first.children.is_empty() {
+        let child_specs: Vec<BlockTreeSpec> = first.children.iter().map(to_spec).collect();
+        let child_outcomes = append_forest(workspace, hlc, block, &child_specs)?;
+        apply_properties_forest(workspace, hlc, &first.children, &child_outcomes)?;
+        for o in &child_outcomes {
+            push_ids(&mut new_blocks, o);
+        }
+    }
+    // The first bullet's own properties apply to the host block.
+    apply_properties_node(workspace, hlc, first, block)?;
+
+    // Remaining root-level bullets become siblings after the host.
+    let mut prev = block;
+    for parsed in &blocks[1..] {
+        let id = create_after(workspace, hlc, prev, Some(&parsed.text))?;
+        new_blocks.push(id);
+        apply_properties_node(workspace, hlc, parsed, id)?;
+        attach_children(workspace, hlc, parsed, id, &mut new_blocks)?;
+        prev = id;
+    }
+
+    // Right-hand side of the caret survives as one more sibling so the
+    // user never loses the tail of what they were typing.
+    if !right.trim().is_empty() {
+        let id = create_after(workspace, hlc, prev, Some(right.trim_start()))?;
+        new_blocks.push(id);
+    }
+
+    Ok(PasteOutcome {
+        new_blocks,
+        host_text: Some(host_text),
+        root_count: blocks.len(),
+    })
+}
+
+/// Fallback used when the heuristic says the clipboard isn't an
+/// outline. Behaviour depends on the anchor: caret-paste splices the
+/// raw text; sibling/child variants drop it into a single new block.
+pub(super) fn paste_plain_text(
+    workspace: &mut Workspace,
+    hlc: &HlcGenerator,
+    anchor: PasteAnchor,
+    text: &str,
+) -> Result<PasteOutcome, ActionError> {
+    match anchor {
+        PasteAnchor::AtCaret { block, caret } => {
+            let original = workspace
+                .block_text(block)
+                .ok_or_else(|| ActionError::NotInTree(block.to_string()))?;
+            let (left, right) = split_at_char(&original, caret);
+            let new_text = format!("{left}{text}{right}");
+            edit_text(workspace, hlc, block, &new_text)?;
+            Ok(PasteOutcome {
+                new_blocks: Vec::new(),
+                host_text: Some(new_text),
+                root_count: 0,
+            })
+        }
+        PasteAnchor::AfterBlock(after) => {
+            if text.is_empty() {
+                return Ok(PasteOutcome::default());
+            }
+            let id = create_after(workspace, hlc, after, Some(text))?;
+            Ok(PasteOutcome {
+                new_blocks: vec![id],
+                host_text: None,
+                root_count: 1,
+            })
+        }
+        PasteAnchor::AsLastChildOf(parent) => {
+            if text.is_empty() {
+                return Ok(PasteOutcome::default());
+            }
+            let id = create_under(workspace, hlc, parent, Some(text))?;
+            Ok(PasteOutcome {
+                new_blocks: vec![id],
+                host_text: None,
+                root_count: 1,
+            })
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn to_spec(node: &ParsedNode) -> BlockTreeSpec {
+    BlockTreeSpec {
+        text: node.text.clone(),
+        children: node.children.iter().map(to_spec).collect(),
+    }
+}
+
+fn attach_children(
+    workspace: &mut Workspace,
+    hlc: &HlcGenerator,
+    parsed: &ParsedNode,
+    parent_id: NodeId,
+    new_blocks: &mut Vec<NodeId>,
+) -> Result<(), ActionError> {
+    if parsed.children.is_empty() {
+        return Ok(());
+    }
+    let child_specs: Vec<BlockTreeSpec> = parsed.children.iter().map(to_spec).collect();
+    let child_outcomes = append_forest(workspace, hlc, parent_id, &child_specs)?;
+    apply_properties_forest(workspace, hlc, &parsed.children, &child_outcomes)?;
+    for o in &child_outcomes {
+        push_ids(new_blocks, o);
+    }
+    Ok(())
+}
+
+fn apply_properties_forest(
+    workspace: &mut Workspace,
+    hlc: &HlcGenerator,
+    parsed: &[ParsedNode],
+    outcomes: &[BlockTreeOutcome],
+) -> Result<(), ActionError> {
+    debug_assert_eq!(
+        parsed.len(),
+        outcomes.len(),
+        "parsed/outcome arity mismatch"
+    );
+    for (p, o) in parsed.iter().zip(outcomes.iter()) {
+        apply_properties_node(workspace, hlc, p, o.id)?;
+        apply_properties_forest(workspace, hlc, &p.children, &o.children)?;
+    }
+    Ok(())
+}
+
+fn apply_properties_node(
+    workspace: &mut Workspace,
+    hlc: &HlcGenerator,
+    parsed: &ParsedNode,
+    node: NodeId,
+) -> Result<(), ActionError> {
+    for (key, value) in &parsed.properties {
+        set_property(
+            workspace,
+            hlc,
+            node,
+            key,
+            Some(PropValue::Text(value.clone())),
+        )?;
+    }
+    Ok(())
+}
+
+fn split_at_char(s: &str, caret: usize) -> (String, String) {
+    let mut chars = s.chars();
+    let left: String = chars.by_ref().take(caret).collect();
+    let right: String = chars.collect();
+    (left, right)
+}
+
+fn join_caret_left_with(left: &str, addition: &str) -> String {
+    if left.is_empty() {
+        return addition.to_string();
+    }
+    let ends_ws = left
+        .chars()
+        .last()
+        .map(|c| c.is_whitespace())
+        .unwrap_or(true);
+    let starts_ws = addition
+        .chars()
+        .next()
+        .map(|c| c.is_whitespace())
+        .unwrap_or(true);
+    if ends_ws || starts_ws {
+        format!("{left}{addition}")
+    } else {
+        format!("{left} {addition}")
+    }
+}

--- a/crates/outl-actions/src/paste/anchors.rs
+++ b/crates/outl-actions/src/paste/anchors.rs
@@ -148,7 +148,11 @@ pub(super) fn paste_plain_text(
             Ok(PasteOutcome {
                 new_blocks: vec![id],
                 host_text: None,
-                root_count: 1,
+                // Plain-text path: see `PasteOutcome::root_count`. The
+                // block exists because of the anchor, not because the
+                // user pasted outline syntax — counter stays at 0 so
+                // the status reads "pasted text".
+                root_count: 0,
             })
         }
         PasteAnchor::AsLastChildOf(parent) => {
@@ -159,7 +163,7 @@ pub(super) fn paste_plain_text(
             Ok(PasteOutcome {
                 new_blocks: vec![id],
                 host_text: None,
-                root_count: 1,
+                root_count: 0,
             })
         }
     }

--- a/crates/outl-actions/src/paste/mod.rs
+++ b/crates/outl-actions/src/paste/mod.rs
@@ -1,0 +1,378 @@
+//! Paste external markdown as a tree of blocks.
+//!
+//! When a user copies a chunk of bullet-list markdown from another app
+//! (Roam, Logseq, GitHub issue, Notion export, Notes.app draft) and
+//! pastes it into outl, we want the hierarchy to come across — not a
+//! single block with literal `\n- ` characters in it. This module is
+//! the **single** entry point both clients (TUI, mobile) call to make
+//! that happen, so the semantics stay identical between surfaces.
+//!
+//! ## What gets converted to outl syntax on the way in
+//!
+//! `paste_markdown` runs the raw clipboard text through
+//! [`normalize::normalize_external_syntax`] before parsing it. The
+//! conversions cover the most common syntaxes the user might copy
+//! from:
+//!
+//! | Input (external) | Output (outl) | Origin |
+//! |------------------|---------------|--------|
+//! | `{{[[TODO]]}} foo` | `TODO foo` | Roam |
+//! | `{{[[DONE]]}} foo` | `DONE foo` | Roam |
+//! | `- [ ] foo` | `- TODO foo` | GitHub / CommonMark task list |
+//! | `- [x] foo` / `- [X] foo` | `- DONE foo` | GitHub / CommonMark |
+//! | `{{embed: ((blk-XXXXXX))}}` | `!((blk-XXXXXX))` | Roam |
+//! | `{{[[query]]: foo}}` | `{{query: foo}}` | Roam |
+//! | `^^highlight^^` | (stripped) | Roam |
+//! | `{{video: url}}` and other unknown `{{…}}` | (stripped) | various |
+//! | `id:: 01HXY…` (alone on a line) | (line dropped) | Logseq |
+//! | 4-space indent | 2-space indent | Roam/Notion export |
+//!
+//! The unknown-token strip is deliberate: blocks come into outl clean.
+//! We never invent information; we only delete tokens that aren't
+//! part of our syntax.
+//!
+//! ## Properties
+//!
+//! Lines of the form `key:: value` that the parser attaches to a block
+//! are re-applied to the freshly minted node as `Op::SetProp` via
+//! [`crate::page::set_property`]. They converge across devices the
+//! same way every other op does.
+
+mod anchors;
+mod normalize;
+
+use outl_core::hlc::HlcGenerator;
+use outl_core::id::NodeId;
+use outl_core::workspace::Workspace;
+
+use crate::block::BlockTreeOutcome;
+use crate::error::ActionError;
+
+pub use normalize::normalize_external_syntax;
+
+/// Where in the workspace the pasted markdown should be grafted.
+#[derive(Debug, Clone)]
+pub enum PasteAnchor {
+    /// Append the pasted blocks as new last children of `parent`.
+    AsLastChildOf(NodeId),
+    /// Insert the pasted blocks as siblings immediately after `after`.
+    AfterBlock(NodeId),
+    /// The user is editing `block` and the caret sits at char offset
+    /// `caret` inside its text.
+    ///
+    /// The first parsed bullet (if any) is appended to the text on the
+    /// left of the caret and becomes the new text of `block`; any
+    /// children of that first bullet land as children of `block`.
+    /// Subsequent root-level bullets become siblings after `block`.
+    /// Finally, whatever text was on the right of the caret is added
+    /// as one more sibling so nothing the user typed gets lost.
+    AtCaret {
+        /// Block currently being edited.
+        block: NodeId,
+        /// Caret position, measured in `char` offsets into the block's
+        /// text (not byte offsets).
+        caret: usize,
+    },
+}
+
+/// What `paste_markdown` did, so the caller can update UI state.
+#[derive(Debug, Clone, Default)]
+pub struct PasteOutcome {
+    /// Ids of newly created blocks, in DFS / sibling order.
+    pub new_blocks: Vec<NodeId>,
+    /// New text of the host block when `AtCaret` was used and the
+    /// host's text changed. `None` for the other anchors.
+    pub host_text: Option<String>,
+    /// Number of root-level blocks the caller should report to the
+    /// user (e.g. status line `"pasted N blocks"`). Zero when the
+    /// paste was treated as plain text.
+    pub root_count: usize,
+}
+
+/// Apply pasted markdown to the workspace at `anchor`.
+///
+/// `raw` is the clipboard contents verbatim. The function:
+///
+/// 1. Normalises external syntax to outl (see module docs).
+/// 2. Detects whether the result is an outline (any line starting
+///    with `- `). If not, falls back to "plain text" behaviour
+///    appropriate for the anchor.
+/// 3. Parses the normalised text via `outl_md::parse::parse`.
+/// 4. Materialises blocks through [`crate::block::append_tree`] /
+///    [`crate::block::create_after`].
+/// 5. Re-applies block properties via `Op::SetProp`.
+pub fn paste_markdown(
+    workspace: &mut Workspace,
+    hlc: &HlcGenerator,
+    anchor: PasteAnchor,
+    raw: &str,
+) -> Result<PasteOutcome, ActionError> {
+    let normalized = normalize_external_syntax(raw);
+    let trimmed = normalized.trim_end_matches('\n');
+
+    if !looks_like_outline(trimmed) {
+        return anchors::paste_plain_text(workspace, hlc, anchor, trimmed);
+    }
+
+    let parsed = outl_md::parse::parse(trimmed);
+    if parsed.blocks.is_empty() {
+        // Heuristic said outline but parser disagreed (mangled input).
+        // Fall back to plain-text behaviour so we never lose user input.
+        return anchors::paste_plain_text(workspace, hlc, anchor, trimmed);
+    }
+
+    match anchor {
+        PasteAnchor::AsLastChildOf(parent) => {
+            anchors::paste_as_children(workspace, hlc, parent, &parsed.blocks)
+        }
+        PasteAnchor::AfterBlock(after) => {
+            anchors::paste_after(workspace, hlc, after, &parsed.blocks)
+        }
+        PasteAnchor::AtCaret { block, caret } => {
+            anchors::paste_at_caret(workspace, hlc, block, caret, &parsed.blocks)
+        }
+    }
+}
+
+/// True when at least one non-blank line starts with `- ` or is just `-`.
+fn looks_like_outline(s: &str) -> bool {
+    s.lines().any(|line| {
+        let trimmed = line.trim_start();
+        trimmed == "-" || trimmed.starts_with("- ")
+    })
+}
+
+/// Flatten a `BlockTreeOutcome` forest into the ids it minted, in
+/// DFS / sibling order.
+pub(crate) fn collect_ids(outcomes: &[BlockTreeOutcome]) -> Vec<NodeId> {
+    let mut out = Vec::new();
+    for o in outcomes {
+        push_ids(&mut out, o);
+    }
+    out
+}
+
+pub(crate) fn push_ids(out: &mut Vec<NodeId>, o: &BlockTreeOutcome) {
+    out.push(o.id);
+    for c in &o.children {
+        push_ids(out, c);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block::append_block;
+    use outl_core::id::ActorId;
+
+    fn ws() -> (Workspace, HlcGenerator) {
+        let actor = ActorId::new();
+        (
+            Workspace::open_in_memory(actor).unwrap(),
+            HlcGenerator::new(actor),
+        )
+    }
+
+    #[test]
+    fn outline_detector_true_on_bullet_lines() {
+        assert!(looks_like_outline("- foo"));
+        assert!(looks_like_outline("  - nested"));
+        assert!(looks_like_outline("preface\n- bullet"));
+    }
+
+    #[test]
+    fn outline_detector_false_on_plain_text() {
+        assert!(!looks_like_outline("just words"));
+        assert!(!looks_like_outline("multi\nline\ntext"));
+        assert!(!looks_like_outline(""));
+    }
+
+    #[test]
+    fn paste_as_last_child_of_root() {
+        let (mut workspace, hlc) = ws();
+        let parent = append_block(&mut workspace, &hlc, None, Some("host")).unwrap();
+        let out = paste_markdown(
+            &mut workspace,
+            &hlc,
+            PasteAnchor::AsLastChildOf(parent),
+            "- one\n- two\n- three",
+        )
+        .unwrap();
+        assert_eq!(out.root_count, 3);
+        let kids: Vec<String> = crate::tree::children_of(&workspace, parent)
+            .into_iter()
+            .map(|(id, _)| workspace.block_text(id).unwrap_or_default())
+            .collect();
+        assert_eq!(kids, vec!["one", "two", "three"]);
+    }
+
+    #[test]
+    fn paste_after_root_block() {
+        let (mut workspace, hlc) = ws();
+        let a = append_block(&mut workspace, &hlc, None, Some("a")).unwrap();
+        let _z = append_block(&mut workspace, &hlc, None, Some("z")).unwrap();
+        let _ = paste_markdown(
+            &mut workspace,
+            &hlc,
+            PasteAnchor::AfterBlock(a),
+            "- one\n- two",
+        )
+        .unwrap();
+        let order: Vec<String> = crate::tree::children_of(&workspace, NodeId::root())
+            .into_iter()
+            .map(|(id, _)| workspace.block_text(id).unwrap_or_default())
+            .collect();
+        assert_eq!(order, vec!["a", "one", "two", "z"]);
+    }
+
+    #[test]
+    fn paste_at_caret_splits_and_appends_tail() {
+        let (mut workspace, hlc) = ws();
+        let host = append_block(&mut workspace, &hlc, None, Some("olá mundo")).unwrap();
+        // caret = 4 → after "olá " (4 chars including the space).
+        let out = paste_markdown(
+            &mut workspace,
+            &hlc,
+            PasteAnchor::AtCaret {
+                block: host,
+                caret: 4,
+            },
+            "- um\n- dois",
+        )
+        .unwrap();
+        assert_eq!(workspace.block_text(host).as_deref(), Some("olá um"));
+        let order: Vec<String> = crate::tree::children_of(&workspace, NodeId::root())
+            .into_iter()
+            .map(|(id, _)| workspace.block_text(id).unwrap_or_default())
+            .collect();
+        assert_eq!(order, vec!["olá um", "dois", "mundo"]);
+        assert_eq!(out.host_text.as_deref(), Some("olá um"));
+        // 2 new sibling blocks created ("dois", "mundo"). "um" was
+        // merged into the host so it isn't in new_blocks.
+        assert_eq!(out.new_blocks.len(), 2);
+    }
+
+    #[test]
+    fn paste_at_caret_with_plain_text_is_a_splice() {
+        let (mut workspace, hlc) = ws();
+        let host = append_block(&mut workspace, &hlc, None, Some("hello world")).unwrap();
+        let out = paste_markdown(
+            &mut workspace,
+            &hlc,
+            PasteAnchor::AtCaret {
+                block: host,
+                caret: 6,
+            },
+            "BRAVE ",
+        )
+        .unwrap();
+        assert_eq!(
+            workspace.block_text(host).as_deref(),
+            Some("hello BRAVE world")
+        );
+        assert!(out.new_blocks.is_empty());
+    }
+
+    #[test]
+    fn paste_empty_input_is_noop() {
+        let (mut workspace, hlc) = ws();
+        let host = append_block(&mut workspace, &hlc, None, Some("hi")).unwrap();
+        let out = paste_markdown(
+            &mut workspace,
+            &hlc,
+            PasteAnchor::AtCaret {
+                block: host,
+                caret: 2,
+            },
+            "",
+        )
+        .unwrap();
+        assert!(out.new_blocks.is_empty());
+        // Splice of empty into "hi" is still "hi".
+        assert_eq!(workspace.block_text(host).as_deref(), Some("hi"));
+    }
+
+    #[test]
+    fn paste_preserves_nested_children() {
+        let (mut workspace, hlc) = ws();
+        let parent = append_block(&mut workspace, &hlc, None, Some("p")).unwrap();
+        let _ = paste_markdown(
+            &mut workspace,
+            &hlc,
+            PasteAnchor::AsLastChildOf(parent),
+            "- a\n  - a1\n  - a2\n- b",
+        )
+        .unwrap();
+        let kids: Vec<(String, Vec<String>)> = crate::tree::children_of(&workspace, parent)
+            .into_iter()
+            .map(|(id, _)| {
+                let grand: Vec<String> = crate::tree::children_of(&workspace, id)
+                    .into_iter()
+                    .map(|(gid, _)| workspace.block_text(gid).unwrap_or_default())
+                    .collect();
+                (workspace.block_text(id).unwrap_or_default(), grand)
+            })
+            .collect();
+        assert_eq!(
+            kids,
+            vec![
+                ("a".to_string(), vec!["a1".to_string(), "a2".to_string()]),
+                ("b".to_string(), Vec::new()),
+            ]
+        );
+    }
+
+    #[test]
+    fn paste_applies_block_properties() {
+        use outl_core::property::PropValue;
+        let (mut workspace, hlc) = ws();
+        let parent = append_block(&mut workspace, &hlc, None, Some("p")).unwrap();
+        let _ = paste_markdown(
+            &mut workspace,
+            &hlc,
+            PasteAnchor::AsLastChildOf(parent),
+            "- header\n  priority:: high\n  - child",
+        )
+        .unwrap();
+        let kids = crate::tree::children_of(&workspace, parent);
+        assert_eq!(kids.len(), 1);
+        let header_id = kids[0].0;
+        let prop = workspace.tree().property(header_id, "priority");
+        match prop {
+            Some(PropValue::Text(v)) => assert_eq!(v, "high"),
+            other => panic!("expected Text(\"high\"), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn paste_user_prompt_fixture() {
+        // The literal markdown the user pasted in the prompt that
+        // motivated this feature. The exact same string must produce
+        // the expected tree on both clients.
+        let raw = "- #LinkedIn #hot-take. Draft\n    - **Tema:** Can the stockmarket swallow Anthropic, SpaceX and OpenAI? ([hackernews](https://www.economist.com/finance-and-economics/2026/06/01/can-the-stockmarket-swallow-anthropic-spacex-and-openai))\n    - **Score:** 368 pontos, 641 comentários (hackernews)\n    - No mesmo dia, The Economist pergunta se o mercado público consegue engolir Anthropic, OpenAI e SpaceX juntas, Alphabet anuncia equity raise de $80 bi pra AI infra, e Groq abre rodada nova antes da última fechar.\n    - As três privadas somam mais de $1 trilhão em valuation. Capex de AI cresce mais rápido que revenue de qualquer um dos players.\n    - {{[[TODO]]}} revisar antes de postar\n";
+
+        let (mut workspace, hlc) = ws();
+        let _ = paste_markdown(
+            &mut workspace,
+            &hlc,
+            PasteAnchor::AsLastChildOf(NodeId::root()),
+            raw,
+        )
+        .unwrap();
+
+        // Exactly one root block — the LinkedIn draft header.
+        let roots = crate::tree::children_of(&workspace, NodeId::root());
+        assert_eq!(roots.len(), 1, "expected 1 root block, got {}", roots.len());
+        let header_id = roots[0].0;
+        assert_eq!(
+            workspace.block_text(header_id).as_deref(),
+            Some("#LinkedIn #hot-take. Draft")
+        );
+
+        // Five children, the last one converted from {{[[TODO]]}}.
+        let kids = crate::tree::children_of(&workspace, header_id);
+        assert_eq!(kids.len(), 5);
+        let last_text = workspace.block_text(kids[4].0).unwrap_or_default();
+        assert_eq!(last_text, "TODO revisar antes de postar");
+    }
+}

--- a/crates/outl-actions/src/paste/mod.rs
+++ b/crates/outl-actions/src/paste/mod.rs
@@ -37,6 +37,44 @@
 //! are re-applied to the freshly minted node as `Op::SetProp` via
 //! [`crate::page::set_property`]. They converge across devices the
 //! same way every other op does.
+//!
+//! ## Adding a new external source
+//!
+//! When the user shows up wanting to paste from a tool we don't
+//! cover yet (Obsidian, RemNote, Bear, Apple Notes, etc.), extend
+//! [`normalize::normalize_external_syntax`]. The pipeline runs in a
+//! fixed order and the order matters — follow these rules:
+//!
+//! 1. **Specific conversions first.** Map every concrete external
+//!    token to its outl equivalent BEFORE the generic-strip step.
+//!    Otherwise the catch-all stripper deletes the token before the
+//!    converter has a chance to see it (this is why `{{[[TODO]]}}`
+//!    has its own `replace` call ahead of the `{{…}}` strip).
+//! 2. **Line-level transforms own indent.** When a converter touches
+//!    a bullet line (`- [ ]` → `- TODO`), do it after the indent
+//!    normaliser so the regex doesn't have to chase 2/4-space drift.
+//! 3. **Strip is last.** Anything still wrapped in `{{…}}` /
+//!    `^^…^^` after the conversions is unknown to outl and gets
+//!    deleted. Use the allowlist callback in `strip_pair` (see how
+//!    `{{query: …}}` is preserved) when the wrapper happens to be
+//!    outl-native — don't add a new strip helper.
+//! 4. **No new dependencies for parsing.** The pipeline is plain
+//!    `str` manipulation on purpose: `regex` would pull a 40+kb dep
+//!    into a crate that runs on the mobile binary. Manual scans
+//!    (see `rewrite_roam_embed`) are the pattern.
+//! 5. **Test the conversion AND the order-of-operations.** Every new
+//!    entry in the table above gets a unit test in
+//!    `normalize.rs::tests`, plus one assertion that the conversion
+//!    runs before the generic strip (mirror the
+//!    `known_token_wins_over_generic_strip` test).
+//! 6. **Update the docs.** Add a row to the table above and to
+//!    `docs/markdown-format.md` so users know what we silently
+//!    rewrite on paste.
+//! 7. **Mirror the heuristic in JS** when the change affects
+//!    bullet detection. `looks_like_outline` lives both in this
+//!    crate and in `crates/outl-mobile/src/lib/paste.ts`; the JS
+//!    copy gates the Tauri round-trip on the client. They must
+//!    stay in lockstep.
 
 mod anchors;
 mod normalize;
@@ -135,6 +173,15 @@ pub fn paste_markdown(
 }
 
 /// True when at least one non-blank line starts with `- ` or is just `-`.
+///
+/// This is the canonical detector that gates the tree-conversion
+/// pipeline. Mobile mirrors it in TypeScript
+/// (`crates/outl-mobile/src/lib/paste.ts::looksLikeOutline`) so the
+/// client can avoid a Tauri round-trip when the user pastes plain
+/// text. The two implementations **must stay in lockstep** — if you
+/// extend this to recognise `*` bullets, ordered lists, or anything
+/// else, update the JS mirror in the same PR and add the case to
+/// `paste.test.ts`.
 fn looks_like_outline(s: &str) -> bool {
     s.lines().any(|line| {
         let trimmed = line.trim_start();

--- a/crates/outl-actions/src/paste/mod.rs
+++ b/crates/outl-actions/src/paste/mod.rs
@@ -121,9 +121,17 @@ pub struct PasteOutcome {
     /// New text of the host block when `AtCaret` was used and the
     /// host's text changed. `None` for the other anchors.
     pub host_text: Option<String>,
-    /// Number of root-level blocks the caller should report to the
-    /// user (e.g. status line `"pasted N blocks"`). Zero when the
-    /// paste was treated as plain text.
+    /// Number of *outline* root-level bullets the user pasted, after
+    /// normalisation and parsing. UI clients show this to confirm
+    /// "pasted N blocks" — it counts what the heuristic actually
+    /// detected, not blocks created.
+    ///
+    /// **Always zero on the plain-text fallback path**, even when
+    /// the anchor (AfterBlock / AsLastChildOf) caused one literal
+    /// block to be created: that block exists only because the
+    /// caller asked us where to drop the raw text, not because the
+    /// payload had bullet structure. Plain-text via AtCaret returns
+    /// zero with no new block at all.
     pub root_count: usize,
 }
 
@@ -145,18 +153,26 @@ pub fn paste_markdown(
     anchor: PasteAnchor,
     raw: &str,
 ) -> Result<PasteOutcome, ActionError> {
+    // Detect outline shape on the **raw** payload. Running
+    // `normalize_external_syntax` first would strip unknown tokens
+    // (`{{video: …}}`, `^^…^^`) and collapse whitespace runs before
+    // we ever decide to fall back to plain text — that means a user
+    // pasting "look at {{video: https://x}}!" into a block would
+    // land a mangled string, not what they copied. Normalisation is
+    // only legitimate when we're actually going to parse bullets.
+    if !looks_like_outline(raw) {
+        return anchors::paste_plain_text(workspace, hlc, anchor, raw);
+    }
+
     let normalized = normalize_external_syntax(raw);
     let trimmed = normalized.trim_end_matches('\n');
-
-    if !looks_like_outline(trimmed) {
-        return anchors::paste_plain_text(workspace, hlc, anchor, trimmed);
-    }
 
     let parsed = outl_md::parse::parse(trimmed);
     if parsed.blocks.is_empty() {
         // Heuristic said outline but parser disagreed (mangled input).
-        // Fall back to plain-text behaviour so we never lose user input.
-        return anchors::paste_plain_text(workspace, hlc, anchor, trimmed);
+        // Fall back to plain-text behaviour with the **raw** payload
+        // so we never edit the user's text behind their back.
+        return anchors::paste_plain_text(workspace, hlc, anchor, raw);
     }
 
     match anchor {
@@ -182,7 +198,12 @@ pub fn paste_markdown(
 /// extend this to recognise `*` bullets, ordered lists, or anything
 /// else, update the JS mirror in the same PR and add the case to
 /// `paste.test.ts`.
-fn looks_like_outline(s: &str) -> bool {
+///
+/// Exposed `pub` so UI clients can branch *before* invoking
+/// [`paste_markdown`]: a TUI in Insert mode, for example, wants to
+/// splice plain text into the live edit buffer instead of going
+/// through the full paste pipeline.
+pub fn looks_like_outline(s: &str) -> bool {
     s.lines().any(|line| {
         let trimmed = line.trim_start();
         trimmed == "-" || trimmed.starts_with("- ")
@@ -297,6 +318,35 @@ mod tests {
         // 2 new sibling blocks created ("dois", "mundo"). "um" was
         // merged into the host so it isn't in new_blocks.
         assert_eq!(out.new_blocks.len(), 2);
+    }
+
+    #[test]
+    fn paste_plain_text_preserves_unknown_tokens() {
+        // Pasting "{{video: ...}}" into a block as plain text must
+        // NOT strip the token — only outline-shaped pastes go through
+        // the normaliser. The user copied that string for a reason
+        // and rewriting it silently is data loss.
+        let (mut workspace, hlc) = ws();
+        // `append_block` trims the seed text, so the host lands as
+        // "watch" (5 chars). Paste at the very end with a leading
+        // space inside the clipboard payload to verify the literal
+        // splice path keeps every byte of the user's text.
+        let host = append_block(&mut workspace, &hlc, None, Some("watch")).unwrap();
+        let out = paste_markdown(
+            &mut workspace,
+            &hlc,
+            PasteAnchor::AtCaret {
+                block: host,
+                caret: 5,
+            },
+            " {{video: https://x.test}} now",
+        )
+        .unwrap();
+        assert_eq!(
+            workspace.block_text(host).as_deref(),
+            Some("watch {{video: https://x.test}} now"),
+        );
+        assert!(out.new_blocks.is_empty());
     }
 
     #[test]

--- a/crates/outl-actions/src/paste/normalize.rs
+++ b/crates/outl-actions/src/paste/normalize.rs
@@ -299,12 +299,28 @@ fn extract_block_ref(s: &str) -> Option<&str> {
 
 /// True for lines that look like `id:: 01HXY8KJZQ9T8M7VN3P2R6S4A1`
 /// (Crockford-base32 ULID, 26 chars).
+///
+/// We validate the alphabet strictly so 26 random alphanumeric
+/// characters don't get dropped by accident. Crockford base32 uses
+/// `0-9` plus `A-Z` minus `I`, `L`, `O`, `U` (also accepts lowercase
+/// in modern ULID libs, so we case-fold here).
 fn is_logseq_id_line(line: &str) -> bool {
     let trimmed = line.trim();
     let Some(after) = trimmed.strip_prefix("id:: ") else {
         return false;
     };
-    after.len() == 26 && after.chars().all(|c| c.is_ascii_alphanumeric())
+    after.len() == 26 && after.chars().all(is_crockford_base32_char)
+}
+
+fn is_crockford_base32_char(c: char) -> bool {
+    let c = c.to_ascii_uppercase();
+    if c.is_ascii_digit() {
+        return true;
+    }
+    if !c.is_ascii_uppercase() {
+        return false;
+    }
+    !matches!(c, 'I' | 'L' | 'O' | 'U')
 }
 
 /// Remove every remaining `{{…}}` and `^^…^^` token. Runs after the
@@ -431,6 +447,26 @@ mod tests {
         let input = "- header\n  id:: 01HXY8KJZQ9T8M7VN3P2R6S4A1\n  - child";
         let out = normalize_external_syntax(input);
         assert_eq!(out, "- header\n  - child");
+    }
+
+    #[test]
+    fn id_line_with_non_crockford_chars_survives() {
+        // Looks 26-char and alphanumeric but uses banned letters
+        // (`I`, `L`) — not a real ULID, must NOT be dropped.
+        let input = "- header\n  id:: IIIILLLLOOOO0000000000000A\n  - child";
+        let out = normalize_external_syntax(input);
+        assert!(out.contains("IIIILLLLOOOO"), "non-ULID id:: stays: {out}");
+    }
+
+    #[test]
+    fn id_line_with_wrong_length_survives() {
+        // 27 chars — wrong length, not a ULID.
+        let input = "- header\n  id:: 01HXY8KJZQ9T8M7VN3P2R6S4A1X\n  - child";
+        let out = normalize_external_syntax(input);
+        assert!(
+            out.contains("01HXY8KJZQ9T8M7VN3P2R6S4A1X"),
+            "long id:: stays: {out}"
+        );
     }
 
     #[test]

--- a/crates/outl-actions/src/paste/normalize.rs
+++ b/crates/outl-actions/src/paste/normalize.rs
@@ -1,0 +1,537 @@
+//! External markdown syntax → outl syntax.
+//!
+//! Pure string-level transforms applied to clipboard text before it
+//! reaches `outl_md::parse::parse`. Reads no workspace, writes no
+//! storage — split out from [`super`] so the conversion logic is
+//! easy to test and easy to extend without dragging in the workspace
+//! plumbing.
+//!
+//! See the table in `super::mod` for the full conversion catalog.
+
+/// Apply every known external-syntax conversion and strip unknown
+/// tokens. The pipeline runs in a fixed order — the more specific
+/// conversions must happen before the generic `{{…}}` strip.
+pub fn normalize_external_syntax(raw: &str) -> String {
+    // 1. Newlines.
+    let raw = raw.replace("\r\n", "\n").replace('\r', "\n");
+
+    // 2. Indent 4 → 2 when every indented line is a multiple of 4 and
+    //    the smallest non-zero leading-space count is 4.
+    let lines: Vec<&str> = raw.lines().collect();
+    let indent_unit = detect_indent_unit(&lines);
+    let normalized_indent: Vec<String> = if indent_unit == 4 {
+        lines.iter().map(|l| renormalize_indent_4_to_2(l)).collect()
+    } else {
+        lines.iter().map(|l| (*l).to_string()).collect()
+    };
+
+    // 3 + 4 + 5: per-line text-level conversions.
+    let mut kept: Vec<String> = Vec::with_capacity(normalized_indent.len());
+    for line in normalized_indent {
+        if is_logseq_id_line(&line) {
+            // Drop Logseq's inline `id::` lines — outl forbids ids in
+            // markdown (root CLAUDE.md invariant #2).
+            continue;
+        }
+        kept.push(convert_line(&line));
+    }
+
+    // 6. Strip remaining {{…}} and ^^…^^ tokens. After the more
+    //    specific replacements had a chance to consume the tokens
+    //    they understand, anything still wrapped is unknown to outl.
+    let stripped: Vec<String> = kept.into_iter().map(strip_unknown_tokens).collect();
+
+    // 7. Collapse double spaces left over by the strip, preserving
+    //    the leading indent so structural meaning isn't lost.
+    let collapsed: Vec<String> = stripped.into_iter().map(collapse_inner_spaces).collect();
+
+    collapsed.join("\n")
+}
+
+fn detect_indent_unit(lines: &[&str]) -> usize {
+    let mut min_nonzero: usize = usize::MAX;
+    let mut all_multiples_of_4 = true;
+    for line in lines {
+        let spaces = line.chars().take_while(|c| *c == ' ').count();
+        if spaces == 0 {
+            continue;
+        }
+        if spaces % 4 != 0 {
+            all_multiples_of_4 = false;
+        }
+        if spaces < min_nonzero {
+            min_nonzero = spaces;
+        }
+    }
+    if min_nonzero == 4 && all_multiples_of_4 {
+        4
+    } else {
+        2
+    }
+}
+
+fn renormalize_indent_4_to_2(line: &str) -> String {
+    let spaces = line.chars().take_while(|c| *c == ' ').count();
+    let levels = spaces / 4;
+    let rest = &line[spaces..];
+    let mut out = String::with_capacity(levels * 2 + rest.len());
+    for _ in 0..levels {
+        out.push_str("  ");
+    }
+    out.push_str(rest);
+    out
+}
+
+fn convert_line(line: &str) -> String {
+    let indent_len = line.chars().take_while(|c| *c == ' ').count();
+    let indent: String = " ".repeat(indent_len);
+    let rest = &line[indent_len..];
+
+    // GitHub task list `[ ]` / `[x]` only at the start of a bullet line.
+    let rest = if let Some(after) = rest.strip_prefix("- [ ] ") {
+        format!("- TODO {after}")
+    } else if let Some(after) = rest
+        .strip_prefix("- [x] ")
+        .or_else(|| rest.strip_prefix("- [X] "))
+    {
+        format!("- DONE {after}")
+    } else {
+        rest.to_string()
+    };
+
+    // Roam tokens, applied anywhere in the line.
+    let rest = rest.replace("{{[[TODO]]}} ", "TODO ");
+    let rest = rest.replace("{{[[TODO]]}}", "TODO");
+    let rest = rest.replace("{{[[DONE]]}} ", "DONE ");
+    let rest = rest.replace("{{[[DONE]]}}", "DONE");
+
+    // Roam embed: {{embed: ((blk-XXXXXX))}} → !((blk-XXXXXX))
+    let rest = rewrite_roam_embed(&rest);
+
+    // Roam query: {{[[query]]: foo}} → {{query: foo}}
+    let rest = rest.replace("{{[[query]]:", "{{query:");
+
+    // Page refs `[[...]]` whose inner content is a non-ISO date
+    // (Roam's "June 2nd, 2026") get normalised to outl's ISO journal
+    // slug. Plain page refs (`[[Avelino]]`) stay verbatim.
+    let rest = rewrite_date_refs(&rest);
+
+    format!("{indent}{rest}")
+}
+
+/// Scan for `[[...]]` page refs and rewrite the inner text when it
+/// parses as a date. Unrecognised forms (plain page names, already
+/// ISO refs) pass through untouched.
+fn rewrite_date_refs(s: &str) -> String {
+    const OPEN: &str = "[[";
+    const CLOSE: &str = "]]";
+    if !s.contains(OPEN) {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut cursor = 0usize;
+    while let Some(start) = s[cursor..].find(OPEN) {
+        let abs_open = cursor + start;
+        out.push_str(&s[cursor..abs_open]);
+        let after_open = abs_open + OPEN.len();
+        if let Some(close_rel) = s[after_open..].find(CLOSE) {
+            let close = after_open + close_rel;
+            let inner = &s[after_open..close];
+            let rewritten = parse_date_label(inner).unwrap_or_else(|| inner.to_string());
+            out.push_str(OPEN);
+            out.push_str(&rewritten);
+            out.push_str(CLOSE);
+            cursor = close + CLOSE.len();
+        } else {
+            // Unbalanced — keep the rest verbatim and stop.
+            out.push_str(&s[abs_open..]);
+            return out;
+        }
+    }
+    out.push_str(&s[cursor..]);
+    out
+}
+
+/// Recognise common "free-form date" spellings and return the ISO
+/// `YYYY-MM-DD` form outl uses for journal slugs. `None` when the
+/// input doesn't look like a date — callers must fall back to the
+/// original text in that case.
+///
+/// Supported inputs:
+///
+/// - Roam long form: `April 22nd, 2026` / `January 1st, 2025`
+/// - Short month long form: `Apr 22nd, 2026`
+/// - Roam alt: `2026/04/22` and `2026-04-22` pass through unchanged
+fn parse_date_label(raw: &str) -> Option<String> {
+    let s = raw.trim();
+    if s.is_empty() {
+        return None;
+    }
+    // Already ISO — keep it.
+    if is_iso_date(s) {
+        return Some(s.to_string());
+    }
+    // `2026/04/22` → `2026-04-22`
+    if let Some(iso) = normalise_slashed_iso(s) {
+        return Some(iso);
+    }
+    // Roam long form: "<Month> <day><ord>, <year>"
+    parse_long_form(s)
+}
+
+fn is_iso_date(s: &str) -> bool {
+    s.len() == 10
+        && s.as_bytes()[4] == b'-'
+        && s.as_bytes()[7] == b'-'
+        && s.bytes().enumerate().all(|(i, b)| {
+            if i == 4 || i == 7 {
+                b == b'-'
+            } else {
+                b.is_ascii_digit()
+            }
+        })
+}
+
+fn normalise_slashed_iso(s: &str) -> Option<String> {
+    if s.len() != 10 || s.as_bytes()[4] != b'/' || s.as_bytes()[7] != b'/' {
+        return None;
+    }
+    let ok = s.bytes().enumerate().all(|(i, b)| {
+        if i == 4 || i == 7 {
+            b == b'/'
+        } else {
+            b.is_ascii_digit()
+        }
+    });
+    if !ok {
+        return None;
+    }
+    Some(format!("{}-{}-{}", &s[..4], &s[5..7], &s[8..10]))
+}
+
+fn parse_long_form(s: &str) -> Option<String> {
+    let comma = s.rfind(", ")?;
+    let (left, year_str) = (&s[..comma], &s[comma + 2..]);
+    let year: i32 = year_str.parse().ok()?;
+    if !(1900..=2999).contains(&year) {
+        return None;
+    }
+    let space = left.find(' ')?;
+    let (month_name, day_part) = (&left[..space], &left[space + 1..]);
+    let month = month_number(month_name)?;
+    let day = strip_ordinal_suffix(day_part).parse::<u32>().ok()?;
+    if !(1..=31).contains(&day) {
+        return None;
+    }
+    Some(format!("{year:04}-{month:02}-{day:02}"))
+}
+
+fn month_number(name: &str) -> Option<u32> {
+    let n = name.to_ascii_lowercase();
+    Some(match n.as_str() {
+        "january" | "jan" => 1,
+        "february" | "feb" => 2,
+        "march" | "mar" => 3,
+        "april" | "apr" => 4,
+        "may" => 5,
+        "june" | "jun" => 6,
+        "july" | "jul" => 7,
+        "august" | "aug" => 8,
+        "september" | "sep" | "sept" => 9,
+        "october" | "oct" => 10,
+        "november" | "nov" => 11,
+        "december" | "dec" => 12,
+        _ => return None,
+    })
+}
+
+fn strip_ordinal_suffix(day: &str) -> &str {
+    for suffix in ["st", "nd", "rd", "th"] {
+        if let Some(rest) = day.strip_suffix(suffix) {
+            return rest;
+        }
+    }
+    day
+}
+
+/// Replace every occurrence of `{{embed: ((blk-XXXXXX))}}` with
+/// `!((blk-XXXXXX))`. Tolerates whitespace around the inner ref.
+fn rewrite_roam_embed(s: &str) -> String {
+    const NEEDLE: &str = "{{embed:";
+    if !s.contains(NEEDLE) {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut cursor = 0usize;
+    while let Some(start) = s[cursor..].find(NEEDLE) {
+        let abs_start = cursor + start;
+        out.push_str(&s[cursor..abs_start]);
+        let after_open = abs_start + NEEDLE.len();
+        // Locate the matching `}}` for this opener.
+        if let Some(close_rel) = s[after_open..].find("}}") {
+            let close = after_open + close_rel;
+            let inner = s[after_open..close].trim();
+            if let Some(inner_ref) = extract_block_ref(inner) {
+                out.push('!');
+                out.push_str(inner_ref);
+                cursor = close + 2;
+                continue;
+            }
+        }
+        // Couldn't parse — leave the literal alone, advance past `{{`.
+        out.push_str(&s[abs_start..abs_start + 2]);
+        cursor = abs_start + 2;
+    }
+    out.push_str(&s[cursor..]);
+    out
+}
+
+/// Extract `((blk-XXXXXX))` from a string that contains exactly that
+/// token (possibly with surrounding whitespace). Returns the matched
+/// slice so the caller can paste it back verbatim.
+fn extract_block_ref(s: &str) -> Option<&str> {
+    let s = s.trim();
+    if !s.starts_with("((blk-") || !s.ends_with("))") {
+        return None;
+    }
+    Some(s)
+}
+
+/// True for lines that look like `id:: 01HXY8KJZQ9T8M7VN3P2R6S4A1`
+/// (Crockford-base32 ULID, 26 chars).
+fn is_logseq_id_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    let Some(after) = trimmed.strip_prefix("id:: ") else {
+        return false;
+    };
+    after.len() == 26 && after.chars().all(|c| c.is_ascii_alphanumeric())
+}
+
+/// Remove every remaining `{{…}}` and `^^…^^` token. Runs after the
+/// known conversions above, so anything still wearing these wrappers
+/// is by definition unknown to outl.
+///
+/// The `{{...}}` pass keeps outl-native forms intact:
+///
+/// - `{{query: ...}}` — saved-query token (parsed by `outl_md`).
+fn strip_unknown_tokens(line: String) -> String {
+    let line = strip_pair(&line, "{{", "}}", is_unknown_braces_token);
+    strip_pair(&line, "^^", "^^", |_| true)
+}
+
+/// True when the inner body of a `{{…}}` token is *not* a recognised
+/// outl construct and should be deleted.
+fn is_unknown_braces_token(inner: &str) -> bool {
+    let trimmed = inner.trim_start();
+    !trimmed.starts_with("query:") && !trimmed.starts_with("query ")
+}
+
+/// Strip every `open … close` pair from `s` for which
+/// `should_strip(inner)` returns `true`. Pairs that the filter rejects
+/// are copied through verbatim, opener and closer included.
+fn strip_pair(s: &str, open: &str, close: &str, should_strip: impl Fn(&str) -> bool) -> String {
+    if !s.contains(open) {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut cursor = 0usize;
+    while let Some(start) = s[cursor..].find(open) {
+        let abs = cursor + start;
+        out.push_str(&s[cursor..abs]);
+        let after_open = abs + open.len();
+        if let Some(close_rel) = s[after_open..].find(close) {
+            let close_pos = after_open + close_rel;
+            let inner = &s[after_open..close_pos];
+            if should_strip(inner) {
+                cursor = close_pos + close.len();
+            } else {
+                // Keep the token verbatim, advance past its closer.
+                out.push_str(&s[abs..close_pos + close.len()]);
+                cursor = close_pos + close.len();
+            }
+        } else {
+            // No closer — append the rest verbatim so we don't blow
+            // up on unbalanced text.
+            out.push_str(&s[abs..]);
+            return out;
+        }
+    }
+    out.push_str(&s[cursor..]);
+    out
+}
+
+/// Collapse runs of two or more spaces in the body of `line` to a
+/// single space. Preserves the leading indent so the parser's
+/// indent-based hierarchy isn't garbled by a strip in the body.
+///
+/// Trailing spaces survive on purpose: the body of `normalize_external_syntax`
+/// is also fed to plain-text paste (`splice into block at caret`),
+/// and a user who pasted `"BRAVE "` (with a trailing space) expects
+/// that space to land in the splice.
+fn collapse_inner_spaces(line: String) -> String {
+    let indent_len = line.chars().take_while(|c| *c == ' ').count();
+    if line.len() == indent_len {
+        return line;
+    }
+    let (indent, body) = line.split_at(indent_len);
+    let mut out = String::with_capacity(line.len());
+    out.push_str(indent);
+    let mut prev_space = false;
+    for c in body.chars() {
+        if c == ' ' {
+            if !prev_space {
+                out.push(' ');
+            }
+            prev_space = true;
+        } else {
+            out.push(c);
+            prev_space = false;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roam_todo_becomes_prefix() {
+        let out = normalize_external_syntax("- {{[[TODO]]}} foo");
+        assert_eq!(out, "- TODO foo");
+    }
+
+    #[test]
+    fn roam_done_becomes_prefix() {
+        let out = normalize_external_syntax("- {{[[DONE]]}} bar");
+        assert_eq!(out, "- DONE bar");
+    }
+
+    #[test]
+    fn github_checkbox_becomes_todo() {
+        assert_eq!(normalize_external_syntax("- [ ] foo"), "- TODO foo");
+        assert_eq!(normalize_external_syntax("- [x] foo"), "- DONE foo");
+        assert_eq!(normalize_external_syntax("- [X] foo"), "- DONE foo");
+    }
+
+    #[test]
+    fn roam_embed_becomes_outl_embed() {
+        let out = normalize_external_syntax("see {{embed: ((blk-r6s4a1))}} here");
+        assert_eq!(out, "see !((blk-r6s4a1)) here");
+    }
+
+    #[test]
+    fn roam_query_becomes_outl_query() {
+        let out = normalize_external_syntax("- {{[[query]]: TODO}}");
+        assert_eq!(out, "- {{query: TODO}}");
+    }
+
+    #[test]
+    fn logseq_id_line_is_dropped() {
+        let input = "- header\n  id:: 01HXY8KJZQ9T8M7VN3P2R6S4A1\n  - child";
+        let out = normalize_external_syntax(input);
+        assert_eq!(out, "- header\n  - child");
+    }
+
+    #[test]
+    fn unknown_tokens_are_stripped() {
+        // {{video: ...}} not in the known set → stripped.
+        let out = normalize_external_syntax("- check {{video: https://x.test}} this");
+        assert_eq!(out, "- check this");
+        // ^^highlight^^ — same fate.
+        let out = normalize_external_syntax("- ^^hot take^^ here");
+        assert_eq!(out, "- here");
+    }
+
+    #[test]
+    fn indent_4_normalizes_to_2() {
+        let input = "- parent\n    - child\n        - grand";
+        let out = normalize_external_syntax(input);
+        assert_eq!(out, "- parent\n  - child\n    - grand");
+    }
+
+    #[test]
+    fn indent_2_stays_unchanged() {
+        let input = "- parent\n  - child";
+        let out = normalize_external_syntax(input);
+        assert_eq!(out, "- parent\n  - child");
+    }
+
+    #[test]
+    fn known_token_wins_over_generic_strip() {
+        // The {{[[TODO]]}} conversion must run before the generic
+        // {{...}} strip, otherwise TODO becomes empty.
+        let out = normalize_external_syntax("- {{[[TODO]]}} review");
+        assert_eq!(out, "- TODO review");
+    }
+
+    #[test]
+    fn roam_long_date_becomes_iso() {
+        assert_eq!(
+            normalize_external_syntax("- check [[June 2nd, 2026]]"),
+            "- check [[2026-06-02]]",
+        );
+        assert_eq!(
+            normalize_external_syntax("- [[January 1st, 2025]]"),
+            "- [[2025-01-01]]",
+        );
+        assert_eq!(
+            normalize_external_syntax("- [[December 31st, 2025]]"),
+            "- [[2025-12-31]]",
+        );
+        assert_eq!(
+            normalize_external_syntax("- meet [[April 22nd, 2026]] again"),
+            "- meet [[2026-04-22]] again",
+        );
+    }
+
+    #[test]
+    fn short_month_long_date_becomes_iso() {
+        assert_eq!(
+            normalize_external_syntax("- [[Apr 22nd, 2026]]"),
+            "- [[2026-04-22]]",
+        );
+        assert_eq!(
+            normalize_external_syntax("- [[Sep 3rd, 2025]]"),
+            "- [[2025-09-03]]",
+        );
+    }
+
+    #[test]
+    fn slashed_date_becomes_iso() {
+        assert_eq!(
+            normalize_external_syntax("- [[2026/04/22]]"),
+            "- [[2026-04-22]]",
+        );
+    }
+
+    #[test]
+    fn iso_date_is_left_alone() {
+        assert_eq!(
+            normalize_external_syntax("- [[2026-06-02]]"),
+            "- [[2026-06-02]]",
+        );
+    }
+
+    #[test]
+    fn plain_page_ref_is_left_alone() {
+        assert_eq!(
+            normalize_external_syntax("- ping [[Avelino]] today"),
+            "- ping [[Avelino]] today",
+        );
+        // Looks date-ish but isn't: missing year, leave verbatim.
+        assert_eq!(
+            normalize_external_syntax("- [[June 2nd]]"),
+            "- [[June 2nd]]",
+        );
+    }
+
+    #[test]
+    fn unbalanced_brackets_dont_panic() {
+        // No closer — passthrough.
+        assert_eq!(
+            normalize_external_syntax("- before [[unclosed"),
+            "- before [[unclosed",
+        );
+    }
+}

--- a/crates/outl-mobile/CLAUDE.md
+++ b/crates/outl-mobile/CLAUDE.md
@@ -39,6 +39,27 @@ What this crate **does** own:
 - Tauri command surface (argument parsing, error mapping).
 - Solid frontend that consumes the commands.
 
+## Paste from external apps
+
+The textarea in `BlockRow.tsx` intercepts paste events whose payload
+looks like a bullet list (`lib/paste.ts::looksLikeOutline`) and routes
+the text to `outl_actions::paste_markdown` via the `paste_markdown_at`
+Tauri command. Plain text falls through to the browser's default
+splice so a one-off URL or code snippet still pastes the way the user
+expects.
+
+Two cross-runtime contracts live here. Both must stay in sync:
+
+1. **`looksLikeOutline`** mirrors `outl_actions::paste::looks_like_outline`.
+   Extending the Rust detector (e.g. accept `*` bullets or ordered
+   lists) requires the same change in `lib/paste.ts` plus a Vitest case.
+2. **Caret offset.** `textarea.selectionStart` is a UTF-16 code unit
+   offset; the Rust backend expects a Unicode codepoint count.
+   `lib/paste.ts::utf16OffsetToCharOffset` does the conversion before
+   the Tauri call so pasting after an emoji lands the splice at the
+   right place. Skip this and supplementary-plane characters shift
+   the splice by one per char.
+
 ## iCloud layout
 
 The workspace root is `<ubiquity-container>/Documents/`. The container

--- a/crates/outl-mobile/src-tauri/src/lib.rs
+++ b/crates/outl-mobile/src-tauri/src/lib.rs
@@ -482,13 +482,13 @@ fn set_block_collapsed(
 
 /// Paste external clipboard markdown as a tree of blocks.
 ///
-/// `caret` is a `char` offset (not bytes) into the host block's text,
-/// matching the convention `outl_actions::PasteAnchor::AtCaret` uses.
-/// The frontend's textarea reports `selectionStart` as a UTF-16 code
-/// unit offset; for ASCII content that's identical to a char count,
-/// which is what the user prompt sends today. We can tighten this when
-/// we ship multi-byte text in the textarea (issue tracked in the
-/// frontend `BlockRow.tsx` paste handler).
+/// `caret` is a Unicode codepoint offset into the host block's text,
+/// matching the convention `outl_actions::PasteAnchor::AtCaret` uses
+/// (Rust `str::chars()` iterates codepoints, not UTF-16 code units).
+/// The frontend converts `textarea.selectionStart` (UTF-16) into a
+/// codepoint count via `utf16OffsetToCharOffset` before invoking
+/// this command, so we get the right offset for text containing
+/// emoji and other supplementary-plane characters too.
 #[tauri::command]
 fn paste_markdown_at(
     page_id: String,

--- a/crates/outl-mobile/src-tauri/src/lib.rs
+++ b/crates/outl-mobile/src-tauri/src/lib.rs
@@ -36,9 +36,10 @@ use outl_actions::{
     append_block, apply_page_md_with_sidecar, backlinks_for_page, create_after, date_from_slug,
     delete, edit_text, find_by_slug, indent, journal_slug, journal_title, list_pages,
     migrate_legacy_into_today, move_down, move_up, next_journal_date, open_journal,
-    open_or_create_page, open_today, outdent, page_meta as page_meta_action, previous_journal_date,
-    read_page_view_with_workspace, set_block_collapsed as action_set_block_collapsed, today,
-    toggle_todo as action_toggle_todo, ActionError, Backlink, OutlineNode, PageKind, PageMeta,
+    open_or_create_page, open_today, outdent, page_meta as page_meta_action,
+    paste_markdown as action_paste_markdown, previous_journal_date, read_page_view_with_workspace,
+    set_block_collapsed as action_set_block_collapsed, today, toggle_todo as action_toggle_todo,
+    ActionError, Backlink, OutlineNode, PageKind, PageMeta, PasteAnchor,
 };
 use outl_core::hlc::HlcGenerator;
 use outl_core::id::{ActorId, NodeId};
@@ -479,6 +480,39 @@ fn set_block_collapsed(
     })
 }
 
+/// Paste external clipboard markdown as a tree of blocks.
+///
+/// `caret` is a `char` offset (not bytes) into the host block's text,
+/// matching the convention `outl_actions::PasteAnchor::AtCaret` uses.
+/// The frontend's textarea reports `selectionStart` as a UTF-16 code
+/// unit offset; for ASCII content that's identical to a char count,
+/// which is what the user prompt sends today. We can tighten this when
+/// we ship multi-byte text in the textarea (issue tracked in the
+/// frontend `BlockRow.tsx` paste handler).
+#[tauri::command]
+fn paste_markdown_at(
+    page_id: String,
+    block_id: String,
+    caret: u32,
+    text: String,
+    state: State<'_, AppState>,
+) -> Result<PageView, String> {
+    let page = parse_node_id(&page_id)?;
+    let block = parse_node_id(&block_id)?;
+    finish_in_page(&state, page, |ws| {
+        action_paste_markdown(
+            ws,
+            &state.hlc,
+            PasteAnchor::AtCaret {
+                block,
+                caret: caret as usize,
+            },
+            &text,
+        )
+        .map(|_| ())
+    })
+}
+
 #[tauri::command]
 fn reload_workspace(state: State<'_, AppState>) -> Result<(), String> {
     let engine = outl_actions::SyncEngine::new(state.storage_root.clone(), state.hlc.actor());
@@ -712,6 +746,7 @@ pub fn run() {
             move_block_up,
             move_block_down,
             set_block_collapsed,
+            paste_markdown_at,
             reload_workspace,
             // Legacy
             list_outline,

--- a/crates/outl-mobile/src/components/BlockRow.tsx
+++ b/crates/outl-mobile/src/components/BlockRow.tsx
@@ -4,6 +4,7 @@ import { MarkdownInline } from "../lib/markdown";
 import { autoClosePair, autoDeletePair } from "../lib/autocomplete";
 import { haptic } from "../lib/haptics";
 import { rawTextWithTodo } from "../lib/outline";
+import { looksLikeOutline } from "../lib/paste";
 import { parkCaret } from "../lib/textarea";
 import { SwipeRow } from "./SwipeRow";
 
@@ -37,6 +38,15 @@ interface BlockRowProps {
   onRefClick?: (target: string) => void;
   onTagClick?: (tag: string) => void;
   onTextareaMount?: (el: HTMLTextAreaElement) => void;
+  /**
+   * Called when the user pastes outline-shaped markdown into this
+   * block's textarea. The frontend has already detected via
+   * `looksLikeOutline` that the clipboard payload deserves a
+   * full-on tree conversion; the parent wires this up to the Tauri
+   * `paste_markdown_at` command and refreshes the page on resolve.
+   * `caret` is a `char` offset into the host block's text.
+   */
+  onPasteMarkdown?: (blockId: string, caret: number, text: string) => void;
 }
 
 /**
@@ -90,6 +100,12 @@ export function BlockRow(props: BlockRowProps): JSX.Element {
           onRefClick={props.onRefClick}
           onTagClick={props.onTagClick}
           onTextareaMount={props.onTextareaMount}
+          onPasteMarkdown={
+            props.onPasteMarkdown
+              ? (caret, text) =>
+                  props.onPasteMarkdown!(props.block.id, caret, text)
+              : undefined
+          }
         />
       </SwipeRow>
 
@@ -150,6 +166,9 @@ function BlockBody(props: {
   onRefClick?: (target: string) => void;
   onTagClick?: (tag: string) => void;
   onTextareaMount?: (el: HTMLTextAreaElement) => void;
+  /** See `BlockRowProps.onPasteMarkdown`. The parent has already
+   *  injected `blockId`; this variant gets the caret + text. */
+  onPasteMarkdown?: (caret: number, text: string) => void;
 }) {
   let longPressTimer: number | undefined;
   let downX = 0;
@@ -279,6 +298,7 @@ function BlockBody(props: {
             onInput={props.onDraftChange}
             onBlur={props.onCommitEdit}
             onMount={props.onTextareaMount}
+            onPaste={props.onPasteMarkdown}
           />
         </Show>
       </div>
@@ -389,6 +409,13 @@ function EditableTextarea(props: {
   onInput: (v: string) => void;
   onBlur: () => void;
   onMount?: (el: HTMLTextAreaElement) => void;
+  /**
+   * Called when the user pastes outline-shaped markdown. Receives
+   * the caret position (in chars) and the verbatim clipboard text.
+   * The parent is responsible for `preventDefault` semantics on the
+   * paste event — we already do that here when this is set.
+   */
+  onPaste?: (caret: number, text: string) => void;
 }) {
   let ref!: HTMLTextAreaElement;
   let resizeRaf = 0;
@@ -478,6 +505,19 @@ function EditableTextarea(props: {
           props.onInput(ta.value);
         }
         autoResize();
+      }}
+      onPaste={(e) => {
+        // External-clipboard markdown → tree of blocks. We only
+        // intercept when the payload looks like an outline; plain
+        // text falls through to the browser's default splice so
+        // pasting a single URL or code snippet still works the way
+        // the user expects.
+        if (!props.onPaste) return;
+        const text = e.clipboardData?.getData("text/plain") ?? "";
+        if (!looksLikeOutline(text)) return;
+        e.preventDefault();
+        const caret = e.currentTarget.selectionStart ?? 0;
+        props.onPaste(caret, text);
       }}
       onBlur={props.onBlur}
     />

--- a/crates/outl-mobile/src/components/BlockRow.tsx
+++ b/crates/outl-mobile/src/components/BlockRow.tsx
@@ -4,7 +4,7 @@ import { MarkdownInline } from "../lib/markdown";
 import { autoClosePair, autoDeletePair } from "../lib/autocomplete";
 import { haptic } from "../lib/haptics";
 import { rawTextWithTodo } from "../lib/outline";
-import { looksLikeOutline } from "../lib/paste";
+import { looksLikeOutline, utf16OffsetToCharOffset } from "../lib/paste";
 import { parkCaret } from "../lib/textarea";
 import { SwipeRow } from "./SwipeRow";
 
@@ -516,7 +516,12 @@ function EditableTextarea(props: {
         const text = e.clipboardData?.getData("text/plain") ?? "";
         if (!looksLikeOutline(text)) return;
         e.preventDefault();
-        const caret = e.currentTarget.selectionStart ?? 0;
+        // `selectionStart` is a UTF-16 code unit offset; the Rust
+        // backend wants a codepoint count. Conversion is a no-op
+        // for BMP text but matters when the host block contains
+        // emoji or other supplementary-plane characters.
+        const ta = e.currentTarget;
+        const caret = utf16OffsetToCharOffset(ta.value, ta.selectionStart ?? 0);
         props.onPaste(caret, text);
       }}
       onBlur={props.onBlur}

--- a/crates/outl-mobile/src/components/Journal.tsx
+++ b/crates/outl-mobile/src/components/Journal.tsx
@@ -22,6 +22,7 @@ import {
   openPageBySlug,
   openTodayJournal,
   outdentBlock,
+  pasteMarkdown,
   previousDay,
   reloadWorkspace,
   resolveRef,
@@ -455,6 +456,31 @@ export function Journal() {
         void commitEdit();
       });
     }
+  }
+
+  /**
+   * Apply an external-clipboard markdown paste to the workspace.
+   *
+   * `BlockRow`'s textarea has already detected via `looksLikeOutline`
+   * that the payload deserves the outline → blocks conversion and
+   * called `preventDefault` on the original paste event. We commit
+   * any in-flight draft first (the host block's text would otherwise
+   * race with the paste's `AtCaret` splice), hand the raw text to
+   * the backend, then re-apply the resulting `PageView`.
+   */
+  async function handlePasteMarkdown(blockId: string, caret: number, text: string) {
+    const pid = pageId();
+    if (!pid) return;
+    if (editingId() === blockId) {
+      // Flush whatever the user was typing so the splice operates on
+      // the workspace state the textarea is showing, not on stale
+      // backend text.
+      const draftText = draft();
+      const committed = await withError(() => editBlock(pid, blockId, draftText));
+      if (committed) setView(committed);
+    }
+    const next = await withError(() => pasteMarkdown(pid, blockId, caret, text));
+    if (next) applyView(next);
   }
 
   async function handleToggleTodo(id: string) {
@@ -922,6 +948,7 @@ export function Journal() {
                   onToggleCollapse={handleToggleCollapse}
                   onRefClick={handleRefClick}
                   onTagClick={handleTagClick}
+                  onPasteMarkdown={handlePasteMarkdown}
                   onTextareaMount={(el) => {
                     activeTextarea = el;
                     setActiveTextareaSignal(el);

--- a/crates/outl-mobile/src/lib/api.ts
+++ b/crates/outl-mobile/src/lib/api.ts
@@ -152,6 +152,33 @@ export function reloadWorkspace(): Promise<void> {
 }
 
 /**
+ * Hand off an external-clipboard paste to the backend for conversion
+ * into a tree of blocks. The Rust side normalises external syntax
+ * (Roam `{{[[TODO]]}}`, GitHub checkboxes, etc.), parses the bullet
+ * structure, and grafts it under `blockId` at the caret position.
+ *
+ * Returns the refreshed `PageView` so the caller can re-render.
+ * `caret` is a `char` offset into the host block's text — for ASCII
+ * content the textarea's `selectionStart` (UTF-16 code units) is
+ * equivalent. The frontend should `preventDefault` on the original
+ * paste event before calling this so the default browser splice
+ * doesn't run alongside the backend conversion.
+ */
+export function pasteMarkdown(
+  pageId: string,
+  blockId: string,
+  caret: number,
+  text: string,
+): Promise<PageView> {
+  return invoke<PageView>("paste_markdown_at", {
+    pageId,
+    blockId,
+    caret,
+    text,
+  });
+}
+
+/**
  * Persist the collapsed flag on a single block. The backend writes
  * straight to the sidecar (no `Op` is generated — collapsed is UI
  * state). Returns the refreshed page view so the caller can re-render

--- a/crates/outl-mobile/src/lib/paste.test.ts
+++ b/crates/outl-mobile/src/lib/paste.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { looksLikeOutline } from "./paste";
+import { looksLikeOutline, utf16OffsetToCharOffset } from "./paste";
 
 describe("looksLikeOutline", () => {
   it("returns false for empty input", () => {
@@ -37,5 +37,42 @@ describe("looksLikeOutline", () => {
     // `-foo` is not a bullet — must be `- foo`.
     expect(looksLikeOutline("-foo")).toBe(false);
     expect(looksLikeOutline("hyphen-word")).toBe(false);
+  });
+});
+
+describe("utf16OffsetToCharOffset", () => {
+  it("returns 0 for offset 0", () => {
+    expect(utf16OffsetToCharOffset("anything", 0)).toBe(0);
+    expect(utf16OffsetToCharOffset("", 0)).toBe(0);
+  });
+
+  it("matches the UTF-16 offset for pure ASCII", () => {
+    const s = "hello world";
+    expect(utf16OffsetToCharOffset(s, 5)).toBe(5);
+    expect(utf16OffsetToCharOffset(s, s.length)).toBe(s.length);
+  });
+
+  it("matches the UTF-16 offset for BMP text", () => {
+    // pt-BR with accents — `á` is U+00E1, still BMP, one code unit.
+    const s = "olá mundo";
+    expect(utf16OffsetToCharOffset(s, 4)).toBe(4); // after "olá "
+    expect(utf16OffsetToCharOffset(s, s.length)).toBe(s.length);
+  });
+
+  it("collapses surrogate pairs to a single char", () => {
+    // 😀 = U+1F600 — supplementary plane, takes 2 UTF-16 code units.
+    const s = "hi 😀 you";
+    // Selection start right after the emoji: UTF-16 offset 5
+    // (`h` `i` ` ` `😀-high` `😀-low`), but only 4 chars.
+    expect(utf16OffsetToCharOffset(s, 5)).toBe(4);
+    // End of string: 9 UTF-16 units (h, i, space, 2× emoji surrogate,
+    // space, y, o, u), 8 chars.
+    expect(s.length).toBe(9);
+    expect(utf16OffsetToCharOffset(s, s.length)).toBe(8);
+  });
+
+  it("clamps when the offset overshoots", () => {
+    const s = "abc";
+    expect(utf16OffsetToCharOffset(s, 999)).toBe(3);
   });
 });

--- a/crates/outl-mobile/src/lib/paste.test.ts
+++ b/crates/outl-mobile/src/lib/paste.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { looksLikeOutline } from "./paste";
+
+describe("looksLikeOutline", () => {
+  it("returns false for empty input", () => {
+    expect(looksLikeOutline("")).toBe(false);
+  });
+
+  it("returns false for plain text", () => {
+    expect(looksLikeOutline("just one line of text")).toBe(false);
+    expect(looksLikeOutline("multi\nline\nbut no bullets")).toBe(false);
+  });
+
+  it("returns true on a single bullet line", () => {
+    expect(looksLikeOutline("- one bullet")).toBe(true);
+  });
+
+  it("returns true when the bullet is indented", () => {
+    expect(looksLikeOutline("    - nested")).toBe(true);
+    expect(looksLikeOutline("\t- tab-indented")).toBe(true);
+  });
+
+  it("returns true when bullets appear after non-bullet preface", () => {
+    expect(looksLikeOutline("intro paragraph\n- bullet")).toBe(true);
+  });
+
+  it("ignores leading whitespace lines", () => {
+    expect(looksLikeOutline("\n\n  \n- after blanks")).toBe(true);
+  });
+
+  it("treats an empty bullet marker as outline", () => {
+    expect(looksLikeOutline("-")).toBe(true);
+    expect(looksLikeOutline("  -")).toBe(true);
+  });
+
+  it("returns false for dash followed by non-space", () => {
+    // `-foo` is not a bullet — must be `- foo`.
+    expect(looksLikeOutline("-foo")).toBe(false);
+    expect(looksLikeOutline("hyphen-word")).toBe(false);
+  });
+});

--- a/crates/outl-mobile/src/lib/paste.ts
+++ b/crates/outl-mobile/src/lib/paste.ts
@@ -21,6 +21,11 @@
  * non-blank line starts with `- ` or is just `-`). The detector errs
  * on the side of "outline" — false positives only cost one Tauri
  * round trip while false negatives lose the user's hierarchy.
+ *
+ * Mirror of `outl_actions::paste::looks_like_outline`. Keep both in
+ * sync — the Rust side is the canonical contract; the JS copy exists
+ * to gate the Tauri round-trip before the user sees a flash of
+ * "browser default splice" while the backend runs.
  */
 export function looksLikeOutline(text: string): boolean {
   if (!text) return false;
@@ -31,4 +36,34 @@ export function looksLikeOutline(text: string): boolean {
     }
   }
   return false;
+}
+
+/**
+ * Convert a UTF-16 code unit offset (what the DOM textarea reports
+ * via `selectionStart`) into a Unicode-codepoint offset, which is
+ * what `outl_actions::PasteAnchor::AtCaret { caret }` expects — Rust
+ * `str::chars()` iterates codepoints, not UTF-16 code units.
+ *
+ * For text that lives entirely in the BMP (every codepoint ≤ U+FFFF)
+ * the two counts are equal, so this is a no-op for ASCII / most CJK.
+ * It only matters for content with characters in supplementary planes
+ * — emoji, mathematical symbols, less-common CJK extensions — where
+ * each codepoint takes 2 UTF-16 code units. Without this conversion,
+ * pasting after such a character lands the splice one position too
+ * late per high-plane char before the caret.
+ */
+export function utf16OffsetToCharOffset(
+  text: string,
+  utf16Offset: number,
+): number {
+  if (utf16Offset <= 0) return 0;
+  let chars = 0;
+  let i = 0;
+  while (i < utf16Offset && i < text.length) {
+    const cp = text.codePointAt(i);
+    if (cp === undefined) break;
+    i += cp > 0xffff ? 2 : 1;
+    chars += 1;
+  }
+  return chars;
 }

--- a/crates/outl-mobile/src/lib/paste.ts
+++ b/crates/outl-mobile/src/lib/paste.ts
@@ -1,0 +1,34 @@
+/**
+ * Heuristic and helpers for the external-clipboard paste flow.
+ *
+ * The actual markdown → block-tree conversion happens in the Rust
+ * backend (`outl_actions::paste_markdown`, exposed as the
+ * `paste_markdown_at` Tauri command). The frontend's job is to:
+ *
+ * 1. Detect that the user pasted *outline-like* content (otherwise we
+ *    let the browser do its default thing — splice the text into the
+ *    textarea — so plain text doesn't trigger a round trip).
+ * 2. Hand the raw clipboard string to the backend along with the
+ *    block id and caret position; the backend mutates the workspace
+ *    and returns the refreshed page view.
+ *
+ * The same heuristic is mirrored in
+ * `outl_actions::paste::looks_like_outline`. Keep them in sync.
+ */
+
+/**
+ * True when `text` looks like a markdown bullet list (at least one
+ * non-blank line starts with `- ` or is just `-`). The detector errs
+ * on the side of "outline" — false positives only cost one Tauri
+ * round trip while false negatives lose the user's hierarchy.
+ */
+export function looksLikeOutline(text: string): boolean {
+  if (!text) return false;
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.replace(/^[ \t]+/, "");
+    if (trimmed === "-" || trimmed.startsWith("- ")) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/crates/outl-tui/CLAUDE.md
+++ b/crates/outl-tui/CLAUDE.md
@@ -161,7 +161,8 @@ src/
 │   ├── block.rs         # Insert mode, create/indent/outdent/delete blocks
 │   ├── history.rs       # undo / redo snapshots
 │   ├── visual.rs        # Visual mode + range ops
-│   ├── yank.rs          # yank register, paste
+│   ├── yank.rs          # yank register, in-app paste of yanked blocks
+│   ├── paste.rs         # external-clipboard paste (bracketed paste → outl_actions::paste_markdown)
 │   ├── exec.rs          # run code block via outl_exec
 │   └── overlay.rs       # quick switcher, search, palette, autocomplete
 ├── input.rs             # key → action routing

--- a/crates/outl-tui/src/actions/mod.rs
+++ b/crates/outl-tui/src/actions/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod history;
 pub(crate) mod lifecycle;
 pub(crate) mod nav;
 pub(crate) mod overlay;
+pub(crate) mod paste;
 pub(crate) mod sidebar;
 pub(crate) mod toast;
 pub(crate) mod visual;

--- a/crates/outl-tui/src/actions/paste.rs
+++ b/crates/outl-tui/src/actions/paste.rs
@@ -1,0 +1,156 @@
+//! External clipboard paste — convert markdown into a tree of blocks.
+//!
+//! Wired to `Event::Paste` from crossterm's bracketed-paste support.
+//! Delegates the work to [`outl_actions::paste_markdown`] so the
+//! semantics stay identical between the TUI and the mobile client.
+//!
+//! ## v0 anchor policy
+//!
+//! For simplicity, the TUI always uses [`outl_actions::PasteAnchor::AfterBlock`]
+//! against the currently selected block. The mobile client uses
+//! `AtCaret` when the paste happens inside a textarea — we deliberately
+//! do not match that here in v0 because the TUI runs an AST-first edit
+//! pipeline (the buffer is the source while in Insert; the workspace
+//! is the source while in Normal). Reusing `AtCaret` from inside Insert
+//! would require swapping the workspace state mid-edit, which the
+//! peer-sync code path explicitly avoids (see `poll_jsonl_updates`).
+//!
+//! What we do instead in Insert mode: commit the in-flight buffer
+//! first, then paste, then reload the workspace from disk so the new
+//! tree shows up.
+
+use outl_actions::{children_of, find_by_slug, paste_markdown, PasteAnchor};
+use outl_core::id::NodeId;
+use outl_core::workspace::Workspace;
+
+use crate::state::{App, Mode};
+
+impl App {
+    /// Apply a bracketed-paste payload to the workspace.
+    ///
+    /// `text` is the verbatim clipboard contents reported by crossterm.
+    /// The function:
+    ///
+    /// 1. Commits any in-flight Insert buffer to disk first so the
+    ///    workspace is in a clean state before we apply ops to it.
+    /// 2. Resolves the currently selected block's `NodeId` via the
+    ///    workspace index (sidecar-backed, O(1)).
+    /// 3. Routes the text through `outl_actions::paste_markdown` with
+    ///    [`PasteAnchor::AfterBlock`].
+    /// 4. Reloads the materialised page from disk and updates the
+    ///    status line with the block count the user just pasted.
+    ///
+    /// Empty paste, no selected block, or no index entry for the
+    /// selected block are all soft failures that surface in the
+    /// status line and leave the workspace untouched.
+    pub(crate) fn paste_external(&mut self, text: String) {
+        if text.is_empty() {
+            return;
+        }
+        if matches!(self.mode, Mode::Insert { .. }) {
+            self.commit_insert();
+        }
+        // Force a save + reconcile *before* resolving the selected
+        // block's NodeId so the workspace tree mirrors the in-memory
+        // AST. Otherwise a freshly opened journal (or a `.md`
+        // imported externally that the orphan scanner hasn't picked
+        // up yet) leaves the tree with fewer children than the AST
+        // shows, and the path walk dead-ends.
+        self.save();
+
+        let slug = self.current_slug();
+        let Some(path) = outl_md::outline_ops::path_for_index(&self.page.blocks, self.selected)
+        else {
+            self.status = "paste: no selected block".into();
+            return;
+        };
+        // Resolve the selected block's NodeId by walking the workspace
+        // tree directly. We deliberately don't go through
+        // `WorkspaceIndex::block_at_location` here: the index is
+        // sidecar-backed and rebuilt off the critical path, so right
+        // after a freshly opened journal (or a previous paste that
+        // hasn't reprojected yet) the entry may not exist. The
+        // workspace tree is always up to date.
+        let Some(page_id) = find_by_slug(&self.workspace, &slug) else {
+            self.status = "paste: current page not in workspace".into();
+            return;
+        };
+        let Some(node_id) = resolve_node_id_at_path(&self.workspace, page_id, &path) else {
+            self.status = "paste: could not resolve selected block in tree".into();
+            return;
+        };
+
+        match paste_markdown(
+            &mut self.workspace,
+            &self.hlc,
+            PasteAnchor::AfterBlock(node_id),
+            &text,
+        ) {
+            Ok(out) => {
+                // Full refresh: re-read everything from disk and
+                // rebuild the workspace index. The lighter
+                // `reload_workspace_from_disk` path leaves the page
+                // list and index pointing at pre-paste state, which
+                // showed up as ghost cells on the right edge of the
+                // outline after the user moved the cursor.
+                self.reload_workspace_from_disk();
+                self.refresh_page_list();
+                self.spawn_index_rebuild();
+                // Land the selection on the bottom of what we just
+                // pasted so the user sees the new tail without
+                // scrolling — nicer than landing wherever the post-
+                // reload flat index happens to fall.
+                self.flat_len = outl_md::outline_ops::flat_count(&self.page.blocks);
+                let landed = self.flat_index_for_node(node_id, out.new_blocks.last().copied());
+                if let Some(idx) = landed {
+                    self.selected = idx.min(self.flat_len.saturating_sub(1));
+                }
+                self.cursor_col = 0;
+                // Any half-pressed Vim chord (`y`, `g`, `d`, `q`) from
+                // before the paste must not survive — otherwise the
+                // next keystroke fires the chord against a freshly
+                // pasted block the user hadn't reviewed yet.
+                self.pending_chord = None;
+                self.status = if out.root_count > 0 {
+                    format!(
+                        "pasted {n} block{s}",
+                        n = out.root_count,
+                        s = if out.root_count == 1 { "" } else { "s" }
+                    )
+                } else {
+                    "pasted text".into()
+                };
+            }
+            Err(e) => {
+                self.status = format!("paste failed: {e}");
+            }
+        }
+    }
+
+    /// Locate a freshly-pasted block in the current AST so the caller
+    /// can move the selection cursor onto it. Tries the last pasted
+    /// id first, falls back to the anchor block.
+    fn flat_index_for_node(&self, anchor: NodeId, last_pasted: Option<NodeId>) -> Option<usize> {
+        let target = last_pasted.unwrap_or(anchor);
+        self.id_by_flat.iter().position(|id| *id == target)
+    }
+}
+
+/// Walk the tree from `page_id` following the DFS path produced by
+/// `outl_md::outline_ops::path_for_index`. Returns the `NodeId` at
+/// `path` when every step lines up, `None` if any segment is out of
+/// range (in practice only happens when the AST drifted from the
+/// workspace state, e.g. a peer added blocks since the last reload).
+fn resolve_node_id_at_path(
+    workspace: &Workspace,
+    page_id: NodeId,
+    path: &[usize],
+) -> Option<NodeId> {
+    let mut current = page_id;
+    for &idx in path {
+        let kids = children_of(workspace, current);
+        let (child, _) = kids.into_iter().nth(idx)?;
+        current = child;
+    }
+    Some(current)
+}

--- a/crates/outl-tui/src/actions/paste.rs
+++ b/crates/outl-tui/src/actions/paste.rs
@@ -23,7 +23,7 @@ use outl_actions::{children_of, find_by_slug, paste_markdown, PasteAnchor};
 use outl_core::id::NodeId;
 use outl_core::workspace::Workspace;
 
-use crate::state::{App, Mode};
+use crate::state::{App, EditTarget, Mode};
 
 impl App {
     /// Apply a bracketed-paste payload to the workspace.
@@ -47,6 +47,22 @@ impl App {
         if text.is_empty() {
             return;
         }
+        // `commit_insert` writes the in-flight buffer back into the
+        // AST and — when the buffer changed against the current page
+        // — already calls `save()` (render → write → reconcile)
+        // internally. Calling `save()` again afterwards would pay the
+        // I/O + reconcile a second time for nothing. Track whether
+        // the upcoming `commit_insert` will save the current page so
+        // we skip the redundant call below.
+        let commit_will_save_current = match &self.mode {
+            Mode::Insert {
+                target,
+                buffer,
+                original_text,
+                ..
+            } => matches!(target, EditTarget::CurrentPage) && buffer.as_string() != *original_text,
+            _ => false,
+        };
         if matches!(self.mode, Mode::Insert { .. }) {
             self.commit_insert();
         }
@@ -56,7 +72,9 @@ impl App {
         // imported externally that the orphan scanner hasn't picked
         // up yet) leaves the tree with fewer children than the AST
         // shows, and the path walk dead-ends.
-        self.save();
+        if !commit_will_save_current {
+            self.save();
+        }
 
         let slug = self.current_slug();
         let Some(path) = outl_md::outline_ops::path_for_index(&self.page.blocks, self.selected)

--- a/crates/outl-tui/src/actions/paste.rs
+++ b/crates/outl-tui/src/actions/paste.rs
@@ -19,7 +19,7 @@
 //! first, then paste, then reload the workspace from disk so the new
 //! tree shows up.
 
-use outl_actions::{children_of, find_by_slug, paste_markdown, PasteAnchor};
+use outl_actions::{children_of, find_by_slug, looks_like_outline, paste_markdown, PasteAnchor};
 use outl_core::id::NodeId;
 use outl_core::workspace::Workspace;
 
@@ -46,6 +46,19 @@ impl App {
     pub(crate) fn paste_external(&mut self, text: String) {
         if text.is_empty() {
             return;
+        }
+        // Plain-text paste inside Insert mode is the common "drop a
+        // URL / snippet into what I'm writing" workflow. Splicing the
+        // raw text into the live buffer keeps the keyboard up and
+        // the cursor where the user expects. Outline-shaped pastes
+        // still go through the full pipeline below so they create
+        // siblings as documented.
+        if !looks_like_outline(&text) {
+            if let Mode::Insert { buffer, .. } = &mut self.mode {
+                buffer.insert_str(&text);
+                self.status = "pasted text".into();
+                return;
+            }
         }
         // `commit_insert` writes the in-flight buffer back into the
         // AST and — when the buffer changed against the current page

--- a/crates/outl-tui/src/runtime.rs
+++ b/crates/outl-tui/src/runtime.rs
@@ -15,6 +15,7 @@ use crossterm::event::{
     self, Event, KeyCode, KeyEventKind, KeyModifiers, KeyboardEnhancementFlags,
     PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
+use crossterm::event::{DisableBracketedPaste, EnableBracketedPaste};
 use crossterm::execute;
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, supports_keyboard_enhancement, EnterAlternateScreen,
@@ -108,6 +109,12 @@ pub fn run_with_theme_override(path: &Path, theme_override: Option<&str>) -> Res
     enable_raw_mode().context("enabling raw mode")?;
     let mut stdout = std::io::stdout();
     execute!(stdout, EnterAlternateScreen).context("entering alt screen")?;
+    // Ask the terminal to deliver pastes as a single `Event::Paste`
+    // instead of streaming the clipboard contents as keystrokes (which
+    // would interleave `\n` with the user's keymap and produce
+    // surprise commits + new blocks). Best-effort: terminals without
+    // bracketed-paste support silently ignore the CSI sequence.
+    let _ = execute!(stdout, EnableBracketedPaste);
 
     // Ask the terminal to report enhanced key events (kitty keyboard
     // protocol). When supported, this lets us distinguish `Shift+Enter`
@@ -141,6 +148,7 @@ pub fn run_with_theme_override(path: &Path, theme_override: Option<&str>) -> Res
     if enhanced_keys {
         let _ = execute!(terminal.backend_mut(), PopKeyboardEnhancementFlags);
     }
+    let _ = execute!(terminal.backend_mut(), DisableBracketedPaste);
     let _ = disable_raw_mode();
     let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);
     let _ = terminal.show_cursor();
@@ -320,8 +328,16 @@ fn event_loop(
             app.check_external_changes();
             continue;
         }
-        let Event::Key(key) = event::read()? else {
-            continue;
+        let key = match event::read()? {
+            Event::Key(k) => k,
+            Event::Paste(text) => {
+                // Bracketed-paste payload — convert markdown bullets
+                // to outl blocks via the shared paste pipeline.
+                app.check_external_changes();
+                app.paste_external(text);
+                continue;
+            }
+            _ => continue,
         };
         if key.kind != KeyEventKind::Press {
             continue;

--- a/docs/markdown-format.md
+++ b/docs/markdown-format.md
@@ -473,9 +473,11 @@ base32 strings count. A random 26-character alphanumeric label
 (e.g. `id:: IIIILLLLOOOO0000000000000A`) is not a ULID and stays
 on the page.
 
-Heuristic: when no line begins with `- ` (after leading whitespace),
-the paste is treated as plain text — the clipboard payload is
-spliced into the current block at the caret, no tree conversion.
+Heuristic: when no line is either a bare `-` or starts with `- `
+(after leading whitespace), the paste is treated as plain text. The
+clipboard payload is spliced into the current block at the caret,
+no tree conversion. The bare `-` form matches the parser, which
+treats a lone `-` on a line as an empty bullet.
 
 Caret offsets in the mobile client are converted from UTF-16 code
 units (what `textarea.selectionStart` reports) into Unicode

--- a/docs/markdown-format.md
+++ b/docs/markdown-format.md
@@ -432,4 +432,37 @@ A TUI opens showing one orphan at a time with candidates. Keys:
 | `s` | skip (revisit later) |
 | `q` | quit |
 
+---
+
+## External paste → outl syntax
+
+When the user pastes clipboard markdown from another outliner / note
+app into outl, `outl_actions::paste_markdown` (in `outl-actions`)
+normalises the input before parsing it as bullets. The same pipeline
+runs in the TUI (bracketed-paste handler) and the mobile client
+(textarea `onPaste`).
+
+| Input (external) | Output (outl) | Origin |
+|------------------|---------------|--------|
+| `{{[[TODO]]}} foo` | `TODO foo` | Roam |
+| `{{[[DONE]]}} foo` | `DONE foo` | Roam |
+| `- [ ] foo` | `- TODO foo` | GitHub / CommonMark task list |
+| `- [x] foo` / `- [X] foo` | `- DONE foo` | GitHub / CommonMark |
+| `{{embed: ((blk-XXXXXX))}}` | `!((blk-XXXXXX))` | Roam |
+| `{{[[query]]: foo}}` | `{{query: foo}}` | Roam |
+| `^^highlight^^` | (stripped) | Roam |
+| `{{video: url}}` and other unknown `{{…}}` | (stripped) | various |
+| `id:: 01HXY…` (alone on a line) | (line dropped) | Logseq |
+| 4-space indent | 2-space indent | Roam / Notion export |
+
+Unknown tokens (`{{…}}` and `^^…^^` that aren't outl-native) are
+stripped on purpose so blocks land clean. Block properties parsed off
+the source (`key:: value` indented under a bullet) become
+`Op::SetProp` on the newly-created node so they converge across
+devices like every other op.
+
+Heuristic: when no line begins with `- ` (after leading whitespace),
+the paste is treated as plain text — the clipboard payload is
+spliced into the current block at the caret, no tree conversion.
+
 The orphan log is cleared as items are resolved.

--- a/docs/markdown-format.md
+++ b/docs/markdown-format.md
@@ -452,7 +452,8 @@ runs in the TUI (bracketed-paste handler) and the mobile client
 | `{{[[query]]: foo}}` | `{{query: foo}}` | Roam |
 | `^^highlight^^` | (stripped) | Roam |
 | `{{video: url}}` and other unknown `{{…}}` | (stripped) | various |
-| `id:: 01HXY…` (alone on a line) | (line dropped) | Logseq |
+| `id:: <26-char Crockford ULID>` (alone on a line) | (line dropped) | Logseq |
+| `[[June 2nd, 2026]]`, `[[Apr 22nd, 2026]]`, `[[2026/04/22]]` | `[[2026-06-02]]` etc. | Roam / mixed |
 | 4-space indent | 2-space indent | Roam / Notion export |
 
 Unknown tokens (`{{…}}` and `^^…^^` that aren't outl-native) are
@@ -461,8 +462,25 @@ the source (`key:: value` indented under a bullet) become
 `Op::SetProp` on the newly-created node so they converge across
 devices like every other op.
 
+Date refs `[[…]]` whose inner text parses as a date land as the ISO
+slug outl uses for journals. Supported forms: long month (`June 2nd,
+2026`), short month (`Apr 22nd, 2026`), slashed ISO (`2026/04/22`).
+Plain page refs (`[[Avelino]]`) and ambiguous dates (`[[June 2nd]]`
+without a year) pass through untouched.
+
+The `id::` line strip is strict. Only 26-character Crockford
+base32 strings count. A random 26-character alphanumeric label
+(e.g. `id:: IIIILLLLOOOO0000000000000A`) is not a ULID and stays
+on the page.
+
 Heuristic: when no line begins with `- ` (after leading whitespace),
 the paste is treated as plain text — the clipboard payload is
 spliced into the current block at the caret, no tree conversion.
+
+Caret offsets in the mobile client are converted from UTF-16 code
+units (what `textarea.selectionStart` reports) into Unicode
+codepoints before the Tauri round-trip, so pasting after an emoji
+or other supplementary-plane character lands the splice at the
+right spot.
 
 The orphan log is cleared as items are resolved.


### PR DESCRIPTION
Markdown pasted from Roam, Logseq, GitHub or Notion landed as one string per block. Hierarchy, TODO state and date refs all got lost.

New paste_markdown in outl-actions normalizes external syntax (Roam tokens, GH checkboxes, Logseq id::, free-form dates, 4-space indent) and inserts the parsed tree at the caller's anchor. TUI hooks into bracketed paste. Mobile hooks into the textarea onPaste with a JS heuristic so plain text still splices.

fixed: #44