### PR TITLE
fix(tui): quick switcher keeps full candidate set when query shrinks

### DIFF
--- a/crates/outl-tui/src/actions/overlay.rs
+++ b/crates/outl-tui/src/actions/overlay.rs
@@ -101,6 +101,7 @@ impl App {
         let candidates = self.collect_switch_candidates();
         self.overlay = Some(Overlay::QuickSwitch(QuickSwitchState {
             query: String::new(),
+            all_candidates: candidates.clone(),
             candidates,
             selected: 0,
             preview_cache: std::cell::RefCell::new(None),
@@ -110,8 +111,12 @@ impl App {
     pub(crate) fn refresh_quick_switch(&mut self) {
         if let Some(Overlay::QuickSwitch(ref mut qs)) = self.overlay {
             // Score every candidate by the current query; drop misses.
+            // Always filter from the full, immutable `all_candidates`
+            // set — never from the already-narrowed `candidates`, or
+            // deleting query characters could never restore items that
+            // an earlier, longer query had dropped.
             let mut filtered: Vec<SwitchCandidate> = qs
-                .candidates
+                .all_candidates
                 .iter()
                 .filter_map(|c| {
                     let primary = crate::fuzzy::fuzzy_score(&qs.query, &c.label);
@@ -780,4 +785,84 @@ pub(crate) fn read_page_title(md: &Path) -> Option<String> {
         .find(|(k, _)| k == "title")
         .map(|(_, v)| v.trim().to_string())
         .filter(|s| !s.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::state::{App, Overlay, QuickSwitchState, SwitchCandidate, SwitchKind};
+    use outl_core::id::ActorId;
+    use outl_core::workspace::Workspace;
+    use tempfile::TempDir;
+
+    fn page(label: &str) -> SwitchCandidate {
+        SwitchCandidate {
+            label: label.to_string(),
+            key: label.to_string(),
+            kind: SwitchKind::Page,
+            score: 0,
+        }
+    }
+
+    fn test_app() -> (App, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let actor = ActorId::new();
+        let ws = Workspace::open_in_memory(actor).unwrap();
+        let app = App::new(
+            dir.path().to_path_buf(),
+            ws,
+            actor,
+            crate::theme::default_theme(),
+            false,
+        )
+        .unwrap();
+        (app, dir)
+    }
+
+    /// Regression: deleting query characters must restore candidates an
+    /// earlier, longer query had filtered out. The bug was that
+    /// `refresh_quick_switch` narrowed `candidates` in place, destroying
+    /// the source set, so backspacing could never bring matches back.
+    #[test]
+    fn quick_switch_widens_when_query_shrinks() {
+        let (mut app, _dir) = test_app();
+        let all = vec![page("foo"), page("food"), page("bar")];
+        app.overlay = Some(Overlay::QuickSwitch(QuickSwitchState {
+            query: String::new(),
+            all_candidates: all.clone(),
+            candidates: all,
+            selected: 0,
+            preview_cache: std::cell::RefCell::new(None),
+        }));
+
+        // Type "food": only the "food" page survives.
+        if let Some(Overlay::QuickSwitch(ref mut qs)) = app.overlay {
+            qs.query = "food".into();
+        }
+        app.refresh_quick_switch();
+        let after_food: Vec<String> = match &app.overlay {
+            Some(Overlay::QuickSwitch(qs)) => {
+                qs.candidates.iter().map(|c| c.label.clone()).collect()
+            }
+            _ => unreachable!(),
+        };
+        assert_eq!(after_food, vec!["food".to_string()]);
+
+        // Backspace down to "foo": both "foo" and "food" must come back.
+        if let Some(Overlay::QuickSwitch(ref mut qs)) = app.overlay {
+            qs.query = "foo".into();
+        }
+        app.refresh_quick_switch();
+        let mut after_foo: Vec<String> = match &app.overlay {
+            Some(Overlay::QuickSwitch(qs)) => {
+                qs.candidates.iter().map(|c| c.label.clone()).collect()
+            }
+            _ => unreachable!(),
+        };
+        after_foo.sort();
+        assert_eq!(
+            after_foo,
+            vec!["foo".to_string(), "food".to_string()],
+            "shrinking the query must restore candidates the longer query dropped"
+        );
+    }
 }

--- a/crates/outl-tui/src/state.rs
+++ b/crates/outl-tui/src/state.rs
@@ -233,10 +233,12 @@ pub(crate) enum SwitchKind {
 #[derive(Debug)]
 pub(crate) struct QuickSwitchState {
     pub(crate) query: String,
-    /// The full, immutable candidate set captured when the switcher
-    /// opens. `refresh_quick_switch` always filters *from here* into
-    /// `candidates` — never destructively narrows the displayed list,
-    /// or deleting query characters could never restore dropped items.
+    /// The full candidate set captured when the switcher opens.
+    /// Treated as read-only after `open_quick_switch` populates it:
+    /// `refresh_quick_switch` always filters *from here* into
+    /// `candidates` and never writes back, so deleting query
+    /// characters can always restore candidates a longer query had
+    /// dropped.
     pub(crate) all_candidates: Vec<SwitchCandidate>,
     /// The filtered + scored subset currently shown, recomputed from
     /// `all_candidates` on every keystroke.

--- a/crates/outl-tui/src/state.rs
+++ b/crates/outl-tui/src/state.rs
@@ -233,6 +233,13 @@ pub(crate) enum SwitchKind {
 #[derive(Debug)]
 pub(crate) struct QuickSwitchState {
     pub(crate) query: String,
+    /// The full, immutable candidate set captured when the switcher
+    /// opens. `refresh_quick_switch` always filters *from here* into
+    /// `candidates` — never destructively narrows the displayed list,
+    /// or deleting query characters could never restore dropped items.
+    pub(crate) all_candidates: Vec<SwitchCandidate>,
+    /// The filtered + scored subset currently shown, recomputed from
+    /// `all_candidates` on every keystroke.
     pub(crate) candidates: Vec<SwitchCandidate>,
     pub(crate) selected: usize,
     /// One-slot cache for the preview pane so the renderer doesn't


### PR DESCRIPTION
## Problem

In the quick switcher (`Ctrl+P`), searching for something and then **changing/deleting** the search terms left the result set still filtered by the already-deleted text.

## Cause

`QuickSwitchState.candidates` was both the source list **and** the filtered list. On every keystroke, `refresh_quick_switch` filtered `candidates` and wrote the resulting subset back into `candidates` — destroying the original list. Backspacing/editing could never restore candidates that a longer query had dropped.

(The universal search `/` did not have the bug because it re-reads the `.md` files from disk and rebuilds the hits from scratch on every keystroke.)

## Fix

- New `all_candidates` field on `QuickSwitchState`, captured once in `open_quick_switch`.
- `refresh_quick_switch` now **always filters from `all_candidates`** into `candidates`, never narrowing destructively.
- Regression test `quick_switch_widens_when_query_shrinks`: narrows to `food`, backspaces to `foo`, and asserts both `foo` **and** `food` come back. Verified it fails without the fix.

## Tests

`cargo test -p outl-tui` — 87 passing.