### PR TITLE
feat(desktop): bottom-left icon buttons to toggle sidebar and shortcuts help

### DIFF
--- a/crates/outl-desktop/CLAUDE.md
+++ b/crates/outl-desktop/CLAUDE.md
@@ -123,6 +123,8 @@ Today the suite is the scaffold: one Vitest file (`src/setup.test.ts`) that impo
 
 The full catalog lives in **`crates/outl-shortcuts`** (single source of truth, also consumed by the TUI). The desktop fetches it via the `list_shortcut_bindings` Tauri command on boot and wires every `Action` through `lib/action-handlers.ts`.
 
+Two of these chords also have **visible icon affordances** in a fixed bottom-left cluster (`components/ChromeToggleBar.tsx`, mounted by `AppShell`, VS Code activity-bar convention): the **sidebar toggle** (`◫`, mirrors `Cmd/Ctrl+Shift+E`) and the **shortcuts-help toggle** (`?`, mirrors `?` / `Cmd/Ctrl+/`). They carry no business logic — clicking flips the same `appState.sidebarOpen` / `appState.helpOpen` store signal the dispatcher flips, so button and keyboard stay in sync. The cluster floats over the main pane on an elevated, bordered surface (clear contrast against page content; active toggle inverts to the accent color), so the sidebar button stays reachable even after the left pane is hidden.
+
 ### OS-standard chrome (Global mode — fire in any context)
 
 | Chord | Action |

--- a/crates/outl-desktop/src/components/AppShell.tsx
+++ b/crates/outl-desktop/src/components/AppShell.tsx
@@ -18,6 +18,7 @@ import { OutlineView } from "./OutlineView";
 import { Picker } from "./Picker";
 import { SettingsModal } from "./SettingsModal";
 import { HelpOverlay } from "./HelpOverlay";
+import { ChromeToggleBar } from "./ChromeToggleBar";
 
 /**
  * 2-pane shell rendered once a workspace is loaded.
@@ -145,6 +146,7 @@ export function AppShell() {
         <OutlineView />
       </div>
 
+      <ChromeToggleBar />
       <Picker onPicked={applyView} />
       <SettingsModal />
       <HelpOverlay />

--- a/crates/outl-desktop/src/components/ChromeToggleBar.tsx
+++ b/crates/outl-desktop/src/components/ChromeToggleBar.tsx
@@ -1,0 +1,73 @@
+import { appState, setAppState } from "../lib/store";
+
+/**
+ * Small chrome toggle button (sidebar / shortcuts help).
+ *
+ * These surface keyboard chords that are otherwise invisible
+ * (`Cmd/Ctrl+Shift+E` for the sidebar, `?` / `Cmd/Ctrl+/` for the
+ * help overlay). They carry no business logic — clicking flips the
+ * same store signal the `outl-shortcuts` dispatcher flips, so the
+ * button and the keyboard stay in sync automatically.
+ */
+function ChromeToggle(props: {
+  glyph: string;
+  active: boolean;
+  label: string;
+  title: string;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={props.label}
+      aria-pressed={props.active}
+      title={props.title}
+      onClick={props.onToggle}
+      class={`flex h-7 w-7 items-center justify-center rounded-md text-[14px] leading-none transition-colors ${
+        props.active
+          ? "bg-(--color-outl-accent) text-(--color-outl-bg)"
+          : "text-(--color-outl-fg-dim) hover:bg-(--color-outl-bg-elev) hover:text-(--color-outl-fg)"
+      }`}
+    >
+      <span aria-hidden="true">{props.glyph}</span>
+    </button>
+  );
+}
+
+/**
+ * Bottom-left chrome cluster — sidebar + shortcuts-help toggles.
+ *
+ * Pinned to the lower-left corner of the window (VS Code's activity-bar
+ * convention) so the affordances are always in the same place, independent
+ * of which page or pane is open. The sidebar toggle stays reachable here
+ * even after the left pane is hidden because the cluster floats over the
+ * main pane, not inside the sidebar.
+ *
+ * The cluster sits on an elevated, bordered surface so it reads with clear
+ * contrast against the page content behind it; the active toggle inverts to
+ * the accent color for an unmistakable on/off state.
+ */
+export function ChromeToggleBar() {
+  return (
+    <div class="fixed bottom-3 left-3 z-20 flex items-center gap-1 rounded-lg border border-(--color-outl-border) bg-(--color-outl-bg-elev) p-1 shadow-lg">
+      <ChromeToggle
+        glyph="◫"
+        active={appState.sidebarOpen}
+        label={appState.sidebarOpen ? "Hide sidebar" : "Show sidebar"}
+        title="Toggle sidebar (⌘⇧E)"
+        onToggle={() => setAppState("sidebarOpen", !appState.sidebarOpen)}
+      />
+      <ChromeToggle
+        glyph="?"
+        active={appState.helpOpen}
+        label={
+          appState.helpOpen
+            ? "Hide keyboard shortcuts"
+            : "Show keyboard shortcuts"
+        }
+        title="Keyboard shortcuts (?)"
+        onToggle={() => setAppState("helpOpen", !appState.helpOpen)}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #56.

## What

Surfaces the two otherwise **keyboard-only** desktop toggles as clickable icon buttons in a fixed **bottom-left cluster** (VS Code activity-bar convention):

- **◫ Sidebar** — mirrors `Cmd/Ctrl+Shift+E`
- **? Shortcuts help** — mirrors `?` / `Cmd/Ctrl+/`

## Why

The sidebar defaults to hidden on first launch (`sidebarOpen: false`), and the shortcuts cheatsheet (`HelpOverlay`) is only reachable via the `?` key — both invisible to a first-time user. These buttons make them discoverable.

## How

- New `components/ChromeToggleBar.tsx`, mounted by `AppShell`. Floats over the main pane on an elevated, bordered surface for clear contrast against page content; the active toggle inverts to the accent color for an unmistakable on/off state. The sidebar button stays reachable even after the left pane is hidden.
- Both buttons flip the same store signals (`appState.sidebarOpen` / `appState.helpOpen`) the `outl-shortcuts` dispatcher uses, so button and keyboard stay in sync.
- **No new business logic**, **no icon dependency** (Unicode glyphs).
- Buttons carry `aria-label` + `aria-pressed`.

## Tests

- `bunx tsc --noEmit` → clean
- `bun --filter outl-desktop test` → 33 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
