### PR TITLE
feat(desktop): open the backlinks panel by default

### DIFF
--- a/crates/outl-desktop/src/lib/store.ts
+++ b/crates/outl-desktop/src/lib/store.ts
@@ -79,8 +79,11 @@ export interface AppStateShape {
    * shifted variant on the desktop to keep `Cmd+B` reserved for the
    * universal markdown "bold" chord).
    *
-   * Defaults to `false`: outline first, references on demand —
-   * matches the TUI's `show_backlinks: false` default.
+   * Defaults to `true`: references stay visible below the outline so
+   * a page's incoming links are discoverable without a chord. The
+   * inline section only renders when the page actually has backlinks
+   * (`<InlineBacklinks />` guards on `appState.backlinks.length`), so
+   * an open default costs nothing on pages with no references.
    */
   backlinksOpen: boolean;
   /** Picker overlay open state. `Cmd/Ctrl+P` toggles. */
@@ -104,7 +107,7 @@ const [state, setState] = createStore<AppStateShape>({
   editingBlockId: null,
   mode: "normal",
   sidebarOpen: false,
-  backlinksOpen: false,
+  backlinksOpen: true,
   pickerOpen: false,
   settingsOpen: false,
   helpOpen: false,


### PR DESCRIPTION
Closes #59.

## What

Default the desktop **backlinks panel to open**. `backlinksOpen` now starts `true`, so a page's incoming references show below the outline on load — no `Cmd/Ctrl+Shift+B` required.

## Why

References are a core outliner affordance; hiding them by default means a user has to know a chord to discover what links to the current page. Showing them up front makes the connection graph visible without friction.

## Safety

`<InlineBacklinks />` already guards on `appState.backlinks.length > 0`, so pages with no incoming links render exactly as before — the open default only adds the section where there's something to show. `Cmd/Ctrl+Shift+B` still toggles it off for an outline-only view.

## Tests

- `bunx tsc --noEmit` → clean
- `bun --filter outl-desktop test` → 33 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
