### PR TITLE
fix(mobile): keep search sheet results above the iOS keyboard

### DIFF
--- a/crates/outl-mobile/src/components/PageSwitcher.tsx
+++ b/crates/outl-mobile/src/components/PageSwitcher.tsx
@@ -8,6 +8,7 @@ import {
 import type { PageMeta } from "@outl/shared/api/types";
 import { listPages } from "@outl/shared/api/commands";
 import { createSheetDrag } from "../lib/sheet-drag";
+import { useKeyboardInset } from "../lib/viewport";
 
 interface PageSwitcherProps {
   open: boolean;
@@ -37,6 +38,13 @@ export function PageSwitcher(props: PageSwitcherProps) {
   // Calendar). Wire `drag.onPointer*` onto the grab handle only,
   // never the whole header.
   const drag = createSheetDrag(() => props.onClose());
+  // iOS WKWebView ignores `interactive-widget=resizes-content` (it's
+  // Chromium-only), so the keyboard OVERLAYS the layout viewport
+  // instead of shrinking it. Without compensating, the bottom of the
+  // filtered list sits behind the keyboard and can never be scrolled
+  // into view. We pad the sheet by the keyboard height so the scroll
+  // area ends right above it.
+  const keyboardInset = useKeyboardInset();
 
   const filtered = createMemo(() => {
     const all = pages() ?? [];
@@ -62,9 +70,16 @@ export function PageSwitcher(props: PageSwitcherProps) {
         onClick={props.onClose}
       />
       <div
-        class="outl-sheet-up fixed inset-x-0 bottom-0 z-50 flex max-h-[80vh] flex-col overflow-hidden rounded-t-2xl bg-(--color-ios-bg)/85 shadow-2xl backdrop-blur-2xl backdrop-saturate-150 dark:bg-(--color-iosd-bg)/85"
+        class="outl-sheet-up fixed inset-x-0 bottom-0 z-50 flex flex-col overflow-hidden rounded-t-2xl bg-(--color-ios-bg)/85 shadow-2xl backdrop-blur-2xl backdrop-saturate-150 dark:bg-(--color-iosd-bg)/85"
         style={{
-          "padding-bottom": "env(safe-area-inset-bottom)",
+          // Fullscreen sheet, iOS page-sheet style: anchored to the
+          // bottom and stretching up to just below the status bar so
+          // the rounded corners + grab handle stay visible.
+          top: "calc(env(safe-area-inset-top) + 8px)",
+          // When the keyboard is up, its inset already covers the
+          // home-indicator safe area — take the max instead of
+          // stacking both.
+          "padding-bottom": `max(env(safe-area-inset-bottom), ${keyboardInset()}px)`,
           transform: `translateY(${drag.translateY()}px)`,
           transition: drag.dragging()
             ? "none"


### PR DESCRIPTION
Fixes #67

## Problem

Opening the search icon on mobile raises the keyboard, and when the filtered result list is taller than the visible area, the bottom items sit behind the keyboard with no way to scroll them into view.
The sheet's height was also content-driven (`max-h-[80vh]`), jumping between a short strip and 80vh depending on the result count, with the search field flush against the status bar.

## Root cause

`interactive-widget=resizes-content` (set in `index.html` and relied upon by the comment in `src/lib/viewport.ts`) is Chromium-only.
iOS WKWebView ignores it, so the keyboard **overlays** the layout viewport instead of resizing it — the sheet's `fixed bottom-0` container keeps its full height behind the keyboard.
`useKeyboardInset()` already measured the keyboard correctly via `visualViewport`, but had no consumers.

## Fix (`PageSwitcher.tsx` only)

- Consume the existing `useKeyboardInset()` and pad the sheet with `max(env(safe-area-inset-bottom), <keyboardInset>px)` — `max` instead of summing, since the keyboard inset already covers the home-indicator area. The scroll area now ends right above the keyboard.
- Replace `max-h-[80vh]` with a fullscreen, iOS-page-sheet-style anchor: `bottom-0` up to `top: calc(env(safe-area-inset-top) + 8px)`. Sheet height is now stable regardless of result count and the search field keeps a margin below the status bar.

The `Calendar` sheet shares the bottom-sheet pattern but has no text input, so it is unaffected.

## Testing

- `bunx tsc --noEmit` clean, `bun run test` 27/27 passing.
- Verified manually on the iPhone 17 Pro simulator (software keyboard via `Cmd+K`): with a query returning more results than fit on screen, the list now scrolls until the last row is fully visible above the keyboard, and the sheet opens fullscreen with a margin below the status bar.