### PR TITLE
feat(frontend): auto-pair brackets, parens and braces in GUI block editors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ The same "one owner, every client wraps" policy applies on the TS side.
 
 - `<MarkdownInline />` (renderer for `InlineToken[]` produced by `outl_md::tokenize_owned`)
 - `<ParseWarningsBanner />` (renders `PageView.warnings`; mirrors the TUI's `warnings_banner` chrome)
-- Pure helpers: `looksLikeOutline`, `utf16OffsetToCharOffset`, `detectRefContext`, `autoClose/DeletePair`, `insertPair/Text`, `applySuggestion`
+- Pure helpers: `looksLikeOutline`, `utf16OffsetToCharOffset`, `detectRefContext`, `autoClose/DeletePair`, `autoPairBracket`, `insertPair/Text`, `applySuggestion`
 - DTO interfaces (`PageMeta`, `OutlineNode`, `BlockNode`, `Backlink`, `InlineToken`, `PageView`, `WorkspaceSummary`, …)
 - Typed `invoke<T>()` wrappers for the Tauri commands every client uses (`@outl/shared/api/commands`)
 

--- a/crates/outl-desktop/CLAUDE.md
+++ b/crates/outl-desktop/CLAUDE.md
@@ -195,6 +195,8 @@ Implementation lives in `lib/markdown-wrap.ts`: each handler reads `document.act
 | `Esc` / blur | Commit |
 | `Backspace` on empty | Delete the block |
 | `[[` / `((` | Auto-close pair (`@outl/shared/autocomplete`) |
+| `(` / `[` / `{` | Auto-pair with the matching closer, caret between (`autoPairBracket`, TUI parity); typing `)` / `]` / `}` over an identical closer steps past it instead of doubling |
+| `Backspace` inside an empty pair | Collapses the whole pair — `[[]]` / `(())` (4 chars) and `()` / `[]` / `{}` (2 chars) — via `autoDeletePair` |
 
 ### `Enter` outside a textarea (Normal mode)
 

--- a/crates/outl-desktop/src/components/BlockRow.tsx
+++ b/crates/outl-desktop/src/components/BlockRow.tsx
@@ -10,8 +10,8 @@ import {
 } from "@outl/shared/markdown";
 import {
   applySuggestion,
-  autoClosePair,
   autoDeletePair,
+  autoPairBracket,
   detectRefContext,
 } from "@outl/shared/autocomplete";
 import { searchPages } from "@outl/shared/api/commands";
@@ -285,24 +285,6 @@ export function BlockRow(props: {
       await props.cb.onDeleteEmpty(props.block.id);
       return;
     }
-    // Bracket-pair completion ([[…]], ((…))).
-    if (e.key === "[" || e.key === "(") {
-      // Let the character land first; check on the next tick.
-      queueMicrotask(() => {
-        if (!textareaRef) return;
-        const completion = autoClosePair(textareaRef.value, textareaRef.selectionStart ?? 0);
-        if (completion) {
-          setDraft(completion.value);
-          textareaRef.value = completion.value;
-          textareaRef.setSelectionRange(completion.caret, completion.caret);
-        }
-        // Whether or not the pair auto-closed, the caret may now be
-        // inside a `[[…]]` — refresh the suggester (setting the value
-        // programmatically above doesn't fire `onInput`).
-        refreshSuggest();
-      });
-      return;
-    }
     if (e.key === "Backspace") {
       const ta = textareaRef;
       if (ta) {
@@ -317,6 +299,31 @@ export function BlockRow(props: {
     }
     // Default: let the keystroke through; the bound input handler
     // updates the draft signal.
+  }
+
+  /**
+   * Auto-pair `(` / `[` / `{` and step over auto-inserted closers
+   * (issue #21) — same Insert-mode behaviour as the TUI. Typing the
+   * second `[` lands as `[[|]]`, so the `[[` ref flow keeps working
+   * without `autoClosePair` (the closer is never doubled).
+   * `beforeinput` (not keydown) so layouts that reach brackets via
+   * AltGr / Option dead keys are matched by the character actually
+   * produced, never by the physical key.
+   */
+  function handleBeforeInput(e: InputEvent) {
+    if (e.inputType !== "insertText" || e.isComposing) return;
+    const ta = textareaRef;
+    if (!ta) return;
+    if (ta.selectionStart !== ta.selectionEnd) return; // typing over a selection
+    const completion = autoPairBracket(ta.value, ta.selectionStart ?? 0, e.data ?? "");
+    if (!completion) return;
+    e.preventDefault();
+    setDraft(completion.value);
+    ta.value = completion.value;
+    ta.setSelectionRange(completion.caret, completion.caret);
+    // Setting the value programmatically doesn't fire `onInput`, and
+    // the caret may now sit inside a `[[…]]` — refresh the suggester.
+    refreshSuggest();
   }
 
   async function handlePaste(e: ClipboardEvent) {
@@ -561,6 +568,7 @@ export function BlockRow(props: {
                 onSelect={() => refreshSuggest()}
                 onBlur={() => void commit()}
                 onKeyDown={handleKeydown}
+                onBeforeInput={handleBeforeInput}
                 onPaste={handlePaste}
               />
               <RefSuggestPopup

--- a/crates/outl-frontend-shared/CLAUDE.md
+++ b/crates/outl-frontend-shared/CLAUDE.md
@@ -38,7 +38,7 @@ crates/outl-frontend-shared/
     │   ├── index.ts        # looksLikeOutline, utf16OffsetToCharOffset
     │   └── paste.test.ts
     └── autocomplete/
-        ├── index.ts        # autoClosePair, autoDeletePair, insertPair, insertText, detectRefContext, applySuggestion
+        ├── index.ts        # autoClosePair, autoPairBracket, autoDeletePair, insertPair, insertText, detectRefContext, applySuggestion
         └── autocomplete.test.ts
 ```
 
@@ -87,6 +87,7 @@ When in doubt, ship in the client; promote later when the second client appears.
 | `looksLikeOutline` | `@outl/shared/paste` | `outl_actions::paste::looks_like_outline` |
 | `utf16OffsetToCharOffset` | `@outl/shared/paste` | (runtime gap — UTF-16 ↔ codepoint, no Rust mirror) |
 | `detectRefContext`, `autoClose/DeletePair`, `insertPair/Text`, `applySuggestion` | `@outl/shared/autocomplete` | `outl_tui::actions::overlay::detect_trigger` |
+| `autoPairBracket` (single `(`/`[`/`{` auto-pair + closer step-over; `autoDeletePair` also collapses empty `()`/`[]`/`{}`) | `@outl/shared/autocomplete` | `outl_tui::input::insert` (`insert_pair`) + `EditBuffer::delete_pair_back` |
 | `<ParseWarningsBanner />` + `@outl/shared/warnings/styles` CSS | `@outl/shared/warnings` | TUI `view::warnings_banner` (visual parity, neutral chrome). Clients **must** `@import "@outl/shared/warnings/styles"` from their root stylesheet — without it the banner renders with unstyled neutral classes and looks invisible against the page. |
 | `ParseWarning` / `ParseWarningKind` (DTO of `PageView.warnings`) | `@outl/shared/api/types` | `outl_md::ParseWarning` / `ParseWarningKind` |
 | DTOs (`PageMeta`, `OutlineNode`, `BlockNode`, `Backlink`, `InlineToken`, `PageView`, `CreateBlockReply`, `WorkspaceSummary`, …) | `@outl/shared/api/types` | the corresponding `serde`-serialised Rust structs |

--- a/crates/outl-frontend-shared/src/autocomplete/autocomplete.test.ts
+++ b/crates/outl-frontend-shared/src/autocomplete/autocomplete.test.ts
@@ -4,6 +4,7 @@ import {
   applySuggestion,
   autoClosePair,
   autoDeletePair,
+  autoPairBracket,
   detectRefContext,
   insertPair,
   insertText,
@@ -35,6 +36,56 @@ describe("autoClosePair", () => {
   });
 });
 
+describe("autoPairBracket", () => {
+  it.each([
+    ["(", ")"],
+    ["[", "]"],
+    ["{", "}"],
+  ])("typing %s inserts the pair with the caret between", (open, close) => {
+    const result = autoPairBracket("ab", 1, open);
+    expect(result).toEqual({ value: `a${open}${close}b`, caret: 2 });
+  });
+
+  it("pairs at the very start and end of the value", () => {
+    expect(autoPairBracket("", 0, "(")).toEqual({ value: "()", caret: 1 });
+    expect(autoPairBracket("xy", 2, "{")).toEqual({ value: "xy{}", caret: 3 });
+  });
+
+  it("builds [[|]] when the second [ is typed inside an auto-paired []", () => {
+    // First `[` produced `[|]`; the second one must land as `[[|]]`
+    // so the existing `[[` ref flow keeps working (autoClosePair is
+    // a no-op on that shape — the closer is never doubled).
+    const result = autoPairBracket("a[]", 2, "[");
+    expect(result).toEqual({ value: "a[[]]", caret: 3 });
+    expect(autoClosePair(result!.value, result!.caret)).toBeNull();
+  });
+
+  it.each([")", "]", "}"])(
+    "typing %s over an identical closer steps past it",
+    (close) => {
+      const open = { ")": "(", "]": "[", "}": "{" }[close]!;
+      const value = `${open}x${close}`;
+      expect(autoPairBracket(value, 2, close)).toEqual({ value, caret: 3 });
+    },
+  );
+
+  it("steps over both closers of a doubled ref pair", () => {
+    expect(autoPairBracket("[[a]]", 3, "]")).toEqual({ value: "[[a]]", caret: 4 });
+    expect(autoPairBracket("[[a]]", 4, "]")).toEqual({ value: "[[a]]", caret: 5 });
+  });
+
+  it("lets a closer through when the next char differs", () => {
+    expect(autoPairBracket("(x", 2, ")")).toBeNull();
+    expect(autoPairBracket("(]", 1, ")")).toBeNull();
+  });
+
+  it("ignores non-bracket characters", () => {
+    expect(autoPairBracket("ab", 1, "x")).toBeNull();
+    expect(autoPairBracket("ab", 1, '"')).toBeNull();
+    expect(autoPairBracket("ab", 1, "")).toBeNull();
+  });
+});
+
 describe("autoDeletePair", () => {
   it("collapses an empty [[]] when caret is in the middle", () => {
     const result = autoDeletePair("foo [[]]", 6);
@@ -63,6 +114,33 @@ describe("autoDeletePair", () => {
 
   it("does not cross-mix [[ with ))", () => {
     expect(autoDeletePair("[[))", 2)).toBeNull();
+  });
+
+  it.each([
+    ["()", "("],
+    ["[]", "["],
+    ["{}", "{"],
+  ])("collapses an empty %s in one keystroke", (pair) => {
+    const result = autoDeletePair(`a${pair}b`, 2);
+    expect(result).toEqual({ value: "ab", caret: 1 });
+  });
+
+  it("prefers the doubled pair over the inner single pair", () => {
+    // Caret in `[[|]]` — the whole ref scaffold goes, not just `[]`.
+    expect(autoDeletePair("[[]]", 2)).toEqual({ value: "", caret: 0 });
+  });
+
+  it("collapses nested singles one level at a time", () => {
+    expect(autoDeletePair("([])", 2)).toEqual({ value: "()", caret: 1 });
+  });
+
+  it("does not collapse a single pair with content between", () => {
+    expect(autoDeletePair("(x)", 2)).toBeNull();
+  });
+
+  it("does not cross-mix single openers and closers", () => {
+    expect(autoDeletePair("(]", 1)).toBeNull();
+    expect(autoDeletePair("{)", 1)).toBeNull();
   });
 });
 

--- a/crates/outl-frontend-shared/src/autocomplete/index.ts
+++ b/crates/outl-frontend-shared/src/autocomplete/index.ts
@@ -64,35 +64,91 @@ export function autoClosePair(
   return null;
 }
 
+/** Single-character bracket pairs handled by {@link autoPairBracket}
+ *  and {@link autoDeletePair}. Mirrors the TUI's Insert-mode set
+ *  (`outl-tui/src/input/insert.rs`). */
+const BRACKET_PAIRS: Record<string, string> = {
+  "(": ")",
+  "[": "]",
+  "{": "}",
+};
+
+const BRACKET_CLOSERS = new Set(Object.values(BRACKET_PAIRS));
+
 /**
- * Inverse of {@link autoClosePair}: when the caret sits in the empty
- * middle of `[[]]` or `(())` and the user presses Backspace, delete
- * the whole pair in one shot so they don't have to mash backspace
- * four times to undo an aborted ref. Returns `null` when the caret
- * isn't between an empty pair — let the default backspace through.
+ * Auto-pair a single bracket keystroke, mirroring the TUI's Insert
+ * mode: typing `(`, `[` or `{` inserts the matching closer and
+ * leaves the caret between the two; typing `)`, `]` or `}` when that
+ * exact character already sits to the right of the caret steps over
+ * it instead of doubling (the closer was almost certainly
+ * auto-inserted, so the keystroke's intent is "move past it").
  *
- * Only fires for *empty* pairs (`[[]]`, `(())`). The moment the user
- * has typed something in the middle (`[[ave]]`), backspace goes
- * back to deleting one char at a time so they can fix typos.
+ * `typed` is the character the user is about to insert — callers
+ * intercept it in `beforeinput` (soft keyboards don't emit reliable
+ * `keydown` characters) and apply the returned value themselves.
+ * Returns `null` when `typed` isn't a bracket character; let the
+ * default insertion through.
+ *
+ * Pair insertion is deliberately unconditional, like the TUI's
+ * `insert_pair`: typing the second `[` next to an auto-inserted `]`
+ * yields `[[|]]` directly, which is exactly the shape the `[[` ref
+ * flow wants — and {@link autoClosePair} stays a no-op on it, so the
+ * two layers never double a closer.
+ */
+export function autoPairBracket(
+  value: string,
+  selection: number,
+  typed: string,
+): PairCompletion | null {
+  const close = BRACKET_PAIRS[typed];
+  if (close) {
+    return {
+      value: value.slice(0, selection) + typed + close + value.slice(selection),
+      caret: selection + 1,
+    };
+  }
+  if (BRACKET_CLOSERS.has(typed) && value[selection] === typed) {
+    return { value, caret: selection + 1 };
+  }
+  return null;
+}
+
+/**
+ * Inverse of {@link autoClosePair} / {@link autoPairBracket}: when
+ * the caret sits in the empty middle of a pair and the user presses
+ * Backspace, delete the whole pair in one shot so they don't have to
+ * mash backspace to undo an aborted ref or bracket. Returns `null`
+ * when the caret isn't between an empty pair — let the default
+ * backspace through.
+ *
+ * Doubled ref pairs (`[[]]`, `(())`) are checked first and collapse
+ * all four characters; the single-character pairs (`()`, `[]`, `{}`)
+ * collapse two. The moment the user has typed something in the
+ * middle (`[[ave]]`, `(x)`), backspace goes back to deleting one
+ * char at a time so they can fix typos.
  */
 export function autoDeletePair(
   value: string,
   selection: number,
 ): PairCompletion | null {
-  if (selection < 2) return null;
-  const left = value.slice(selection - 2, selection);
-  const right = value.slice(selection, selection + 2);
-  if (left === "[[" && right === "]]") {
-    return {
-      value: value.slice(0, selection - 2) + value.slice(selection + 2),
-      caret: selection - 2,
-    };
+  if (selection >= 2) {
+    const left = value.slice(selection - 2, selection);
+    const right = value.slice(selection, selection + 2);
+    if ((left === "[[" && right === "]]") || (left === "((" && right === "))")) {
+      return {
+        value: value.slice(0, selection - 2) + value.slice(selection + 2),
+        caret: selection - 2,
+      };
+    }
   }
-  if (left === "((" && right === "))") {
-    return {
-      value: value.slice(0, selection - 2) + value.slice(selection + 2),
-      caret: selection - 2,
-    };
+  if (selection >= 1) {
+    const close = BRACKET_PAIRS[value[selection - 1] ?? ""];
+    if (close !== undefined && value[selection] === close) {
+      return {
+        value: value.slice(0, selection - 1) + value.slice(selection + 1),
+        caret: selection - 1,
+      };
+    }
   }
   return null;
 }

--- a/crates/outl-mobile/CLAUDE.md
+++ b/crates/outl-mobile/CLAUDE.md
@@ -122,6 +122,7 @@ They were extracted to **`crates/outl-frontend-shared/`** so mobile and desktop 
 | `looksLikeOutline` | `@outl/shared/paste` | `outl_actions::paste::looks_like_outline` |
 | `<MarkdownInline />` (renderer of `InlineToken[]`) | `@outl/shared/markdown` | `outl_md::tokenize_owned` (backend produces the tokens; the renderer is a discriminant-to-JSX switch) |
 | `detectRefContext` (+ `autoClose/DeletePair`, `insertPair/Text`, `applySuggestion`) | `@outl/shared/autocomplete` | `outl_tui::actions::overlay::detect_trigger` (the `[[` and `((` triggers; TUI also covers `#` and `/`) |
+| `autoPairBracket` (auto-pair `(`/`[`/`{` + step over auto-inserted closers; wired through `BlockRow`'s `onBeforeInput` because iOS soft keyboards don't emit reliable per-char `keydown`) | `@outl/shared/autocomplete` | `outl_tui::input::insert` (`insert_pair`) + `EditBuffer::delete_pair_back` |
 | `utf16OffsetToCharOffset` | `@outl/shared/paste` | runtime gap, no Rust mirror — `textarea.selectionStart` is UTF-16; the backend expects codepoints. Skipping this conversion shifts the splice by one per supplementary-plane character |
 
 **Adding a new cross-runtime contract = add it in `@outl/shared` from day one.** Never add it under `outl-mobile/src/lib/` first — the next time desktop catches up to the feature, it has to consume from the same file.

--- a/crates/outl-mobile/src/components/BlockRow.tsx
+++ b/crates/outl-mobile/src/components/BlockRow.tsx
@@ -12,7 +12,11 @@ import { HighlightedCode, detectFence } from "@outl/shared/highlight";
 function detectFenceText(text: string) {
   return detectFence(text);
 }
-import { autoClosePair, autoDeletePair } from "@outl/shared/autocomplete";
+import {
+  autoClosePair,
+  autoDeletePair,
+  autoPairBracket,
+} from "@outl/shared/autocomplete";
 import { looksLikeOutline, utf16OffsetToCharOffset } from "@outl/shared/paste";
 import { haptic } from "../lib/haptics";
 import { rawTextWithTodo } from "../lib/outline";
@@ -540,6 +544,28 @@ function EditableTextarea(props: {
         // iOS WKWebView. `parkCaret` (called twice — once before and
         // once after `props.onInput` triggers Solid's `value=`
         // re-binding) keeps the caret where we asked.
+        ta.value = completion.value;
+        parkCaret(ta, completion.caret);
+        props.onInput(completion.value);
+        parkCaret(ta, completion.caret);
+        autoResize();
+      }}
+      onBeforeInput={(e) => {
+        // Auto-pair `(` / `[` / `{` and step over auto-inserted
+        // closers (issue #21) — same Insert-mode behaviour as the
+        // TUI. `beforeinput` (not keydown) because iOS soft
+        // keyboards don't emit reliable per-character key events;
+        // `insertText` with a single-char `data` is the one signal
+        // that survives every input method.
+        if (e.inputType !== "insertText" || e.isComposing) return;
+        const ta = e.currentTarget;
+        if (ta.selectionStart !== ta.selectionEnd) return; // typing over a selection
+        const caret = ta.selectionStart ?? 0;
+        const completion = autoPairBracket(ta.value, caret, e.data ?? "");
+        if (!completion) return;
+        e.preventDefault();
+        // Same caret-reset trap as Backspace above — park twice,
+        // around the Solid `value=` re-binding.
         ta.value = completion.value;
         parkCaret(ta, completion.caret);
         props.onInput(completion.value);


### PR DESCRIPTION
Implements #21 for **both** GUI clients (mobile + desktop), mirroring the TUI Insert mode.

## What changed

- **@outl/shared/autocomplete** (one owner, both clients wrap):
  - New `autoPairBracket`: typing `(`, `[` or `{` inserts the matching closer with the caret between (same as the TUI `insert_pair`, `outl-tui/src/input/insert.rs`); typing `)`, `]` or `}` over an identical closer steps past it instead of doubling.
  - `autoDeletePair` extended: Backspace inside an empty `()` / `[]` / `{}` collapses the whole pair; the doubled ref pairs (`[[]]` / `(())`) keep priority and collapse all four chars.
- **Mobile `BlockRow`**: wired through `onBeforeInput` — iOS soft keyboards do not emit reliable per-char `keydown`; `insertText` + single-char `data` is the one signal that survives every input method. Uses the existing double-`parkCaret` pattern around the Solid value re-binding.
- **Desktop `BlockRow`**: same `onBeforeInput` path; replaces the old keydown `[` / `(` microtask + `autoClosePair` block (also fixes AltGr/Option layouts, since beforeinput matches the produced character, not the physical key). `refreshSuggest` still runs so the `[[` popup opens.

## Design note (vs. the issue wording)

The issue asks to "skip when the next character is already the matching closer". Pair insertion is deliberately **unconditional** instead (exactly what the TUI does): with a skip, the second `[` typed inside an auto-paired `[|]` would land as `[[|]` and `autoClosePair` would complete it to `[[|]]]` — three closers. Unconditional insertion makes the second opener land as a complete `[[|]]`, on which `autoClosePair` is a no-op, so the existing `[[` -> `[[]]` and `((` -> `(())` flows (including the toolbar `insertPair` buttons) keep working and a closer is never doubled. The anti-doubling the issue is after is covered by the closer step-over.

## Tests

- 16 new cases in `autocomplete.test.ts` (pair insertion, `[[|]]` composition with `autoClosePair`, step-over, single/double collapse priority, no cross-mixing).
- `bun --filter @outl/shared test` -> 88 passed; mobile -> 27 passed; desktop -> 37 passed; `tsc --noEmit` clean on all three packages.
- Docs synced: root `CLAUDE.md`, `outl-frontend-shared/CLAUDE.md`, `outl-mobile/CLAUDE.md`, `outl-desktop/CLAUDE.md` (`docs/shortcuts.md` already advertised this behavior — it is now true).

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)
