### PR TITLE
fix(desktop): free Cmd+X for native cut + implement Cmd+Z/Cmd+Shift+Z undo/redo

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -378,7 +378,7 @@ UI-agnostic; TUI and mobile both consume them.
 
 #### 13. Code-block execution (outl-actions::exec)
 
-Cross-client glue every UI uses to wire a "run this fence" gesture (TUI `g x`, desktop `Cmd+X`, mobile long-press) into `outl-exec` and back. `outl_actions::exec::run_code_block` is the **only** entry point a Tauri command / TUI action should call — never re-implement flat-DFS / `.md` path / DTO per client.
+Cross-client glue every UI uses to wire a "run this fence" gesture (TUI `g x`, desktop `Cmd+Shift+X`, mobile long-press) into `outl-exec` and back. `outl_actions::exec::run_code_block` is the **only** entry point a Tauri command / TUI action should call — never re-implement flat-DFS / `.md` path / DTO per client.
 
 | Intent | Use this | File |
 |---|---|---|
@@ -402,6 +402,18 @@ Runtime selection (which languages ship) is per-binary via `outl-exec` features 
 | Per-actor write lock | `outl_core::ActorWriteLock::try_acquire` | `crates/outl-core/src/lock.rs` |
 | Resolve which actor this process writes as | `outl_core::resolve_write_actor` | `crates/outl-core/src/lock.rs` |
 | The `Storage` trait every backend implements (invariant #5) | `outl_core::Storage` / `StorageError` | `crates/outl-core/src/storage/mod.rs` |
+
+#### 15. Undo / redo history (outl-actions::history)
+
+Bounded snapshot stacks with vim semantics (a new edit clears redo) shared by GUI clients — the desktop's `Cmd+Z` / `Cmd+Shift+Z` ride these.
+Restores route through `outl_md::reconcile_md`, so an undo is **new ops in the log**, never a rewrite (invariant #1 holds).
+Not per-keystroke undo inside an uncommitted draft — that belongs to the client's editor widget.
+
+| Intent | Use this | File |
+|---|---|---|
+| Bounded undo / redo stacks over any snapshot type (`record` / `undo` / `redo` / `can_undo` / `can_redo` / `clear`) | `outl_actions::history::HistoryStacks` | `crates/outl-actions/src/history.rs` |
+| Default per-stack bound (matches the TUI's session cap) | `outl_actions::DEFAULT_HISTORY_CAP` | `crates/outl-actions/src/history.rs` |
+| Restore a page to a previously-rendered `.md` snapshot (write + reconcile → min ops through `Workspace::apply`) | `outl_actions::restore_page_md` | `crates/outl-actions/src/history.rs` |
 
 **Review checklist on every PR that adds a helper:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -503,7 +503,7 @@ UI-agnostic; both TUI and mobile consume them.
 
 #### 13. Code-block execution (outl-actions::exec)
 
-The **cross-client glue** every UI uses to wire a "run this fence" gesture (TUI `g x`, desktop `Cmd+X`, mobile long-press → "Run code") through to `outl-exec` and back. `outl_actions::exec::run_code_block` is the **only** entry point a Tauri command / TUI action should call — never re-implement the flat-DFS walk, the `.md` path lookup, or the DTO shape per client.
+The **cross-client glue** every UI uses to wire a "run this fence" gesture (TUI `g x`, desktop `Cmd+Shift+X`, mobile long-press → "Run code") through to `outl-exec` and back. `outl_actions::exec::run_code_block` is the **only** entry point a Tauri command / TUI action should call — never re-implement the flat-DFS walk, the `.md` path lookup, or the DTO shape per client.
 
 | Intent | Use this | File |
 |---|---|---|
@@ -527,6 +527,18 @@ The runtime catalog (which languages are available) is selected by the **binary*
 | Acquire the per-actor write lock (one process writing this actor's jsonl) | `outl_core::ActorWriteLock::try_acquire` | `crates/outl-core/src/lock.rs` |
 | Resolve which actor this process writes as | `outl_core::resolve_write_actor` | `crates/outl-core/src/lock.rs` |
 | The `Storage` trait every persistent backend implements (invariant #5) | `outl_core::Storage` / `StorageError` | `crates/outl-core/src/storage/mod.rs` |
+
+#### 15. Undo / redo history (outl-actions::history)
+
+Bounded snapshot stacks with vim semantics (a new edit clears redo) shared by GUI clients — the desktop's `Cmd+Z` / `Cmd+Shift+Z` ride these.
+Restores route through `outl_md::reconcile_md`, so an undo is **new ops in the log**, never a rewrite (invariant #1 holds).
+This is *not* per-keystroke undo inside an uncommitted draft — that belongs to the client's editor widget.
+
+| Intent | Use this | File |
+|---|---|---|
+| Bounded undo / redo stacks over any snapshot type (`record` / `undo` / `redo` / `can_undo` / `can_redo` / `clear`) | `outl_actions::history::HistoryStacks` | `crates/outl-actions/src/history.rs` |
+| Default per-stack bound (matches the TUI's session cap) | `outl_actions::DEFAULT_HISTORY_CAP` | `crates/outl-actions/src/history.rs` |
+| Restore a page to a previously-rendered `.md` snapshot (write + reconcile → min ops through `Workspace::apply`) | `outl_actions::restore_page_md` | `crates/outl-actions/src/history.rs` |
 
 If your need is **not** in this catalog and you've grepped honestly, that's a fair sign the primitive doesn't exist yet — add it in the upstream crate that owns the concept (usually `outl-md` for parse / render / sidecar / inline, `outl-actions` for workspace mutations and ingest, `outl-core` for op-log / tree / HLC), then update this catalog in the same commit.
 The hook will remind you to sync `copilot-instructions.md`.

--- a/crates/outl-actions/CLAUDE.md
+++ b/crates/outl-actions/CLAUDE.md
@@ -34,6 +34,7 @@ outl-cli / outl-tui / outl-mobile / future clients
 | `page`      | `PageMeta` (`id`, `slug`, `title`, `kind`, `icon`, **`pinned`** — surfaced from the `pinned::` page property so every client that consumes `list_all` sees the flag without re-querying the workspace index), `PageKind` (Page / Journal), `open_or_create`, `open_or_create_by_name` (slugifies a human-typed name + keeps it as the title — drives `[[ref]]`/`#tag` click handlers in TUI + mobile), `open_or_create_by_ref` (the canonical "user tapped a ref" decision tree — date → journal, literal/slugified/title match → existing page, else create), `open_journal`, `open_today`, `find_by_slug`, `list_all`, `migrate_legacy_into_today`, `journal_slug`, `journal_title`, `today`, `date_from_slug`, `previous_journal_date`, `next_journal_date`, `page_id_from_slug` (deterministic ID derivation so two peers agree on a fresh page's NodeId) |
 | `backlinks` | `Backlink`, `backlinks_for_target`, `backlinks_for_page` (a mention is a literal `[[target]]` **or** a `#tag` whose slug form resolves to the page — the same `slugify` rule a tag click goes through, so navigation and "Linked from" can't drift), `extract_refs` (parse `[[ref]]` tokens) |
 | `journal`   | `render_page_md`, `apply_page_md`, `apply_page_md_with_sidecar`, `apply_all_pages_md`, `mutate_page_md`, `journals_dir`, `pages_dir`, `page_md_path`, `write_md_atomic` |
+| `history`   | `HistoryStacks<T>` (bounded undo / redo stacks, vim semantics: a new edit clears redo), `DEFAULT_HISTORY_CAP`, `restore_page_md` (write a previously-rendered `.md` snapshot + reconcile it back — the restore is new ops through `Workspace::apply`, never a log rewrite). Drives the desktop's `Cmd+Z` / `Cmd+Shift+Z`; per-keystroke undo inside an uncommitted draft stays in the client's editor widget. |
 | `sync`      | `SyncEngine`, `OpsFileSnapshot`. Reload workspace from disk, re-project a page's `.md` + sidecar, snapshot peer jsonls (skipping own), scan for orphan `.md` files (no sidecar / stale hash). Shared by TUI poller + mobile iCloud watcher. |
 | `paste`     | `paste_markdown`, `PasteAnchor`, `PasteOutcome`, `normalize_external_syntax`. Converts external clipboard markdown (Roam `{{[[TODO]]}}`, GitHub `[ ]/[x]`, Logseq `id::`, 4-space indent) into outl syntax and grafts the bullet structure as blocks. Drives `Event::Paste` in the TUI and the mobile `paste_markdown_at` Tauri command. |
 | `error`     | `ActionError`                                                                  |
@@ -94,7 +95,8 @@ The historical "auto-preserve prefix" behaviour was removed because it made `TOD
 
 ## What this crate does NOT own
 
-- **UI state.** Selections, modes, keymaps, undo stack for in-flight text editing live in the clients.
+- **UI state.** Selections, modes, keymaps, and the undo stack for **in-flight text editing** (per-keystroke history inside an uncommitted draft) live in the clients.
+  Committed-mutation undo is different: the bounded snapshot stacks + `.md` restore live here in `history` so every GUI shares one engine.
 - **In-flight outline AST.** When the user is typing into a buffer that hasn't been parsed yet, the manipulation happens on `Vec<OutlineNode>` via `outl_md::outline_ops` (re-exported through the `outl-tui/src/outline_ops.rs` shim).
   We don't pull that up because it's not workspace-grounded — it's a stage *before* ops exist.
   It lives in `outl-md` because the mobile client also needs it, but no `Workspace` is touched, so it stays out of `outl-actions`.

--- a/crates/outl-actions/src/error.rs
+++ b/crates/outl-actions/src/error.rs
@@ -53,6 +53,11 @@ pub enum ActionError {
     #[error("sidecar: {0}")]
     Sidecar(#[from] outl_md::sidecar::SidecarError),
 
+    /// `.md` ↔ ops reconcile failure while restoring an undo / redo
+    /// snapshot (`history::restore_page_md`).
+    #[error("reconcile: {0}")]
+    Reconcile(#[from] outl_md::ReconcileError),
+
     /// Code-block execution orchestration failed (sidecar IO, op log
     /// apply, `.md` reconcile during the run). Runtime-level failures
     /// (`unknown language`, timeout) come back through the success

--- a/crates/outl-actions/src/history.rs
+++ b/crates/outl-actions/src/history.rs
@@ -1,0 +1,268 @@
+//! Bounded undo / redo snapshot stacks shared by GUI clients.
+//!
+//! Two bounded stacks with vim semantics: every committed mutation
+//! pushes a snapshot onto `undo`; `undo` pops to `redo`; `redo` pops
+//! back to `undo`; a **new edit clears `redo`** (a new edit branches
+//! history).
+//!
+//! The engine is generic over the snapshot type because each client
+//! decides what a "page state" is on its surface:
+//!
+//! - the desktop snapshots the page's rendered `.md`
+//!   (`journal::render_page_md`) per mutation and restores it with
+//!   `restore_page_md` below;
+//! - a future mobile undo can reuse the same pair unchanged.
+//!
+//! Restores route through `outl_md::reconcile_md` — the snapshot is
+//! written to the page's `.md` and reconciled back (matching → diff →
+//! ops through `Workspace::apply`), so an undo is *new ops in the
+//! log*, never a rewrite of it. The op log stays the single source of
+//! truth (invariant #1).
+//!
+//! This is **not** an in-flight text-editing undo: per-keystroke
+//! history inside an uncommitted draft belongs to the client's editor
+//! widget (the TUI's `EditBuffer`, the browser textarea), not here.
+
+use std::path::Path;
+
+use outl_core::hlc::HlcGenerator;
+use outl_core::id::NodeId;
+use outl_core::workspace::Workspace;
+
+use crate::error::ActionError;
+use crate::journal::{page_md_path, write_md_atomic};
+use crate::page::page_meta;
+
+/// Default bound for each stack. Matches the TUI's session history
+/// cap so a long session can't blow memory.
+pub const DEFAULT_HISTORY_CAP: usize = 200;
+
+/// Bounded undo / redo stacks over an arbitrary snapshot type.
+#[derive(Debug, Clone)]
+pub struct HistoryStacks<T> {
+    undo: Vec<T>,
+    redo: Vec<T>,
+    cap: usize,
+}
+
+impl<T> Default for HistoryStacks<T> {
+    fn default() -> Self {
+        Self::new(DEFAULT_HISTORY_CAP)
+    }
+}
+
+impl<T> HistoryStacks<T> {
+    /// Empty stacks holding at most `cap` snapshots per side.
+    pub fn new(cap: usize) -> Self {
+        Self {
+            undo: Vec::new(),
+            redo: Vec::new(),
+            cap,
+        }
+    }
+
+    /// Record the pre-mutation state. Clears the redo stack — vim
+    /// semantics: a new edit branches history.
+    pub fn record(&mut self, snapshot: T) {
+        self.undo.push(snapshot);
+        if self.undo.len() > self.cap {
+            self.undo.remove(0);
+        }
+        self.redo.clear();
+    }
+
+    /// Pop the most recent snapshot, stashing `current` on the redo
+    /// stack. Returns `None` (and leaves `current` unstashed) when
+    /// there is nothing to undo.
+    pub fn undo(&mut self, current: T) -> Option<T> {
+        let prev = self.undo.pop()?;
+        self.redo.push(current);
+        if self.redo.len() > self.cap {
+            self.redo.remove(0);
+        }
+        Some(prev)
+    }
+
+    /// Inverse of `undo`: pop from redo, stashing `current` back on
+    /// the undo stack.
+    pub fn redo(&mut self, current: T) -> Option<T> {
+        let next = self.redo.pop()?;
+        self.undo.push(current);
+        if self.undo.len() > self.cap {
+            self.undo.remove(0);
+        }
+        Some(next)
+    }
+
+    /// Whether an `undo` would succeed.
+    pub fn can_undo(&self) -> bool {
+        !self.undo.is_empty()
+    }
+
+    /// Whether a `redo` would succeed.
+    pub fn can_redo(&self) -> bool {
+        !self.redo.is_empty()
+    }
+
+    /// Drop both stacks. Call when the snapshots no longer describe
+    /// the live workspace — e.g. on workspace switch, or after a peer
+    /// merge **changed this page** (restoring a pre-merge snapshot
+    /// would silently revert the peer's edits). Don't clear for peer
+    /// merges that left the page untouched; the stacks are still
+    /// valid and the user keeps their undo depth.
+    pub fn clear(&mut self) {
+        self.undo.clear();
+        self.redo.clear();
+    }
+}
+
+/// Restore a page to a previously-captured `.md` snapshot.
+///
+/// Writes `md` to the page's canonical path and reconciles it back
+/// into the workspace — the 3-level matcher diffs the snapshot
+/// against the current sidecar and emits the minimum op sequence
+/// through `Workspace::apply`, so the restore converges across peers
+/// like any other edit and the op log is never rewritten.
+pub fn restore_page_md(
+    ws: &mut Workspace,
+    hlc: &HlcGenerator,
+    root: &Path,
+    page_id: NodeId,
+    md: &str,
+) -> Result<(), ActionError> {
+    let meta = page_meta(ws, page_id).ok_or_else(|| ActionError::NotInTree(page_id.to_string()))?;
+    let path = page_md_path(root, &meta);
+    write_md_atomic(&path, md)?;
+    outl_md::reconcile::reconcile_md(ws, hlc, &path, None)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block::{append_block, edit_text};
+    use crate::journal::{apply_page_md_with_sidecar, render_page_md};
+    use crate::page::{open_or_create, PageKind};
+    use outl_core::id::ActorId;
+    use tempfile::TempDir;
+
+    #[test]
+    fn undo_redo_round_trip() {
+        let mut h: HistoryStacks<&str> = HistoryStacks::new(10);
+        assert!(!h.can_undo());
+        assert!(h.undo("now").is_none());
+
+        h.record("v1");
+        h.record("v2");
+        assert_eq!(h.undo("v3"), Some("v2"));
+        assert!(h.can_redo());
+        assert_eq!(h.redo("v2"), Some("v3"));
+        assert_eq!(h.undo("v3"), Some("v2"));
+        assert_eq!(h.undo("v2"), Some("v1"));
+        assert!(h.undo("v1").is_none());
+    }
+
+    #[test]
+    fn record_clears_redo() {
+        let mut h: HistoryStacks<i32> = HistoryStacks::new(10);
+        h.record(1);
+        assert_eq!(h.undo(2), Some(1));
+        assert!(h.can_redo());
+        h.record(1);
+        assert!(!h.can_redo(), "a new edit must branch history");
+    }
+
+    #[test]
+    fn cap_evicts_oldest() {
+        let mut h: HistoryStacks<i32> = HistoryStacks::new(2);
+        h.record(1);
+        h.record(2);
+        h.record(3);
+        assert_eq!(h.undo(4), Some(3));
+        assert_eq!(h.undo(3), Some(2));
+        assert!(h.undo(2).is_none(), "snapshot 1 must have been evicted");
+    }
+
+    /// Replicates the desktop's exact record / undo loop
+    /// (`finish_in_page_with` + `step_history`) across **multiple**
+    /// consecutive undos — pins that the engine walks the whole
+    /// stack, not just the most recent mutation.
+    #[test]
+    fn consecutive_undos_walk_back_multiple_mutations() {
+        let actor = ActorId::new();
+        let hlc = HlcGenerator::new(actor);
+        let mut ws = Workspace::open_in_memory(actor).unwrap();
+        let tmp = TempDir::new().unwrap();
+
+        let page = open_or_create(&mut ws, &hlc, "ideas", "Ideas", PageKind::Page).unwrap();
+        let block = append_block(&mut ws, &hlc, Some(page), Some("one")).unwrap();
+        apply_page_md_with_sidecar(&ws, tmp.path(), page).unwrap();
+
+        let mut h: HistoryStacks<String> = HistoryStacks::default();
+
+        // Three committed mutations, each recorded the way
+        // `finish_in_page_with` does (pre-mutation render).
+        for text in ["two", "three", "four"] {
+            let before = render_page_md(&ws, page);
+            edit_text(&mut ws, &hlc, block, text).unwrap();
+            assert_ne!(render_page_md(&ws, page), before);
+            h.record(before);
+            apply_page_md_with_sidecar(&ws, tmp.path(), page).unwrap();
+        }
+        assert_eq!(render_page_md(&ws, page), "- four\n");
+
+        // Three undos, each the way `step_history` does it.
+        for expected in ["- three\n", "- two\n", "- one\n"] {
+            let current = render_page_md(&ws, page);
+            let snapshot = h.undo(current).expect("stack must not run dry");
+            restore_page_md(&mut ws, &hlc, tmp.path(), page, &snapshot).unwrap();
+            assert_eq!(render_page_md(&ws, page), expected);
+        }
+        let current = render_page_md(&ws, page);
+        assert!(h.undo(current).is_none(), "exactly three steps recorded");
+
+        // And redo walks forward again.
+        for expected in ["- two\n", "- three\n", "- four\n"] {
+            let current = render_page_md(&ws, page);
+            let snapshot = h.redo(current).expect("redo stack must not run dry");
+            restore_page_md(&mut ws, &hlc, tmp.path(), page, &snapshot).unwrap();
+            assert_eq!(render_page_md(&ws, page), expected);
+        }
+    }
+
+    #[test]
+    fn restore_page_md_round_trips_through_ops() {
+        let actor = ActorId::new();
+        let hlc = HlcGenerator::new(actor);
+        let mut ws = Workspace::open_in_memory(actor).unwrap();
+        let tmp = TempDir::new().unwrap();
+
+        let page = open_or_create(&mut ws, &hlc, "ideas", "Ideas", PageKind::Page).unwrap();
+        let block = append_block(&mut ws, &hlc, Some(page), Some("first")).unwrap();
+        apply_page_md_with_sidecar(&ws, tmp.path(), page).unwrap();
+        let snapshot = render_page_md(&ws, page);
+        let ops_before = ws.log().len();
+
+        edit_text(&mut ws, &hlc, block, "changed").unwrap();
+        apply_page_md_with_sidecar(&ws, tmp.path(), page).unwrap();
+        assert_eq!(ws.block_text(block).as_deref(), Some("changed"));
+
+        restore_page_md(&mut ws, &hlc, tmp.path(), page, &snapshot).unwrap();
+
+        // Note: a >20% text rewrite drops to level-3 matching, so the
+        // restored block may carry a fresh NodeId — same semantics as
+        // the TUI's snapshot undo, which restores through the same
+        // reconcile path. The projection is what must round-trip.
+        assert_eq!(
+            render_page_md(&ws, page),
+            snapshot,
+            "undo must restore the page projection"
+        );
+        assert!(
+            ws.log().len() > ops_before,
+            "the restore must append ops, never rewind the log"
+        );
+        let on_disk = std::fs::read_to_string(tmp.path().join("pages/ideas.md")).unwrap();
+        assert_eq!(on_disk, snapshot, "the .md on disk must match the snapshot");
+    }
+}

--- a/crates/outl-actions/src/lib.rs
+++ b/crates/outl-actions/src/lib.rs
@@ -54,6 +54,7 @@ pub mod block;
 pub mod collapsed;
 pub mod error;
 pub mod exec;
+pub mod history;
 pub mod journal;
 pub mod outline;
 pub mod page;
@@ -73,6 +74,7 @@ pub use block::{
 pub use collapsed::{set_block_collapsed, toggle_block_collapsed};
 pub use error::ActionError;
 pub use exec::{run_code_block, ExecOutputDto, RunCodeBlockOutcome};
+pub use history::{restore_page_md, HistoryStacks, DEFAULT_HISTORY_CAP};
 pub use journal::{
     apply_all_pages_md, apply_page_md, apply_page_md_with_sidecar, journals_dir, mutate_page_md,
     page_md_path, pages_dir, render_page_md, write_md_atomic,

--- a/crates/outl-desktop/CLAUDE.md
+++ b/crates/outl-desktop/CLAUDE.md
@@ -140,7 +140,7 @@ The Vite dev server runs on **port 1421** so it can coexist with `outl-mobile` (
 
 | Layer | Tool | What it covers |
 |-------|------|----------------|
-| Rust commands | `cargo test -p outl-desktop` | command shims, settings IO, fs_watcher (Phases 1+) |
+| Rust commands | `cargo test -p outl-desktop` | command shims, settings IO, fs_watcher (Phases 1+), surgical undo invalidation across a peer reload (`helpers::invalidate_changed_history` — only pages whose projection changed lose their stacks) |
 | Frontend logic | `bun --filter outl-desktop test` | scaffold smoke (today), components + helpers (Phases 1+) |
 
 Frontend suites today: `src/setup.test.ts` (scaffold smoke — `@outl/shared` alias resolves), `src/lib/chord-format.test.ts`, `src/lib/markdown-wrap.test.ts`, `src/lib/outline-walk.test.ts`, and `src/lib/action-handlers.test.ts` (regression tests for the `OpenRefUnderCursor` handler — Normal-mode `Enter` enters Insert on the selected block even when it carries a `[[ref]]`, and only a backlink-row selection opens the source page; pins #70).

--- a/crates/outl-desktop/CLAUDE.md
+++ b/crates/outl-desktop/CLAUDE.md
@@ -160,7 +160,7 @@ Two of these chords also have **visible icon affordances** in a fixed bottom-lef
 | `Cmd/Ctrl+T` | Toggle TODO / DONE on the focused / selected block (T for **t**ask) |
 | `Cmd/Ctrl+Enter` | Toggle TODO / DONE on the focused / selected block (alt) |
 | `Cmd/Ctrl+Shift+Enter` | Commit + create a sibling block below |
-| `Cmd/Ctrl+X` | E**x**ecute the focused / selected code block (mirrors the TUI's `g x` chord) |
+| `Cmd/Ctrl+Shift+X` | E**x**ecute the focused / selected code block (mirrors the TUI's `g x` chord). Inside a textarea the Insert-mode strikethrough binding wins (mode-specific beats Global) — commit first or use the per-block run button. |
 | `Cmd/Ctrl+[` / `]` | Previous / next journal day |
 | `Cmd/Ctrl+Shift+E` | Toggle sidebar (mirrors VS Code's explorer chord) |
 | `Cmd/Ctrl+Shift+B` | Toggle backlinks panel |
@@ -168,6 +168,22 @@ Two of these chords also have **visible icon affordances** in a fixed bottom-lef
 
 > **Why `Cmd+J` for the journal and not `Cmd+T`?** `T` is universally "task" in outliners (TUI's `Ctrl+T`, Logseq's `Cmd+T`, every Markdown task list shortcut). We don't make the user re-learn that. `J` for **journal** is unambiguous and lines up with the `g j` chord the TUI uses.
 > **Why not `Cmd+B` / `Cmd+\`?** `Cmd+B` is **reserved for bold** in every popular markdown editor (Notion, Obsidian, Discord, Slack) — retraining users on a non-standard meaning is hostile. `Cmd+\` is **1Password's** global autofill chord on macOS; hijacking it breaks every user with 1Password installed.
+> **Why did `Cmd+X` stop running code blocks?** It shadowed the OS-universal **cut** inside every textarea (the dispatcher `preventDefault`s matched Global chords even in Insert mode). Clipboard muscle memory beats the e**x**ecute mnemonic in a text-editing app, so run-code moved to `Cmd+Shift+X` and plain `Cmd+X` now falls through to the webview's native cut. See issue #80.
+
+### Undo / redo (Normal mode — fire when no textarea is focused)
+
+| Chord | Action |
+|---|---|
+| `Cmd/Ctrl+Z` | Undo the last committed block mutation on the current page |
+| `Cmd/Ctrl+Shift+Z` | Redo it |
+| `u` / `Ctrl+R` | Same actions, vim spelling (TUI parity) |
+
+Deliberately **Normal**, not Global: with a textarea focused the chord falls through to the webview (the in-flight draft is the textarea's own undo domain), and a Global binding would `preventDefault` it away.
+History is **block-level**: each mutation that goes through `finish_in_page` (edit, create, indent / outdent, move, delete, TODO / quote toggle, paste) pushes the page's pre-mutation `.md` render onto a bounded per-page stack (`outl_actions::history::HistoryStacks`); undo restores the snapshot through `outl_md::reconcile_md`, so the restore is itself ops in the log — the op log stays the source of truth, nothing is rewritten.
+Fold toggles (`set_block_collapsed`) bypass `finish_in_page` and are not undoable, matching their "view state, not content" semantics.
+Invalidation is **surgical**: a workspace **switch** clears every stack, but a peer-driven **reload** (`peer-ops-changed` → `reload_workspace`) drops only the stacks of pages whose projection actually changed across the reload — restoring one of those would silently revert the peer's edits.
+Pages the peer didn't touch keep their full undo depth.
+(The first cut cleared everything on every reload, which capped `Cmd+Z` at one step whenever the TUI was open on the same workspace — every TUI write fires `peer-ops-changed`.)
 
 ### Inline markdown (Insert mode — fire when a textarea is focused)
 
@@ -190,7 +206,8 @@ Implementation lives in `lib/markdown-wrap.ts`: each handler reads `document.act
 | `Enter` | Insert a `\n` inside the current block (multi-line text) |
 | `Cmd/Ctrl+Shift+Enter` | Commit + create a sibling below + edit it |
 | `Cmd/Ctrl+T` / `Cmd/Ctrl+Enter` | Toggle TODO / DONE on this block |
-| `Cmd/Ctrl+X` | Run the code block (mirrors TUI's `g x`) |
+| `Cmd/Ctrl+X` | Native cut — falls through to the webview (no catalog binding matches inside a textarea) |
+| `Cmd/Ctrl+Z` | Falls through to the webview too, but native per-keystroke undo is still broken: the controlled `value={draft()}` binding resets the textarea's undo stack on every keystroke (tracked as follow-up in issue #80) |
 | `Tab` / `Shift-Tab` | Indent / outdent |
 | `Esc` / blur | Commit |
 | `Backspace` on empty | Delete the block |

--- a/crates/outl-desktop/src-tauri/src/commands/history.rs
+++ b/crates/outl-desktop/src-tauri/src/commands/history.rs
@@ -1,0 +1,63 @@
+//! Undo / redo commands.
+//!
+//! Thin adapters over `outl_actions::history` — the stacks live in
+//! `AppState::history` (one per page, snapshots are the page's
+//! rendered `.md`), the restore routes through
+//! `outl_actions::restore_page_md` so every undo / redo is new ops in
+//! the log. `finish_in_page_with` (helpers.rs) is the recording side
+//! of this pair.
+
+use outl_actions::render_page_md;
+use tauri::State;
+
+use crate::helpers::{build_page_view, parse_node_id, storage_root_or_err, with_ws_mut};
+use crate::state::{AppState, PageView};
+
+enum Direction {
+    Undo,
+    Redo,
+}
+
+/// Revert the last committed mutation on `page_id`. Errors with
+/// `"nothing to undo"` when the stack is empty so the frontend can
+/// surface it as a status message.
+#[tauri::command]
+pub(crate) fn undo_page(page_id: String, state: State<'_, AppState>) -> Result<PageView, String> {
+    step_history(&state, &page_id, Direction::Undo)
+}
+
+/// Re-apply the mutation the last `undo_page` reverted.
+#[tauri::command]
+pub(crate) fn redo_page(page_id: String, state: State<'_, AppState>) -> Result<PageView, String> {
+    step_history(&state, &page_id, Direction::Redo)
+}
+
+fn step_history(
+    state: &State<'_, AppState>,
+    page_id: &str,
+    direction: Direction,
+) -> Result<PageView, String> {
+    let root = storage_root_or_err(state)?;
+    let page = parse_node_id(page_id)?;
+    with_ws_mut(state, |ws| {
+        let current = render_page_md(ws, page);
+        let snapshot = {
+            let mut map = state.history.lock();
+            let stacks = map.entry(page).or_default();
+            match direction {
+                Direction::Undo => stacks.undo(current),
+                Direction::Redo => stacks.redo(current),
+            }
+        }
+        .ok_or_else(|| {
+            match direction {
+                Direction::Undo => "nothing to undo",
+                Direction::Redo => "nothing to redo",
+            }
+            .to_string()
+        })?;
+        outl_actions::restore_page_md(ws, &state.hlc, &root, page, &snapshot)
+            .map_err(|e| e.to_string())?;
+        build_page_view(ws, &root, page).map_err(|e| e.to_string())
+    })
+}

--- a/crates/outl-desktop/src-tauri/src/commands/mod.rs
+++ b/crates/outl-desktop/src-tauri/src/commands/mod.rs
@@ -8,6 +8,7 @@
 //! - [`page`] — open and navigate pages and journals.
 //! - [`block`] — every block mutation (create, edit, todo, indent,
 //!   move, paste, collapsed).
+//! - [`history`] — undo / redo of committed block mutations.
 //!
 //! Every command is re-exported at this level so
 //! `tauri::generate_handler!` in `lib.rs` doesn't have to know about
@@ -15,6 +16,7 @@
 
 pub(crate) mod block;
 pub(crate) mod exec;
+pub(crate) mod history;
 pub(crate) mod page;
 pub(crate) mod shortcuts;
 pub(crate) mod theme;
@@ -22,6 +24,7 @@ pub(crate) mod workspace;
 
 pub(crate) use block::*;
 pub(crate) use exec::*;
+pub(crate) use history::*;
 pub(crate) use page::*;
 pub(crate) use shortcuts::*;
 pub(crate) use theme::*;

--- a/crates/outl-desktop/src-tauri/src/commands/workspace.rs
+++ b/crates/outl-desktop/src-tauri/src/commands/workspace.rs
@@ -2,7 +2,8 @@
 
 use std::path::PathBuf;
 
-use outl_actions::open_today;
+use outl_actions::{open_today, render_page_md};
+use outl_core::id::NodeId;
 use tauri::{Emitter, State};
 use tracing::warn;
 
@@ -34,6 +35,8 @@ pub(crate) fn set_workspace(
 
     *state.workspace.lock() = Some(workspace);
     *state.storage_root.lock() = Some(path.clone());
+    // Undo snapshots belong to the previous workspace.
+    state.history.lock().clear();
 
     // (Re)start the FS watcher for the new root. Dropping the
     // previous handle inside `swap_watcher` stops watching the
@@ -148,7 +151,33 @@ pub(crate) fn reload_workspace(
         .map_err(|e| format!("reload workspace: {e}"))?;
     let today_id = open_today(&mut fresh, &state.hlc).map_err(|e| e.to_string())?;
     let _ = engine.reproject_page(&fresh, today_id);
+    // Surgical undo invalidation: only pages whose projection actually
+    // changed across the reload lose their stacks. Restoring a
+    // snapshot of a page the peer DID change would silently revert the
+    // peer's edits — those stacks go. But a blanket `clear()` here
+    // capped `Cmd+Z` at one step whenever the TUI was open on the same
+    // workspace: every TUI write fires `peer-ops-changed` → reload,
+    // and the only snapshot surviving was the one recorded after the
+    // last reload.
+    let stale: Vec<NodeId> = {
+        let ws_guard = state.workspace.lock();
+        let history = state.history.lock();
+        match ws_guard.as_ref() {
+            Some(old) => history
+                .keys()
+                .filter(|id| render_page_md(old, **id) != render_page_md(&fresh, **id))
+                .copied()
+                .collect(),
+            None => history.keys().copied().collect(),
+        }
+    };
     *state.workspace.lock() = Some(fresh);
+    {
+        let mut history = state.history.lock();
+        for id in stale {
+            history.remove(&id);
+        }
+    }
     // Same split as `set_workspace` and the boot opener — reconcile
     // legacy / peer-pushed `.md` files in the background so the
     // frontend doesn't wait.

--- a/crates/outl-desktop/src-tauri/src/commands/workspace.rs
+++ b/crates/outl-desktop/src-tauri/src/commands/workspace.rs
@@ -2,8 +2,7 @@
 
 use std::path::PathBuf;
 
-use outl_actions::{open_today, render_page_md};
-use outl_core::id::NodeId;
+use outl_actions::open_today;
 use tauri::{Emitter, State};
 use tracing::warn;
 
@@ -158,26 +157,14 @@ pub(crate) fn reload_workspace(
     // capped `Cmd+Z` at one step whenever the TUI was open on the same
     // workspace: every TUI write fires `peer-ops-changed` → reload,
     // and the only snapshot surviving was the one recorded after the
-    // last reload.
-    let stale: Vec<NodeId> = {
-        let ws_guard = state.workspace.lock();
-        let history = state.history.lock();
-        match ws_guard.as_ref() {
-            Some(old) => history
-                .keys()
-                .filter(|id| render_page_md(old, **id) != render_page_md(&fresh, **id))
-                .copied()
-                .collect(),
-            None => history.keys().copied().collect(),
-        }
-    };
-    *state.workspace.lock() = Some(fresh);
+    // last reload. The rule lives in `helpers::invalidate_changed_history`
+    // so it stays unit-testable without a Tauri `AppHandle`.
     {
+        let old_guard = state.workspace.lock();
         let mut history = state.history.lock();
-        for id in stale {
-            history.remove(&id);
-        }
+        crate::helpers::invalidate_changed_history(old_guard.as_ref(), &fresh, &mut history);
     }
+    *state.workspace.lock() = Some(fresh);
     // Same split as `set_workspace` and the boot opener — reconcile
     // legacy / peer-pushed `.md` files in the background so the
     // frontend doesn't wait.

--- a/crates/outl-desktop/src-tauri/src/helpers.rs
+++ b/crates/outl-desktop/src-tauri/src/helpers.rs
@@ -3,13 +3,14 @@
 //! Argument parsing, workspace-lock acquisition, and the
 //! `finish_in_page` pattern that every mutation funnels through.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use chrono::NaiveDate;
 use outl_actions::{
     apply_page_md_with_sidecar, backlinks_for_page, date_from_slug, page_meta as page_meta_action,
-    read_page_outline_with_workspace, render_page_md, ActionError, PageOutline,
+    read_page_outline_with_workspace, render_page_md, ActionError, HistoryStacks, PageOutline,
 };
 use outl_core::id::NodeId;
 use outl_core::workspace::Workspace;
@@ -27,6 +28,40 @@ pub(crate) fn parse_node_id(s: &str) -> Result<NodeId, String> {
 
 pub(crate) fn parse_date(slug: &str) -> Result<NaiveDate, String> {
     date_from_slug(slug).ok_or_else(|| format!("invalid date slug: {slug}"))
+}
+
+/// Surgical undo invalidation across a peer-driven reload.
+///
+/// Drops the undo / redo stacks of **only** the pages whose `.md`
+/// projection actually changed between `old` and `fresh`. Restoring a
+/// pre-reload snapshot of a page the peer DID change would silently
+/// revert the peer's edits, so those stacks have to go — but a blanket
+/// clear capped `Cmd+Z` at a single step whenever a peer (e.g. the TUI
+/// on the same workspace) wrote anything, because every peer write
+/// fires `peer-ops-changed` → `reload_workspace`. Pages the reload
+/// left untouched keep their full undo depth.
+///
+/// `old` is `None` only when the workspace wasn't loaded yet; with no
+/// baseline to diff against, every stale stack is dropped.
+///
+/// Extracted from [`crate::commands::workspace::reload_workspace`] so
+/// the rule is unit-testable without a Tauri `AppHandle`.
+pub(crate) fn invalidate_changed_history(
+    old: Option<&Workspace>,
+    fresh: &Workspace,
+    history: &mut HashMap<NodeId, HistoryStacks<String>>,
+) {
+    let stale: Vec<NodeId> = match old {
+        Some(old) => history
+            .keys()
+            .filter(|id| render_page_md(old, **id) != render_page_md(fresh, **id))
+            .copied()
+            .collect(),
+        None => history.keys().copied().collect(),
+    };
+    for id in stale {
+        history.remove(&id);
+    }
 }
 
 /// Acquire a read-only handle to the workspace. Returns the
@@ -134,4 +169,98 @@ where
         let view = build_page_view(ws, &root, page_id).map_err(|e| e.to_string())?;
         Ok((value, view))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use outl_actions::{append_block, open_or_create_page as open_or_create, PageKind};
+    use outl_core::hlc::HlcGenerator;
+    use outl_core::id::ActorId;
+
+    /// Build a workspace with two pages (`alpha`, `beta`), each with a
+    /// single block. Page ids are derived deterministically from the
+    /// slug (`page_id_from_slug`), so a second workspace built the same
+    /// way agrees on the ids — exactly what a peer reload relies on.
+    fn workspace_with_two_pages(actor: ActorId, hlc: &HlcGenerator) -> (Workspace, NodeId, NodeId) {
+        let mut ws = Workspace::open_in_memory(actor).unwrap();
+        let alpha = open_or_create(&mut ws, hlc, "alpha", "Alpha", PageKind::Page).unwrap();
+        append_block(&mut ws, hlc, Some(alpha), Some("alpha one")).unwrap();
+        let beta = open_or_create(&mut ws, hlc, "beta", "Beta", PageKind::Page).unwrap();
+        append_block(&mut ws, hlc, Some(beta), Some("beta one")).unwrap();
+        (ws, alpha, beta)
+    }
+
+    /// Avelino's requested integration test for the surgical history
+    /// invalidation (#82): two pages, history recorded on both, a peer
+    /// reload that changed **only one** of them must drop only that
+    /// page's stack and leave the untouched page's `can_undo` intact.
+    #[test]
+    fn surgical_invalidation_keeps_untouched_page_undoable() {
+        let actor = ActorId::new();
+        let hlc = HlcGenerator::new(actor);
+
+        // 1. Two pages, each with a block.
+        let (old, alpha, beta) = workspace_with_two_pages(actor, &hlc);
+
+        // 2. Record an undo snapshot on both (the pre-mutation render,
+        //    exactly as `finish_in_page_with` does).
+        let mut history: HashMap<NodeId, HistoryStacks<String>> = HashMap::new();
+        history
+            .entry(alpha)
+            .or_default()
+            .record(render_page_md(&old, alpha));
+        history
+            .entry(beta)
+            .or_default()
+            .record(render_page_md(&old, beta));
+        assert!(history[&alpha].can_undo());
+        assert!(history[&beta].can_undo());
+
+        // 3. A peer reload that touched ONLY `beta`. Rebuilding the
+        //    same two slugs yields the same page ids; `beta` gets an
+        //    extra block so its projection diverges, `alpha`'s doesn't.
+        let (mut fresh, _, fresh_beta) = workspace_with_two_pages(actor, &hlc);
+        append_block(&mut fresh, &hlc, Some(fresh_beta), Some("beta two")).unwrap();
+        assert_eq!(
+            render_page_md(&old, alpha),
+            render_page_md(&fresh, alpha),
+            "alpha must be byte-identical across the reload"
+        );
+        assert_ne!(
+            render_page_md(&old, beta),
+            render_page_md(&fresh, beta),
+            "beta must have diverged"
+        );
+
+        invalidate_changed_history(Some(&old), &fresh, &mut history);
+
+        // 4. The untouched page keeps its undo depth; the changed page
+        //    lost its (now-misleading) stack.
+        assert!(
+            history.get(&alpha).is_some_and(|h| h.can_undo()),
+            "alpha was untouched by the reload — its undo must survive"
+        );
+        assert!(
+            !history.contains_key(&beta),
+            "beta changed across the reload — its stack must be dropped"
+        );
+    }
+
+    /// With no prior workspace to diff against, every recorded stack is
+    /// stale and must be dropped (the `None` arm).
+    #[test]
+    fn invalidation_with_no_baseline_clears_everything() {
+        let actor = ActorId::new();
+        let hlc = HlcGenerator::new(actor);
+        let (fresh, alpha, beta) = workspace_with_two_pages(actor, &hlc);
+
+        let mut history: HashMap<NodeId, HistoryStacks<String>> = HashMap::new();
+        history.entry(alpha).or_default().record(String::new());
+        history.entry(beta).or_default().record(String::new());
+
+        invalidate_changed_history(None, &fresh, &mut history);
+
+        assert!(history.is_empty(), "no baseline → drop every stack");
+    }
 }

--- a/crates/outl-desktop/src-tauri/src/helpers.rs
+++ b/crates/outl-desktop/src-tauri/src/helpers.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 use chrono::NaiveDate;
 use outl_actions::{
     apply_page_md_with_sidecar, backlinks_for_page, date_from_slug, page_meta as page_meta_action,
-    read_page_outline_with_workspace, ActionError, PageOutline,
+    read_page_outline_with_workspace, render_page_md, ActionError, PageOutline,
 };
 use outl_core::id::NodeId;
 use outl_core::workspace::Workspace;
@@ -113,7 +113,21 @@ where
 {
     let root = storage_root_or_err(state)?;
     with_ws_mut(state, |ws| {
+        // Capture the pre-mutation projection for undo. Recorded only
+        // when the mutation actually changed the page render, so
+        // no-op commands (indent with no previous sibling, an edit
+        // committing identical text) don't turn `Cmd+Z` into a
+        // visible nothing.
+        let before = render_page_md(ws, page_id);
         let value = f(ws).map_err(|e| e.to_string())?;
+        if render_page_md(ws, page_id) != before {
+            state
+                .history
+                .lock()
+                .entry(page_id)
+                .or_default()
+                .record(before);
+        }
         if let Err(e) = apply_page_md_with_sidecar(ws, &root, page_id) {
             warn!("page md+sidecar sync failed: {e}");
         }

--- a/crates/outl-desktop/src-tauri/src/lib.rs
+++ b/crates/outl-desktop/src-tauri/src/lib.rs
@@ -53,9 +53,9 @@ use crate::commands::{
     create_block, current_workspace, date_title, delete_block, edit_block, get_settings, get_theme,
     indent_block, list_all_pages, list_shortcut_bindings, list_themes, move_block_down,
     move_block_up, next_day, open_journal_for, open_page_by_slug, open_ref, open_today_journal,
-    outdent_block, outl_emoji_search, paste_markdown_at, previous_day, reload_workspace,
+    outdent_block, outl_emoji_search, paste_markdown_at, previous_day, redo_page, reload_workspace,
     resolve_ref, run_code_block, search_pages, search_persons, set_block_collapsed, set_workspace,
-    today_slug_cmd, toggle_quote, toggle_todo, update_settings, workspace_stats,
+    today_slug_cmd, toggle_quote, toggle_todo, undo_page, update_settings, workspace_stats,
 };
 use crate::state::AppState;
 use crate::workspace_open::{load_or_create_actor, spawn_workspace_opener};
@@ -106,6 +106,7 @@ pub fn run() {
                 app_config_dir,
                 registry,
                 fs_watcher,
+                history: Mutex::new(std::collections::HashMap::new()),
             });
 
             Ok(())
@@ -150,6 +151,9 @@ pub fn run() {
             move_block_down,
             set_block_collapsed,
             paste_markdown_at,
+            // Undo / redo
+            undo_page,
+            redo_page,
             // Code execution
             run_code_block,
         ])

--- a/crates/outl-desktop/src-tauri/src/state.rs
+++ b/crates/outl-desktop/src-tauri/src/state.rs
@@ -6,11 +6,13 @@
 //! swap workspaces at runtime and the background opener thread writes
 //! into them.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use outl_actions::{Backlink, OutlineNode, PageMeta};
+use outl_actions::{Backlink, HistoryStacks, OutlineNode, PageMeta};
 use outl_core::hlc::HlcGenerator;
+use outl_core::id::NodeId;
 use outl_core::workspace::Workspace;
 use outl_exec::RuntimeRegistry;
 use parking_lot::Mutex;
@@ -49,6 +51,15 @@ pub(crate) struct AppState {
     /// (replaced) when the user switches workspaces; `None` while
     /// the picker is still up.
     pub fs_watcher: Arc<Mutex<Option<WatcherHandle>>>,
+    /// Per-page undo / redo stacks of rendered `.md` snapshots
+    /// (`outl_actions::history::HistoryStacks`). `finish_in_page_with`
+    /// records the pre-mutation render; `undo_page` / `redo_page`
+    /// restore one through `outl_actions::restore_page_md` (the
+    /// restore is ops in the log, never a rewrite). Fully cleared on
+    /// workspace **switch**; on a peer-driven **reload** only the
+    /// pages whose projection changed lose their stacks (see
+    /// `commands::workspace::reload_workspace`).
+    pub history: Mutex<HashMap<NodeId, HistoryStacks<String>>>,
 }
 
 /// Returned by the `workspace_stats` command.

--- a/crates/outl-desktop/src/lib/action-handlers.test.ts
+++ b/crates/outl-desktop/src/lib/action-handlers.test.ts
@@ -39,12 +39,15 @@ vi.mock("@outl/shared/api/commands", () => ({
 }));
 
 vi.mock("./api", () => ({
+  redoPage: vi.fn(),
   runCodeBlock: vi.fn(),
+  undoPage: vi.fn(),
 }));
 
 import { openRef } from "@outl/shared/api/commands";
 
 import { buildHandlers } from "./action-handlers";
+import { redoPage, undoPage } from "./api";
 import { appState, setAppState } from "./store";
 
 function block(id: string, text: string): BlockNode {
@@ -149,5 +152,67 @@ describe("OpenRefUnderCursor (Normal-mode Enter)", () => {
     // Cursor lands on the referencing block of the opened page.
     expect(appState.selectedBacklinkBlockId).toBeNull();
     expect(appState.selectedBlockId).toBe("blk-source");
+  });
+});
+
+describe("Undo / Redo (Cmd+Z / Cmd+Shift+Z)", () => {
+  const applyView = vi.fn();
+  const setError = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setAppState({
+      page: { id: "pg-1", slug: "today", title: "Today", kind: "journal" },
+      outline: [block("blk-1", "hello")],
+      backlinks: [],
+      selectedBlockId: "blk-1",
+      selectedBacklinkBlockId: null,
+      editingBlockId: null,
+      backlinksOpen: false,
+    });
+  });
+
+  it("undoes on the current page and applies the restored view", async () => {
+    const view = pageView();
+    vi.mocked(undoPage).mockResolvedValue(view);
+
+    const handlers = buildHandlers({ applyView, setError });
+    await handlers.Undo?.();
+
+    expect(undoPage).toHaveBeenCalledWith("pg-1");
+    expect(applyView).toHaveBeenCalledWith(view);
+    expect(setError).not.toHaveBeenCalled();
+  });
+
+  it("redoes on the current page and applies the restored view", async () => {
+    const view = pageView();
+    vi.mocked(redoPage).mockResolvedValue(view);
+
+    const handlers = buildHandlers({ applyView, setError });
+    await handlers.Redo?.();
+
+    expect(redoPage).toHaveBeenCalledWith("pg-1");
+    expect(applyView).toHaveBeenCalledWith(view);
+  });
+
+  it("surfaces an empty history as a status message, not a crash", async () => {
+    vi.mocked(undoPage).mockRejectedValue("nothing to undo");
+
+    const handlers = buildHandlers({ applyView, setError });
+    await handlers.Undo?.();
+
+    expect(setError).toHaveBeenCalledWith("nothing to undo");
+    expect(applyView).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when no page is open", async () => {
+    setAppState("page", null);
+
+    const handlers = buildHandlers({ applyView, setError });
+    await handlers.Undo?.();
+    await handlers.Redo?.();
+
+    expect(undoPage).not.toHaveBeenCalled();
+    expect(redoPage).not.toHaveBeenCalled();
   });
 });

--- a/crates/outl-desktop/src/lib/action-handlers.ts
+++ b/crates/outl-desktop/src/lib/action-handlers.ts
@@ -37,7 +37,7 @@ import {
 } from "@outl/shared/api/commands";
 import type { BlockNode, PageView } from "@outl/shared/api/types";
 
-import { runCodeBlock } from "./api";
+import { redoPage, runCodeBlock, undoPage } from "./api";
 import { insertLink, wrapSelection } from "./markdown-wrap";
 import {
   flattenAll,
@@ -719,22 +719,51 @@ export function buildHandlers(deps: DesktopHandlerDeps): ActionHandlers {
     WrapStrike: () => wrapSelection("~~"),
     InsertLink: () => insertLink(),
 
-    // ── run code block (Cmd+X) ───────────────────────────────────
+    // ── run code block (Cmd+Shift+X) ─────────────────────────────
     //
-    // Targets the focused textarea (Insert) or the selected block
-    // (Normal). Resolves the block, asks the backend to execute the
+    // Targets the selected block (Normal — inside a textarea the
+    // chord resolves to the Insert-mode WrapStrike binding instead).
+    // Resolves the block, asks the backend to execute the
     // `\`\`\`lang … \`\`\`` fence via `outl-exec`, and surfaces the
-    // resulting stdout/stderr through `applyView`.
+    // resulting stdout/stderr through `applyView`. Plain `Cmd+X`
+    // deliberately has no binding — it falls through to the
+    // webview's native cut (issue #80).
     RunCodeBlock: async () => {
       const pageId = appState.page?.id;
       if (!pageId) return;
       const id = targetBlockId();
       if (!id) {
-        deps.setError("Select or focus a code block first, then ⌘X runs it");
+        deps.setError(
+          "Select or focus a code block first, then ⌘⇧X runs it",
+        );
         return;
       }
       const reply = await safeCall(runCodeBlock(pageId, id));
       if (reply) deps.applyView(reply.view);
+    },
+
+    // ── undo / redo (Cmd+Z / Cmd+Shift+Z, Normal mode) ───────────
+    //
+    // Block-level history: reverts / re-applies the last committed
+    // mutation on the current page (the backend snapshots the
+    // page's `.md` render around every `finish_in_page` mutation).
+    // The chords are Normal-mode only, so a focused textarea keeps
+    // its own `Cmd+Z`. An empty stack rejects with "nothing to
+    // undo" / "nothing to redo" — surfaced via the status bar.
+    // Selection is left as-is; if the restored outline no longer
+    // contains the selected block, `<OutlineView />`'s
+    // auto-selection recovers.
+    Undo: async () => {
+      const pageId = appState.page?.id;
+      if (!pageId) return;
+      const view = await safeCall(undoPage(pageId));
+      if (view) deps.applyView(view);
+    },
+    Redo: async () => {
+      const pageId = appState.page?.id;
+      if (!pageId) return;
+      const view = await safeCall(redoPage(pageId));
+      if (view) deps.applyView(view);
     },
 
     // ── commit + new sibling ─────────────────────────────────────
@@ -771,8 +800,7 @@ export function buildHandlers(deps: DesktopHandlerDeps): ActionHandlers {
     // preventDefault) and the textarea / OS handles the chord:
     //
     //   EditBlock chord buffer (CopyBlockRef), EnterVisual,
-    //   YankRange, DeleteRange, Undo, Redo, OpenCommandPalette,
-    //   RunCodeBlock (per-block button).
+    //   YankRange, DeleteRange, OpenCommandPalette.
     //
     // Each shows up as `[shortcuts] … no JS handler` in DevTools so
     // a debugging session can see what's still on the to-do list.

--- a/crates/outl-desktop/src/lib/api.ts
+++ b/crates/outl-desktop/src/lib/api.ts
@@ -9,7 +9,7 @@
  */
 import { invoke } from "@tauri-apps/api/core";
 
-import type { WorkspaceSummary } from "@outl/shared/api/types";
+import type { PageView, WorkspaceSummary } from "@outl/shared/api/types";
 
 // ---------------------------------------------------------------------------
 // Workspace lifecycle (desktop-only)
@@ -50,6 +50,24 @@ export async function workspaceStats(): Promise<WorkspaceSummary> {
 // ---------------------------------------------------------------------------
 // Code execution (desktop-only)
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Undo / redo (desktop-only)
+// ---------------------------------------------------------------------------
+
+/**
+ * Revert the last committed block mutation on the page. Rejects with
+ * `"nothing to undo"` when the page's history stack is empty — the
+ * handler surfaces that as a status message, not a crash.
+ */
+export function undoPage(pageId: string): Promise<PageView> {
+  return invoke<PageView>("undo_page", { pageId });
+}
+
+/** Re-apply the mutation the last {@link undoPage} reverted. */
+export function redoPage(pageId: string): Promise<PageView> {
+  return invoke<PageView>("redo_page", { pageId });
+}
 
 // ---------------------------------------------------------------------------
 // Settings (desktop-only)

--- a/crates/outl-shortcuts/CLAUDE.md
+++ b/crates/outl-shortcuts/CLAUDE.md
@@ -85,6 +85,12 @@ A binding that only the TUI cares about still lives here (with `Mode::Normal` / 
 - `Normal` mode → no binding either (the desktop frontend used to wire it to "toggle sidebar"; that's `Cmd+Shift+E` now to avoid hijacking markdown's universal bold chord — see `crates/outl-desktop/CLAUDE.md` for the rationale).
 
 If you find yourself wanting two different actions on the same chord across modes, the catalog already supports it — just add two `Binding` rows with different `mode` fields and the `no_duplicate_chord_in_same_mode` test will let them through.
+`Cmd+Shift+X` ships exactly that split today: `WrapStrike` in Insert (textarea focused) and `RunCodeBlock` in Global — inside a textarea the mode-specific row wins, everywhere else the Global one fires.
+
+**`Cmd+Z` / `Cmd+X` are the canonical "don't shadow the OS" examples:**
+
+- Plain `Cmd+X` carries **no binding at all** — it used to be `RunCodeBlock` (Global), which `preventDefault`ed the OS-universal cut inside every desktop textarea (issue #80). Run-code lives on `Cmd+Shift+X` now.
+- `Cmd/Ctrl+Z` (Undo) and `Cmd/Ctrl+Shift+Z` (Redo) are bound in **Normal**, not Global, so a focused textarea keeps the chord for its own native undo instead of having the dispatcher swallow it. They sit next to the vim spellings (`u` / `Ctrl+R`) in the catalog.
 
 ## Wire format (Tauri / JSON)
 

--- a/crates/outl-shortcuts/CLAUDE.md
+++ b/crates/outl-shortcuts/CLAUDE.md
@@ -33,7 +33,7 @@ A binding that only the TUI cares about still lives here (with `Mode::Normal` / 
 - **[`Binding`]** — `(mode, chord, action, description)` row.
   The description is what the help overlay displays — keep it short and verb-led ("Open today's journal", not "This shortcut opens today's journal in the current window").
 - **[`default_bindings`]** — the canonical table. Hand-curated, ordered for help-overlay readability.
-- **[`bindings_for_mode`] / [`lookup`]** — query helpers. `lookup` is `O(n)` over the table; the table is small (under 100 entries today) so we don't bother with a hashmap.
+- **[`bindings_for_mode`] / [`lookup`]** — query helpers. `lookup` is `O(n)` over the table; the table is small (under 100 entries today) so we don't bother with a hashmap. **`lookup` prefers a mode-specific binding over a `Global` one** for the same chord — it can't rely on table order because the `Global` chrome rows are listed first for help-overlay readability, so a naive first-match would resolve every dual-bound chord (e.g. `Cmd+Shift+X` → `WrapStrike` in Insert vs. `RunCodeBlock` in Global) to its `Global` action even inside the overriding mode.
 
 ## What this crate does NOT own
 

--- a/crates/outl-shortcuts/src/defaults.rs
+++ b/crates/outl-shortcuts/src/defaults.rs
@@ -33,6 +33,9 @@ fn shift_ch(c: char) -> ChordSequence {
 fn shift_meta_ch(c: char) -> ChordSequence {
     ChordSequence::chord(Chord::new(Modifiers::META | Modifiers::SHIFT, Key::char(c)))
 }
+fn shift_ctrl_ch(c: char) -> ChordSequence {
+    ChordSequence::chord(Chord::new(Modifiers::CTRL | Modifiers::SHIFT, Key::char(c)))
+}
 fn meta_key(k: Key) -> ChordSequence {
     ChordSequence::chord(Chord::new(Modifiers::META, k))
 }
@@ -131,16 +134,26 @@ pub fn default_bindings() -> Vec<Binding> {
             "Toggle TODO / DONE (TUI alt)",
         ),
         // Run the fenced code block under the cursor / focused
-        // block. Desktop: `Cmd+X` (X for e**x**ecute — Apple does
-        // the same in Shortcuts.app and Numbers' "Run script"). The
-        // TUI uses the `g x` chord which lives in `outl-tui/input/`
-        // for now — `Cmd` doesn't exist in crossterm so the catalog
-        // can't drive both surfaces with a single binding.
+        // block. Desktop: `Cmd+Shift+X` (X for e**x**ecute — Apple
+        // does the same in Shortcuts.app and Numbers' "Run script").
+        // Plain `Cmd+X` used to live here but shadowed the
+        // OS-universal **cut** inside every textarea (the dispatcher
+        // `preventDefault`s matched Global chords even in Insert) —
+        // in a text-editing app, clipboard muscle memory wins over
+        // the mnemonic. See issue #80.
+        // Inside a textarea `Cmd+Shift+X` still resolves to the
+        // Insert-mode `WrapStrike` binding below (mode-specific beats
+        // Global), so running a block you're editing means committing
+        // first — the per-block run button covers the in-editor case.
+        // The TUI uses the `g x` chord which lives in
+        // `outl-tui/input/` for now — `Cmd` doesn't exist in
+        // crossterm so the catalog can't drive both surfaces with a
+        // single binding.
         Binding::new(
-            meta('x'),
+            shift_meta_ch('x'),
             Global,
             Action::RunCodeBlock,
-            "Run code block (Cmd+X)",
+            "Run code block (Cmd+Shift+X)",
         ),
         Binding::new(
             pair('g', 'x'),
@@ -389,6 +402,28 @@ pub fn default_bindings() -> Vec<Binding> {
         Binding::new(ch('v'), Normal, Action::EnterVisual, "Enter Visual mode"),
         Binding::new(ch('u'), Normal, Action::Undo, "Undo"),
         Binding::new(ctrl('r'), Normal, Action::Redo, "Redo"),
+        // OS-standard undo / redo chords (desktop). Deliberately
+        // **Normal**, not Global: with a textarea focused the chord
+        // must fall through to the webview (in-flight draft editing
+        // is the textarea's own undo domain), and a Global binding
+        // would `preventDefault` it away. Outside a textarea they
+        // revert / re-apply the last committed block mutation.
+        // `Ctrl` variants cover Windows / Linux (same pattern as the
+        // `Cmd+P` / `Ctrl+P` pair above).
+        Binding::new(meta('z'), Normal, Action::Undo, "Undo (Cmd+Z)"),
+        Binding::new(ctrl('z'), Normal, Action::Undo, "Undo (Ctrl+Z)"),
+        Binding::new(
+            shift_meta_ch('z'),
+            Normal,
+            Action::Redo,
+            "Redo (Cmd+Shift+Z)",
+        ),
+        Binding::new(
+            shift_ctrl_ch('z'),
+            Normal,
+            Action::Redo,
+            "Redo (Ctrl+Shift+Z)",
+        ),
         // ── Insert mode ───────────────────────────────────────────
         //
         // Only `Esc` and `Cmd+Enter` land in the catalog. Every

--- a/crates/outl-shortcuts/src/lib.rs
+++ b/crates/outl-shortcuts/src/lib.rs
@@ -68,14 +68,35 @@ pub fn bindings_for_mode(mode: Mode) -> Vec<Binding> {
 /// back to whatever its default key handling does (typing into a
 /// textarea, …).
 ///
+/// **Mode-specific bindings take precedence over `Global` ones.** A
+/// chord can be bound twice — once for a concrete mode, once for
+/// `Global` — and the concrete mode must win when the editor is in
+/// it. `Cmd+Shift+X` is the canonical case: `WrapStrike` in `Insert`
+/// (textarea focused), `RunCodeBlock` everywhere else via `Global`.
+/// We can't lean on table order here because the `Global` chrome rows
+/// are listed first for help-overlay readability, so a plain
+/// first-match `find` would resolve every dual-bound chord to its
+/// `Global` action even inside the mode that should override it.
+///
 /// Prefix matching is the caller's job: when a [`ChordSequence`]
 /// has two chords (e.g. `g j`), the caller buffers the first chord
 /// and re-queries with the full sequence on the second key.
 pub fn lookup(mode: Mode, seq: &ChordSequence) -> Option<Action> {
-    default_bindings()
-        .into_iter()
-        .find(|b| (b.mode == Mode::Global || b.mode == mode) && &b.chord == seq)
-        .map(|b| b.action)
+    let mut global_match = None;
+    for b in default_bindings() {
+        if &b.chord != seq {
+            continue;
+        }
+        if b.mode == mode {
+            // Exact-mode match wins outright, regardless of where it
+            // sits in the table relative to the Global row.
+            return Some(b.action);
+        }
+        if b.mode == Mode::Global {
+            global_match = Some(b.action);
+        }
+    }
+    global_match
 }
 
 #[cfg(test)]
@@ -140,6 +161,35 @@ mod tests {
                 lookup(mode, chord),
                 Some(Action::OpenPicker),
                 "OpenPicker not reachable in {mode:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn cmd_shift_x_splits_between_insert_and_global() {
+        // `Cmd+Shift+X` is the canonical "same chord, two actions
+        // across modes" case (see `defaults.rs` + the crate
+        // CLAUDE.md). Inside a textarea (Insert) the mode-specific
+        // `WrapStrike` row must win over the Global `RunCodeBlock`
+        // one; everywhere else the Global binding fires. If this
+        // split ever regresses, running a fenced block while editing
+        // it would clobber the user's selection with strikethrough.
+        let shift_meta_x = ChordSequence::chord(Chord::new(
+            Modifiers::META | Modifiers::SHIFT,
+            Key::char('x'),
+        ));
+
+        assert_eq!(
+            lookup(Mode::Insert, &shift_meta_x),
+            Some(Action::WrapStrike),
+            "Cmd+Shift+X in Insert must resolve to WrapStrike (mode-specific beats Global)",
+        );
+
+        for mode in [Mode::Normal, Mode::Visual, Mode::Overlay] {
+            assert_eq!(
+                lookup(mode, &shift_meta_x),
+                Some(Action::RunCodeBlock),
+                "Cmd+Shift+X must fall through to the Global RunCodeBlock in {mode:?}",
             );
         }
     }

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -16,6 +16,7 @@ To keep them honest, we route every workspace operation through one shared crate
 ┌──────────────────────────────────────────────────────────────┐
 │ outl-actions                                                  │
 │   block · tree · todo · journal · outline · page · backlinks  │
+│   history (bounded undo/redo stacks + .md snapshot restore)   │
 │   sync (SyncEngine: reload workspace, reproject page,         │
 │         snapshot peer jsonls, scan for orphan .md)            │
 └──────────────────────────────────────────────────────────────┘
@@ -39,6 +40,7 @@ To keep them honest, we route every workspace operation through one shared crate
 | Op log, tree CRDT, storage trait     | `outl-core`                     |
 | `.md` parse / render, sidecar        | `outl-md`                       |
 | Workspace mutations (edit, indent, todo, delete, journal render) | `outl-actions` |
+| Committed-mutation undo / redo (snapshot stacks + `.md` restore via reconcile) | `outl-actions::history` |
 | Code-block execution (runtimes + orchestration) | `outl-exec`            |
 | Cross-client "run a fence" glue (`run_code_block`) | `outl-actions::exec` |
 | TUI: keymaps, modes, overlays, in-flight AST manipulation | `outl-tui`         |
@@ -80,10 +82,10 @@ Users decide when to clean up; outl never deletes content on their behalf.
 
 ## Running code blocks
 
-Every client that lets the user execute a `` ```lang ``` `` block (TUI `g x`, desktop `Cmd+X` / Run button, mobile long-press → "Run code") goes through **one** shared entry point: `outl_actions::exec::run_code_block(ws, hlc, root, registry, page, block)`.
+Every client that lets the user execute a `` ```lang ``` `` block (TUI `g x`, desktop `Cmd+Shift+X` / Run button, mobile long-press → "Run code") goes through **one** shared entry point: `outl_actions::exec::run_code_block(ws, hlc, root, registry, page, block)`.
 
 ```text
-client gesture (TUI chord / Cmd+X / long-press)
+client gesture (TUI chord / Cmd+Shift+X / long-press)
         │
         ▼
 outl_actions::exec::run_code_block

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -31,7 +31,7 @@ If a row below disagrees with what you observe in the app, **the code is right a
 | Quick switcher (fuzzy pages + journals) | `Ctrl+P` | `Cmd/Ctrl+P` | tap toolbar |
 | Open today's **j**ournal | `t` / `Home` | `Cmd/Ctrl+J` | toolbar |
 | Toggle TODO / DONE on focused or selected block (T for **t**ask) | `Ctrl+T` / `Ctrl+Enter` | `Cmd/Ctrl+T` / `Cmd/Ctrl+Enter` | tap checkbox |
-| Run code block under cursor / inside focused block (X for e**x**ecute) | `g x` chord / `:run` | `Cmd/Ctrl+X` | tap "Run" button |
+| Run code block under cursor / selected block (X for e**x**ecute) | `g x` chord / `:run` | `Cmd/Ctrl+Shift+X` (inside a textarea the Insert-mode strikethrough wins — commit first or use the Run button; plain `Cmd+X` is the OS cut) | tap "Run" button |
 | Previous journal day | `[` | `Cmd/Ctrl+[` | swipe right |
 | Next journal day | `]` | `Cmd/Ctrl+]` | swipe left |
 | Toggle sidebar | `Ctrl+E` | `Cmd/Ctrl+Shift+E` | _(single pane)_ |
@@ -104,8 +104,8 @@ The desktop honours `Normal`/`Visual` only while `editor.vim_mode = true`. The T
 | Reselect last Visual range (chord) | `g v` | `g v` | — |
 | Search workspace for word / block text — forward | `*` | `*` *(seeds picker)* | — |
 | Search workspace for word / block text — backward | `#` | `#` *(seeds picker)* | — |
-| Undo | `u` | `u` / `Cmd+Z` | toolbar |
-| Redo | `Ctrl+R` | `Ctrl+R` / `Cmd+Shift+Z` | toolbar |
+| Undo last committed block mutation | `u` | `u` / `Cmd/Ctrl+Z` | toolbar |
+| Redo | `Ctrl+R` | `Ctrl+R` / `Cmd/Ctrl+Shift+Z` | toolbar |
 | Yank block ref → clipboard (chord) | `y r` | `y r` | — |
 | Enter Visual | `v` | `v` | — |
 | Open command palette | `:` | `:` | — |
@@ -148,7 +148,8 @@ The TUI ships it natively; the desktop has only a selected block id, so the char
 | Block ref autocomplete | `((` triggers picker | `((` triggers picker | — |
 | Slash command autocomplete | `/` | `/` | — |
 | Toggle TODO/DONE on current | `Ctrl+T` / `Ctrl+Enter` | `Cmd/Ctrl+T` / `Cmd/Ctrl+Enter` | tap checkbox / long-press menu |
-| Run code block | `g x` chord | `Cmd/Ctrl+X` | tap "Run" |
+| Cut selection (native) | — | `Cmd/Ctrl+X` | OS selection menu |
+| Run code block | `g x` chord | commit first, then `Cmd/Ctrl+Shift+X` (or the Run button) | tap "Run" |
 
 ---
 


### PR DESCRIPTION
## What & why

Closes #80. Two OS-universal editing shortcuts were broken in the desktop block editors:

- **`Cmd/Ctrl+X` (cut)** never cut — the chord was bound `Global` to `RunCodeBlock`, so the keyboard dispatcher `preventDefault`'ed the native cut inside every textarea.
- **`Cmd/Ctrl+Z` (undo)** did nothing — the `Undo`/`Redo` actions existed in the catalog but were never implemented on the desktop.

## Changes

### 1. Free `Cmd+X`, move run-code to `Cmd+Shift+X`
- `outl-shortcuts`: `RunCodeBlock` rebound from `meta('x')` to `Cmd/Ctrl+Shift+X` (still `Global`). With no catalog binding on plain `Cmd+X`, the dispatcher lets it through and the webview performs the native cut.
- Inside a textarea `Cmd+Shift+X` still resolves to the Insert-mode `WrapStrike` (mode-specific beats Global) — running a block you're editing means committing first or using the Run button. Documented as a deliberate trade-off.

### 2. Shared undo/redo engine in `outl-actions::history`
- New `HistoryStacks<T>`: bounded stacks (cap 200), vim semantics (a new edit clears redo).
- `restore_page_md`: writes a previously-rendered `.md` snapshot and reconciles it back, so every undo/redo is **new ops through `Workspace::apply`** — the op log is never rewritten (invariant #1 holds, converges across peers like any edit).

### 3. Desktop wiring
- `finish_in_page_with` records the pre-mutation render (only when the projection actually changed).
- `undo_page` / `redo_page` Tauri commands; `Cmd/Ctrl+Z` + `Cmd/Ctrl+Shift+Z` bound in **Normal** mode (not Global, so a focused textarea keeps its own native undo). The vim `u` / `Ctrl+R` now also work on the desktop.
- **Surgical history invalidation**: a workspace *switch* clears every stack, but a peer-driven *reload* drops only the stacks of pages whose projection changed. (A blanket clear capped `Cmd+Z` at one step whenever the TUI was open on the same workspace — every peer write fires `peer-ops-changed` → `reload_workspace`.)

### 4. Docs
Shortcut tables (`outl-desktop`, `outl-shortcuts` CLAUDE.md), root catalog + copilot mirror (§15), `outl-actions` CLAUDE.md, `docs/clients.md`, `docs/shortcuts.md`.

## Out of scope
Per-keystroke undo *inside* an uncommitted draft is still broken (the controlled `value={draft()}` textarea resets the native undo stack each keystroke). This PR gives block-level undo of committed mutations, matching the TUI. Tracked as a follow-up in #80.

## Notes
- The **TUI is untouched** — it doesn't consume the catalog and keeps its own snapshot history.
- Adjacent pre-existing issue spotted (not fixed here): `Ctrl+C` is bound Global to `Quit`, which similarly shadows native copy on Windows/Linux. Worth a sibling issue.

## Verification
`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace`, `RUSTDOCFLAGS="-D warnings" cargo doc`, and `bun --filter outl-desktop test` (41 tests incl. new Undo/Redo coverage) all green. New `outl-actions` tests prove the engine walks back multiple mutations and that restores append ops without rewinding the log.
