### PR TITLE
fix: page autocomplete shows title instead of slug (#88)

### DIFF
--- a/crates/outl-actions/src/page.rs
+++ b/crates/outl-actions/src/page.rs
@@ -73,7 +73,10 @@ pub struct PageMeta {
     pub id: String,
     /// Stable slug identifying the page (filename-safe).
     pub slug: String,
-    /// Human-readable title (the page node's text).
+    /// Human-readable title. Resolved most-specific-first: the
+    /// `title::` page property (where ingest / reconcile park the name),
+    /// then the page node's own text (set by in-app creation), then the
+    /// slug as a last resort. See `page_meta`.
     pub title: String,
     /// `page` or `journal`.
     pub kind: PageKind,
@@ -138,7 +141,23 @@ pub fn page_meta(workspace: &Workspace, id: NodeId) -> Option<PageMeta> {
         _ => return None,
     };
     let kind = PageKind::parse(workspace.tree().property(id, KIND_KEY));
-    let title = workspace.block_text(id).unwrap_or_else(|| slug.clone());
+    // Title resolution, most-specific first:
+    //   1. the `title::` page property — where ingest / reconcile parks
+    //      the human-readable name (`diff_to_ops_with_page_props` emits
+    //      it as `Op::SetProp` key `"title"`, and the page root's text
+    //      stays empty for disk-sourced pages);
+    //   2. the page node's own text — set when a page is created
+    //      in-app via `open_or_create_by_name` (the typed name);
+    //   3. the slug — last resort so a title is never empty.
+    // Reading `block_text` alone (the old behaviour) made every
+    // ingested page surface its slug in pickers / autocomplete.
+    let title = match workspace.tree().property(id, "title") {
+        Some(PropValue::Text(s)) if !s.trim().is_empty() => s.trim().to_string(),
+        _ => workspace
+            .block_text(id)
+            .filter(|t| !t.trim().is_empty())
+            .unwrap_or_else(|| slug.clone()),
+    };
     // `icon::` is a free-form page property. It survives as a
     // `PropValue::Text` after `reconcile_md` applies the page's
     // properties; we surface only the textual variant so the wire
@@ -669,6 +688,40 @@ mod tests {
         // same node (idempotent on the slugified form, not the raw input).
         let second = open_or_create_by_name(&mut w, &hlc, "avelino/outl", PageKind::Page).unwrap();
         assert_eq!(id, second);
+    }
+
+    #[test]
+    fn page_meta_prefers_title_property_over_node_text() {
+        // Regression (issue #88): disk-sourced / ingested pages park the
+        // human-readable name in the `title::` property
+        // (`diff_to_ops_with_page_props` emits it as `Op::SetProp` key
+        // "title") while the page root node's text stays empty. The
+        // mobile / desktop autocomplete then rendered the slug because
+        // `page_meta` read `block_text` only. `title::` must win.
+        let (mut w, hlc) = ws();
+        // Create with an empty node text, mimicking an ingested page.
+        let id = open_or_create(&mut w, &hlc, "avelino-outl", "", PageKind::Page).unwrap();
+        set_prop(
+            &mut w,
+            &hlc,
+            id,
+            "title",
+            PropValue::Text("avelino/outl".to_string()),
+        )
+        .unwrap();
+        let meta = page_meta(&w, id).unwrap();
+        assert_eq!(meta.title, "avelino/outl");
+        assert_eq!(meta.slug, "avelino-outl");
+    }
+
+    #[test]
+    fn page_meta_falls_back_to_slug_when_no_title_or_text() {
+        // No `title::` property and empty node text → slug is the last
+        // resort so a title is never blank.
+        let (mut w, hlc) = ws();
+        let id = open_or_create(&mut w, &hlc, "orphan", "", PageKind::Page).unwrap();
+        let meta = page_meta(&w, id).unwrap();
+        assert_eq!(meta.title, "orphan");
     }
 
     #[test]

--- a/crates/outl-mobile/src/lib/native-suggester.test.ts
+++ b/crates/outl-mobile/src/lib/native-suggester.test.ts
@@ -20,10 +20,50 @@ describe("buildShowMessage", () => {
     expect(buildShowMessage(pages)).toEqual({
       action: "show",
       items: [
-        { slug: "avelino", title: "Avelino", kind: "page" },
+        // Page pick value is the title (matches desktop refReplacement).
+        { slug: "Avelino", title: "Avelino", kind: "page" },
+        // Journal pick value stays the ISO slug.
         { slug: "2026-05-28", title: "2026-05-28", kind: "journal" },
       ],
     });
+  });
+
+  it("inserts the title, not the slug, for a page whose slug differs (#88)", () => {
+    // Regression: the chip showed "avelino/outl" but tapping wrote the
+    // slug `avelino-outl`. The picked value (the `slug` wire field) must
+    // be the human-readable title so the ref renders verbatim and still
+    // resolves via the slugified-match arm of open_or_create_by_ref.
+    const pages: PageMeta[] = [
+      { id: "a", slug: "avelino-outl", title: "avelino/outl", kind: "page" },
+    ];
+    const item = buildShowMessage(pages).items[0];
+    expect(item.slug).toBe("avelino/outl");
+    expect(item.title).toBe("avelino/outl");
+  });
+
+  it("keeps inserting the journal's ISO slug, not its long title", () => {
+    const pages: PageMeta[] = [
+      {
+        id: "j1",
+        slug: "2026-05-28",
+        title: "Thursday, May 28, 2026",
+        kind: "journal",
+      },
+    ];
+    const item = buildShowMessage(pages).items[0];
+    expect(item.slug).toBe("2026-05-28");
+    expect(item.title).toBe("2026-05-28");
+  });
+
+  it("inserts the person's title verbatim for an @ mention", () => {
+    const pages: PageMeta[] = [
+      { id: "p1", slug: "avelino", title: "Avelino", kind: "page" },
+    ];
+    // mention=true → pick value is the title (applySuggestion wraps it
+    // as `[[@Avelino]]`).
+    expect(buildShowMessage(pages, { mention: true }).items[0].slug).toBe(
+      "Avelino",
+    );
   });
 
   it("replaces a journal's human title with its ISO slug", () => {

--- a/crates/outl-mobile/src/lib/native-suggester.ts
+++ b/crates/outl-mobile/src/lib/native-suggester.ts
@@ -56,12 +56,17 @@ export function buildShowMessage(
   return {
     action: "show",
     items: items.map((p) => ({
-      // For the `@` mention popup, the picked value handed back to JS
-      // must be the **title** — `applySuggestion` wraps it in
-      // `[[@<title>]]`, and the page slug carries no `@`. For normal
-      // page refs, the slug is still the canonical identifier so
-      // navigation and ref-resolution match the picker.
-      slug: opts.mention ? p.title : p.slug,
+      // `slug` is the value handed back to JS on tap and spliced into
+      // the document. It must match desktop's `refReplacement`
+      // (BlockRow.tsx): journals insert their ISO slug; every other
+      // page inserts its **title**, which renders verbatim inside
+      // `[[…]]` and still resolves through the slugified-match arm of
+      // `open_or_create_by_ref` (so `[[avelino/outl]]` finds the page
+      // stored as `avelino-outl`). Inserting the slug here was the bug
+      // (#88): the chip showed the title but the tap wrote the slug.
+      // `@` mentions always insert the title — `applySuggestion` wraps
+      // it as `[[@<title>]]` and the page identity carries no `@`.
+      slug: p.kind === "journal" && !opts.mention ? p.slug : p.title,
       // Journal pages render under a human-readable title server-side
       // ("Thursday, May 28, 2026"). The mobile UI is anchored on ISO
       // slugs (`2026-05-28`), so show the slug in the chip strip


### PR DESCRIPTION
Page autocomplete on mobile showed the slug instead of the human-readable title, in two distinct spots:
1. `page_meta` read only the page root node's text (empty for disk/ingested pages) and fell back to the slug — now resolves `title::` property → node text → slug. Fixes every client.
2. `buildShowMessage` handed the slug back as the pick value, so the chip showed the title but tapping inserted `[[avelino-outl]]` — now inserts the title (matching desktop `refReplacement`), slug only for journals.

Closes #88.