### PR TITLE
feat: configurable calendar week-start (Monday/Sunday) in config.toml

### DIFF
--- a/crates/outl-config/CLAUDE.md
+++ b/crates/outl-config/CLAUDE.md
@@ -46,6 +46,9 @@ preset = "outl"                   # name from outl_theme::PRESETS
 [editor]
 vim_mode = true                   # default true
 font_size = 15                    # pixels, desktop-only
+
+[calendar]
+week_start = "monday"             # "monday" (default) | "sunday"
 ```
 
 Three sections, each modelled as its own struct ([`WorkspaceCfg`], [`ThemeCfg`], [`EditorCfg`]).
@@ -85,6 +88,7 @@ If the field **must converge between devices**, it doesn't belong in TOML at all
 | `theme.preset` | TUI palette resolver; desktop settings | `crates/outl-tui/src/runtime.rs::resolve_theme`, `crates/outl-desktop/src-tauri/src/commands/theme.rs` |
 | `editor.vim_mode` | Desktop only (TUI ignores) | `crates/outl-desktop/src-tauri/src/settings.rs` |
 | `editor.font_size` | Desktop only | `crates/outl-desktop/src-tauri/src/settings.rs` |
+| `calendar.week_start` | TUI sidebar calendar; desktop sidebar calendar (mobile does not read it — no `~/.config` on iOS) | `crates/outl-tui/src/runtime.rs` (→ `App::week_start` → `view/sidebar.rs`), `crates/outl-desktop/src-tauri/src/settings.rs` (→ `Settings.week_start` → `Sidebar.tsx`) |
 
 Update this table whenever a new reader appears.
 

--- a/crates/outl-config/src/lib.rs
+++ b/crates/outl-config/src/lib.rs
@@ -26,6 +26,9 @@
 //! [editor]
 //! vim_mode = true
 //! font_size = 15
+//!
+//! [calendar]
+//! week_start = "monday"   # "monday" (default) | "sunday"
 //! ```
 //!
 //! All fields are optional — missing values fall back to
@@ -47,7 +50,7 @@ mod paths;
 mod schema;
 
 pub use paths::{config_dir, config_path};
-pub use schema::{Config, EditorCfg, ThemeCfg, WorkspaceCfg};
+pub use schema::{CalendarCfg, Config, EditorCfg, ThemeCfg, WeekStart, WorkspaceCfg};
 
 use std::fs;
 use std::path::Path;

--- a/crates/outl-config/src/schema.rs
+++ b/crates/outl-config/src/schema.rs
@@ -25,6 +25,7 @@ pub struct Config {
     pub workspace: WorkspaceCfg,
     pub theme: ThemeCfg,
     pub editor: EditorCfg,
+    pub calendar: CalendarCfg,
 }
 
 /// Workspace section — primarily where the desktop remembers the
@@ -81,6 +82,31 @@ impl Default for EditorCfg {
     }
 }
 
+/// Calendar section — how the mini-calendar / week views lay out.
+/// Read by every client that renders a calendar (TUI sidebar, desktop
+/// sidebar; the mobile calendar has no `~/.config` to read on iOS and
+/// keeps its own default until it grows an in-app setting).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CalendarCfg {
+    /// Which day the week grid starts on.
+    pub week_start: WeekStart,
+}
+
+/// First column of a calendar week grid.
+///
+/// Defaults to [`WeekStart::Monday`] — the historical TUI / desktop
+/// behaviour — so an existing config keeps rendering identically.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WeekStart {
+    /// ISO week: Monday first (`Mon … Sun`).
+    #[default]
+    Monday,
+    /// US-style week: Sunday first (`Sun … Sat`).
+    Sunday,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -92,5 +118,18 @@ mod tests {
         assert!(c.editor.vim_mode);
         assert_eq!(c.editor.font_size, 15);
         assert!(c.workspace.last.is_none());
+        assert_eq!(c.calendar.week_start, WeekStart::Monday);
+    }
+
+    #[test]
+    fn week_start_parses_and_defaults_per_section() {
+        // Explicit value round-trips through the lowercase serde repr.
+        let c: Config = toml::from_str("[calendar]\nweek_start = \"sunday\"\n").unwrap();
+        assert_eq!(c.calendar.week_start, WeekStart::Sunday);
+
+        // A config that omits `[calendar]` entirely still falls back to
+        // the Monday default (the `#[serde(default)]` partial-section path).
+        let c: Config = toml::from_str("[theme]\npreset = \"dracula\"\n").unwrap();
+        assert_eq!(c.calendar.week_start, WeekStart::Monday);
     }
 }

--- a/crates/outl-desktop/src-tauri/src/settings.rs
+++ b/crates/outl-desktop/src-tauri/src/settings.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use outl_config::{Config, EditorCfg, ThemeCfg, WorkspaceCfg};
+use outl_config::{CalendarCfg, Config, EditorCfg, ThemeCfg, WeekStart, WorkspaceCfg};
 
 /// Flat shape the Solid frontend's `Settings` interface
 /// (`crates/outl-desktop/src/lib/api.ts`) expects. Matches what
@@ -27,6 +27,30 @@ pub struct Settings {
     pub theme: String,
     /// Outline font size in pixels.
     pub font_size: u32,
+    /// Calendar week start: `"monday"` (default) or `"sunday"`.
+    /// String on the wire so the Solid `<SettingsModal>` can bind a
+    /// `<select>` without a codegen step; mapped to / from
+    /// `outl_config::WeekStart` here.
+    pub week_start: String,
+}
+
+/// Map the typed [`WeekStart`] to its wire string.
+fn week_start_str(w: WeekStart) -> String {
+    match w {
+        WeekStart::Monday => "monday",
+        WeekStart::Sunday => "sunday",
+    }
+    .to_string()
+}
+
+/// Parse the wire string back to [`WeekStart`]; anything other than
+/// `"sunday"` falls back to the Monday default (forgiving, like the
+/// rest of the config read path).
+fn week_start_from_str(s: &str) -> WeekStart {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "sunday" => WeekStart::Sunday,
+        _ => WeekStart::Monday,
+    }
 }
 
 impl Settings {
@@ -44,6 +68,7 @@ impl From<Config> for Settings {
             vim_mode: c.editor.vim_mode,
             theme: c.theme.preset,
             font_size: c.editor.font_size,
+            week_start: week_start_str(c.calendar.week_start),
         }
     }
 }
@@ -58,6 +83,9 @@ impl From<Settings> for Config {
             editor: EditorCfg {
                 vim_mode: s.vim_mode,
                 font_size: s.font_size,
+            },
+            calendar: CalendarCfg {
+                week_start: week_start_from_str(&s.week_start),
             },
         }
     }
@@ -97,6 +125,7 @@ mod tests {
         );
         assert_eq!(s.theme, "outl");
         assert_eq!(s.font_size, 15);
+        assert_eq!(s.week_start, "monday", "Monday-first is the default");
     }
 
     #[test]
@@ -106,6 +135,7 @@ mod tests {
             vim_mode: false,
             theme: "dracula".into(),
             font_size: 18,
+            week_start: "sunday".into(),
         };
         let cfg: Config = s.clone().into();
         let back: Settings = cfg.into();
@@ -113,5 +143,16 @@ mod tests {
         assert_eq!(back.vim_mode, s.vim_mode);
         assert_eq!(back.theme, s.theme);
         assert_eq!(back.font_size, s.font_size);
+        assert_eq!(back.week_start, "sunday");
+    }
+
+    #[test]
+    fn unknown_week_start_string_falls_back_to_monday() {
+        let s = Settings {
+            week_start: "garbage".into(),
+            ..Settings::fresh()
+        };
+        let cfg: Config = s.into();
+        assert_eq!(cfg.calendar.week_start, WeekStart::Monday);
     }
 }

--- a/crates/outl-desktop/src/App.tsx
+++ b/crates/outl-desktop/src/App.tsx
@@ -50,6 +50,7 @@ function App() {
   async function hydrateTheme() {
     try {
       const s = await getSettings();
+      setAppState("weekStart", s.week_start === "sunday" ? "sunday" : "monday");
       const palette = await getTheme(s.theme || null);
       applyPaletteToRoot(palette);
     } catch {

--- a/crates/outl-desktop/src/components/SettingsModal.tsx
+++ b/crates/outl-desktop/src/components/SettingsModal.tsx
@@ -65,6 +65,10 @@ export function SettingsModal() {
     try {
       const persisted = await updateSettings(d);
       setDraft(persisted);
+      setAppState(
+        "weekStart",
+        persisted.week_start === "sunday" ? "sunday" : "monday",
+      );
       close();
     } catch (e) {
       setAppState("lastError", e instanceof Error ? e.message : String(e));

--- a/crates/outl-desktop/src/components/Sidebar.tsx
+++ b/crates/outl-desktop/src/components/Sidebar.tsx
@@ -155,11 +155,21 @@ export function Sidebar(props: {
   }
 
   /**
-   * 0 = Monday … 6 = Sunday — matches the TUI's Monday-first week
-   * (the `Mo Tu We Th Fr Sa Su` header).
+   * Column index (0–6) of a JS weekday (`Date.getDay()`, where
+   * `0 = Sunday`) within the grid, honouring the configured week
+   * start. Monday-first maps `Mon→0 … Sun→6`; Sunday-first is the
+   * identity (`Sun→0 … Sat→6`). Read from `appState.weekStart`, which
+   * mirrors `config.toml`'s `[calendar] week_start`.
    */
-  function mondayIndex(jsDay: number): number {
-    return (jsDay + 6) % 7;
+  function weekIndex(jsDay: number): number {
+    return appState.weekStart === "sunday" ? jsDay : (jsDay + 6) % 7;
+  }
+
+  /** Weekday header labels in the configured order. */
+  function weekdayLabels(): string[] {
+    return appState.weekStart === "sunday"
+      ? ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]
+      : ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"];
   }
 
   async function openDay(year: number, monthIdx: number, day: number) {
@@ -270,7 +280,7 @@ export function Sidebar(props: {
      *  empty leading / trailing days. */
     function cells(): Array<{ day: number; slug: string } | null> {
       const first = new Date(year(), monthIdx(), 1);
-      const lead = mondayIndex(first.getDay());
+      const lead = weekIndex(first.getDay());
       const total = daysInMonth(year(), monthIdx());
       const out: Array<{ day: number; slug: string } | null> = [];
       for (let i = 0; i < lead; i++) out.push(null);
@@ -313,7 +323,7 @@ export function Sidebar(props: {
         </div>
 
         <div class="grid grid-cols-7 gap-[2px] text-center text-[9.5px] uppercase tracking-wider text-(--color-outl-fg-dimmer)">
-          <For each={["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]}>
+          <For each={weekdayLabels()}>
             {(d) => <div class="py-[2px]">{d}</div>}
           </For>
         </div>

--- a/crates/outl-desktop/src/lib/api.ts
+++ b/crates/outl-desktop/src/lib/api.ts
@@ -83,6 +83,12 @@ export interface Settings {
    */
   theme: string;
   font_size: number;
+  /**
+   * Calendar week start, mirrored from `config.toml`'s
+   * `[calendar] week_start` (`outl_config::WeekStart`). `"monday"`
+   * (default) or `"sunday"`.
+   */
+  week_start: "monday" | "sunday";
 }
 
 /**

--- a/crates/outl-desktop/src/lib/store.ts
+++ b/crates/outl-desktop/src/lib/store.ts
@@ -152,6 +152,13 @@ export interface AppStateShape {
   settingsOpen: boolean;
   /** Help overlay open state. `?` in Normal mode toggles. */
   helpOpen: boolean;
+  /**
+   * First column of the mini-calendar week grid, mirrored from
+   * `config.toml`'s `[calendar] week_start` (`outl_config::WeekStart`)
+   * via `getSettings()` on boot. Defaults to `"monday"` (the
+   * historical layout) until settings hydrate.
+   */
+  weekStart: "monday" | "sunday";
   /** Last error surfaced to the user (status line). */
   lastError: string | null;
 }
@@ -177,6 +184,7 @@ const [state, setState] = createStore<AppStateShape>({
   pickerSeed: null,
   settingsOpen: false,
   helpOpen: false,
+  weekStart: "monday",
   lastError: null,
 });
 

--- a/crates/outl-tui/src/actions/lifecycle/mod.rs
+++ b/crates/outl-tui/src/actions/lifecycle/mod.rs
@@ -94,6 +94,10 @@ impl App {
             undo: Vec::new(),
             redo: Vec::new(),
             theme,
+            // Default to the historical Monday-first calendar; the
+            // runtime overrides this from `config.toml`'s
+            // `[calendar] week_start` right after construction.
+            week_start: outl_config::WeekStart::Monday,
             exec_registry: RuntimeRegistry::with_builtins(),
             command_registry: CommandRegistry::with_builtins(),
             collapsed: std::collections::HashSet::new(),

--- a/crates/outl-tui/src/runtime.rs
+++ b/crates/outl-tui/src/runtime.rs
@@ -303,6 +303,9 @@ fn event_loop(
     shared_workspace: bool,
 ) -> Result<()> {
     let mut app = App::new(workspace_root, workspace, actor, theme, shared_workspace)?;
+    // Calendar week start comes from the same global `config.toml` the
+    // theme preset above is read from (`[calendar] week_start`).
+    app.week_start = outl_config::load().calendar.week_start;
     loop {
         // Pick up the background index build if it finished since the
         // last frame. Non-blocking; costs ~one channel try_recv.

--- a/crates/outl-tui/src/state.rs
+++ b/crates/outl-tui/src/state.rs
@@ -622,6 +622,11 @@ pub(crate) struct App {
     /// can swap it at runtime without restarting the binary.
     pub(crate) theme: Theme,
 
+    /// First column of the mini-calendar week grid, read from
+    /// `config.toml`'s `[calendar] week_start` (`outl_config::WeekStart`)
+    /// at startup. Defaults to `Monday` (the historical layout).
+    pub(crate) week_start: outl_config::WeekStart,
+
     /// Registered code-block runtimes (`lisp`, `echo`, …). Used by
     /// `gx` / `:run`. Built once at startup; cheap to clone but we keep
     /// one instance per App.

--- a/crates/outl-tui/src/view/sidebar.rs
+++ b/crates/outl-tui/src/view/sidebar.rs
@@ -47,14 +47,24 @@ fn render_calendar(f: &mut ratatui::Frame<'_>, area: Rect, app: &App) {
         View::Page(_) => today,
     };
     let first = NaiveDate::from_ymd_opt(viewing.year(), viewing.month(), 1).unwrap_or(today);
-    // Weekday index, 0 = Monday — line up with the `Mo Tu …` header.
-    let weekday_offset = first.weekday().num_days_from_monday() as usize;
+    // Column of day 1, honouring the configured week start. Monday-first
+    // uses `num_days_from_monday` (`Mon→0`); Sunday-first uses
+    // `num_days_from_sunday` (`Sun→0`). Read from `config.toml`'s
+    // `[calendar] week_start`.
+    let sunday_first = matches!(app.week_start, outl_config::WeekStart::Sunday);
+    let weekday_offset = if sunday_first {
+        first.weekday().num_days_from_sunday() as usize
+    } else {
+        first.weekday().num_days_from_monday() as usize
+    };
     let days_in_month = days_in_month(viewing.year(), viewing.month());
 
-    let mut lines: Vec<Line<'static>> = vec![Line::from(Span::styled(
-        "Mo Tu We Th Fr Sa Su",
-        app.theme.dim,
-    ))];
+    let header = if sunday_first {
+        "Su Mo Tu We Th Fr Sa"
+    } else {
+        "Mo Tu We Th Fr Sa Su"
+    };
+    let mut lines: Vec<Line<'static>> = vec![Line::from(Span::styled(header, app.theme.dim))];
 
     let mut row_spans: Vec<Span<'static>> = Vec::new();
     // Pad the first week with blanks so day 1 aligns with its weekday.

--- a/docs/config.md
+++ b/docs/config.md
@@ -45,6 +45,11 @@ vim_mode = true
 # Outline font size in pixels (desktop only — the TUI uses your
 # terminal font).
 font_size = 15
+
+[calendar]
+# First column of the mini-calendar week grid: "monday" (default) or
+# "sunday". Honoured by the TUI sidebar and the desktop sidebar.
+week_start = "monday"
 ```
 
 ### Field reference
@@ -69,6 +74,12 @@ Available presets: `outl`, `default-dark`, `light`, `logseq-light`, `dracula`, `
 |---|---|---|---|---|
 | `vim_mode` | bool | `true` | desktop | When `false`, the desktop drops the modal `Normal / Insert / Visual` model and only listens to OS-standard chrome chords (`⌘P`, `⌘B`, …). The TUI is vim-style by definition and ignores this. |
 | `font_size` | integer (pixels) | `15` | desktop | Outline body font size. The TUI uses the user's terminal font; setting this has no effect there. |
+
+#### `[calendar]`
+
+| Field | Type | Default | Read by | Effect |
+|---|---|---|---|---|
+| `week_start` | `"monday"` \| `"sunday"` | `"monday"` | TUI, desktop | First column of the mini-calendar week grid. `"monday"` renders `Mo…Su`; `"sunday"` renders `Su…Sa`. Unknown values fall through to `"monday"`. The mobile calendar does not read this yet (iOS has no `~/.config/outl/config.toml`). |
 
 ---
 


### PR DESCRIPTION
Adds a `[calendar] week_start` option (`"monday"` default | `"sunday"`) to the shared `outl-config` schema, honoured by every client that renders a calendar.

- **outl-config**: new `CalendarCfg` + `WeekStart` enum, `#[serde(default)]` so existing configs keep the Monday layout. Partial-section test added.
- **TUI**: `App::week_start` read from the global config in `runtime`; `view::sidebar` uses it for the leading pad + weekday header (`Mo…` vs `Su…`).
- **Desktop**: threaded through `settings.rs` flat `Settings` → `getSettings` → `appState.weekStart`; `Sidebar.tsx` computes the lead + header from it (next to vim_mode/theme/font_size, same round-trip).

**Mobile is intentionally out of scope**: iOS has no `~/.config/outl/config.toml`, so it needs its own in-app setting (follow-up). This change also unifies the prior desktop-Monday / mobile-Sunday split on the two config-reading clients.

Docs: `docs/config.md`, `outl-config` lib doc + CLAUDE.md.

Local: `cargo test -p outl-config -p outl-tui -p outl-desktop` green, `tsc`/clippy/fmt clean, `bun --filter outl-desktop test` green.

Closes #94