### PR TITLE
fix: wrap block text under the cursor

### DIFF
--- a/crates/outl-tui/CLAUDE.md
+++ b/crates/outl-tui/CLAUDE.md
@@ -109,7 +109,10 @@ TUI-specific contracts worth remembering:
   Terminals don't reflow, and `Paragraph::wrap` can't be used because it expands lines *after* layout and would desync the `selected_line` scroll index.
   So `view::wrap::push_wrapped` emits the wrapped `Line`s up front: the first visual row keeps the bullet/fold `head`, continuations re-indent under the text column, and the `│ ` indent rails repeat on every row.
   Wrapping runs on the already-styled `Span`s (post-tokenization), so a break never splits a `**bold**` token back into literal asterisks.
-  **Cursor rows (Insert / Normal-selected) never wrap** — the cursor column is a byte offset into the unwrapped row, so the caller passes width `0` (the "don't wrap" sentinel) for them.
+  **Cursor rows (Insert / Normal-selected) wrap too** — `emit_row_with_cursor` bakes the caret / block cursor into the row's `Span`s *before* `push_wrapped` runs.
+  Reflowing just carries the cursor onto its wrapped visual row: the char offset was already consumed turning it into a span, so there's nothing left to desync.
+  The earlier "cursor rows pass width `0`" workaround was the actual #99 regression: the selected block stayed on one overflowing line and only wrapped once the cursor left it (`viewing mode won't wrap until I navigate away`).
+  `text_width == 0` is still the "don't wrap" sentinel, but only headless renders pass it now.
 
 ## Reuse across UI surfaces (Tauri, mobile)
 

--- a/crates/outl-tui/src/view/outline.rs
+++ b/crates/outl-tui/src/view/outline.rs
@@ -545,6 +545,24 @@ mod tests {
         line.spans.iter().map(|s| s.content.as_ref()).collect()
     }
 
+    /// Render one block at indent 0 with a leaf bullet and no auto-run,
+    /// the shape every wrap regression test needs. Keeps each test to
+    /// its `mode` + `width` instead of repeating the eight-arg call.
+    fn render_block_lines(app: &App, mode: RenderMode, width: u16) -> Vec<Line<'static>> {
+        let mut out = Vec::new();
+        emit_block_lines(
+            0,
+            app.theme.bullet,
+            &mode,
+            false,
+            FoldMarker::None,
+            app,
+            &mut out,
+            width,
+        );
+        out
+    }
+
     // The text used by the wrap regression tests: 43 cells of prose
     // that cannot fit in a 16-cell pane, so a correct renderer must
     // emit more than one visual row.
@@ -552,25 +570,15 @@ mod tests {
 
     /// #99: the selected block in Normal mode used to render on a single
     /// overflowing line and only wrap once the cursor moved off it. It
-    /// must wrap *while* the cursor sits on it.
+    /// must wrap while the cursor sits on it.
     #[test]
     fn normal_cursor_block_wraps_to_pane_width() {
         let (app, _dir) = test_app();
-        let mut out = Vec::new();
         let mode = RenderMode::NormalCursor {
             text: LONG.into(),
             cursor_char: 0,
         };
-        emit_block_lines(
-            0,
-            app.theme.bullet,
-            &mode,
-            false,
-            FoldMarker::None,
-            &app,
-            &mut out,
-            16,
-        );
+        let out = render_block_lines(&app, mode, 16);
         assert!(out.len() > 1, "expected wrap, got {} line(s)", out.len());
     }
 
@@ -579,21 +587,11 @@ mod tests {
     #[test]
     fn editing_block_wraps_and_keeps_the_caret() {
         let (app, _dir) = test_app();
-        let mut out = Vec::new();
         let mode = RenderMode::Editing {
             text: LONG.into(),
             cursor_char: 0,
         };
-        emit_block_lines(
-            0,
-            app.theme.bullet,
-            &mode,
-            false,
-            FoldMarker::None,
-            &app,
-            &mut out,
-            16,
-        );
+        let out = render_block_lines(&app, mode, 16);
         assert!(out.len() > 1, "expected wrap, got {} line(s)", out.len());
         let has_caret = out.iter().any(|l| line_text(l).contains('▏'));
         assert!(has_caret, "caret lost after wrap");
@@ -605,24 +603,14 @@ mod tests {
     #[test]
     fn block_cursor_survives_the_wrap_break() {
         let (app, _dir) = test_app();
-        let mut out = Vec::new();
-        // Cursor on the "d" of the trailing "dog" — past the first
+        // Cursor on the "d" of the trailing "dog", past the first
         // 16-cell row, so it can only be drawn on a continuation row.
         let cursor_char = LONG.len() - 3;
         let mode = RenderMode::NormalCursor {
             text: LONG.into(),
             cursor_char,
         };
-        emit_block_lines(
-            0,
-            app.theme.bullet,
-            &mode,
-            false,
-            FoldMarker::None,
-            &app,
-            &mut out,
-            16,
-        );
+        let out = render_block_lines(&app, mode, 16);
         assert!(out.len() > 1, "expected wrap, got {} line(s)", out.len());
         let cursor_cells = out
             .iter()
@@ -632,26 +620,16 @@ mod tests {
         assert_eq!(cursor_cells, 1, "block cursor must appear exactly once");
     }
 
-    /// A short block under the cursor still renders as a single line —
+    /// A short block under the cursor still renders as a single line:
     /// wrapping only kicks in past the pane width, cursor or not.
     #[test]
     fn short_cursor_block_stays_one_line() {
         let (app, _dir) = test_app();
-        let mut out = Vec::new();
         let mode = RenderMode::NormalCursor {
             text: "short".into(),
             cursor_char: 0,
         };
-        emit_block_lines(
-            0,
-            app.theme.bullet,
-            &mode,
-            false,
-            FoldMarker::None,
-            &app,
-            &mut out,
-            80,
-        );
+        let out = render_block_lines(&app, mode, 80);
         assert_eq!(out.len(), 1);
     }
 

--- a/crates/outl-tui/src/view/outline.rs
+++ b/crates/outl-tui/src/view/outline.rs
@@ -460,16 +460,14 @@ pub(crate) fn emit_block_lines(
             }
         }
 
-        // Cursor rows must stay on a single visual line: the cursor's
-        // column is a byte offset into the unwrapped row text, so
-        // splitting it across wrap rows would desync the caret from
-        // what the user typed. Only wrap when no cursor sits here.
-        let wrap_width = if row.cursor_col.is_some() {
-            0
-        } else {
-            text_width
-        };
-        push_wrapped(guides, head, content, wrap_width, out);
+        // Cursor rows wrap too (#99). The cursor is already baked into
+        // `content` as a styled span by `emit_row_with_cursor` *before*
+        // we wrap, so reflowing the spans just carries the cursor onto
+        // its wrapped visual row — the char offset was already consumed
+        // turning it into a span, there's nothing left to desync. A
+        // `text_width` of 0 (headless render) is still the "don't wrap"
+        // sentinel for every row, cursor or not.
+        push_wrapped(guides, head, content, text_width, out);
     }
 }
 
@@ -522,6 +520,167 @@ enum CursorStyle {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use outl_core::id::ActorId;
+    use outl_core::workspace::Workspace;
+    use tempfile::TempDir;
+
+    fn test_app() -> (App, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let actor = ActorId::new();
+        let ws = Workspace::open_in_memory(actor).unwrap();
+        let app = App::new(
+            dir.path().to_path_buf(),
+            ws,
+            actor,
+            crate::theme::default_theme(),
+            false,
+            outl_config::SyncConfig::default(),
+        )
+        .unwrap();
+        (app, dir)
+    }
+
+    /// Concatenate a rendered line's spans into one `String`.
+    fn line_text(line: &Line<'_>) -> String {
+        line.spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    // The text used by the wrap regression tests: 43 cells of prose
+    // that cannot fit in a 16-cell pane, so a correct renderer must
+    // emit more than one visual row.
+    const LONG: &str = "the quick brown fox jumps over the lazy dog";
+
+    /// #99: the selected block in Normal mode used to render on a single
+    /// overflowing line and only wrap once the cursor moved off it. It
+    /// must wrap *while* the cursor sits on it.
+    #[test]
+    fn normal_cursor_block_wraps_to_pane_width() {
+        let (app, _dir) = test_app();
+        let mut out = Vec::new();
+        let mode = RenderMode::NormalCursor {
+            text: LONG.into(),
+            cursor_char: 0,
+        };
+        emit_block_lines(
+            0,
+            app.theme.bullet,
+            &mode,
+            false,
+            FoldMarker::None,
+            &app,
+            &mut out,
+            16,
+        );
+        assert!(out.len() > 1, "expected wrap, got {} line(s)", out.len());
+    }
+
+    /// #99: the same must hold in Insert mode, and the thin caret has to
+    /// survive the reflow (it's baked into the spans before wrapping).
+    #[test]
+    fn editing_block_wraps_and_keeps_the_caret() {
+        let (app, _dir) = test_app();
+        let mut out = Vec::new();
+        let mode = RenderMode::Editing {
+            text: LONG.into(),
+            cursor_char: 0,
+        };
+        emit_block_lines(
+            0,
+            app.theme.bullet,
+            &mode,
+            false,
+            FoldMarker::None,
+            &app,
+            &mut out,
+            16,
+        );
+        assert!(out.len() > 1, "expected wrap, got {} line(s)", out.len());
+        let has_caret = out.iter().any(|l| line_text(l).contains('▏'));
+        assert!(has_caret, "caret lost after wrap");
+    }
+
+    /// The block cursor travels with its character across a wrap break:
+    /// a cursor on a word that lands on a continuation row still paints
+    /// exactly one inverted cell.
+    #[test]
+    fn block_cursor_survives_the_wrap_break() {
+        let (app, _dir) = test_app();
+        let mut out = Vec::new();
+        // Cursor on the "d" of the trailing "dog" — past the first
+        // 16-cell row, so it can only be drawn on a continuation row.
+        let cursor_char = LONG.len() - 3;
+        let mode = RenderMode::NormalCursor {
+            text: LONG.into(),
+            cursor_char,
+        };
+        emit_block_lines(
+            0,
+            app.theme.bullet,
+            &mode,
+            false,
+            FoldMarker::None,
+            &app,
+            &mut out,
+            16,
+        );
+        assert!(out.len() > 1, "expected wrap, got {} line(s)", out.len());
+        let cursor_cells = out
+            .iter()
+            .flat_map(|l| &l.spans)
+            .filter(|s| s.style == app.theme.cursor_block)
+            .count();
+        assert_eq!(cursor_cells, 1, "block cursor must appear exactly once");
+    }
+
+    /// A short block under the cursor still renders as a single line —
+    /// wrapping only kicks in past the pane width, cursor or not.
+    #[test]
+    fn short_cursor_block_stays_one_line() {
+        let (app, _dir) = test_app();
+        let mut out = Vec::new();
+        let mode = RenderMode::NormalCursor {
+            text: "short".into(),
+            cursor_char: 0,
+        };
+        emit_block_lines(
+            0,
+            app.theme.bullet,
+            &mode,
+            false,
+            FoldMarker::None,
+            &app,
+            &mut out,
+            80,
+        );
+        assert_eq!(out.len(), 1);
+    }
+
+    /// End-to-end of the #99 scenario: a page with one long block,
+    /// selected in Normal mode, rendered through the real
+    /// `render_outline` entry point into a narrow pane. The selected
+    /// block must occupy more than one visual line and the continuation
+    /// must re-indent under the bullet text.
+    #[test]
+    fn selected_block_wraps_through_render_outline() {
+        let (mut app, _dir) = test_app();
+        app.page = outl_md::parse::parse(&format!("- {LONG}"));
+        app.selected = 0;
+        app.cursor_col = 0;
+        app.mode = Mode::Normal;
+
+        let (lines, sel) = render_outline(&app.page, &app, 20);
+        assert_eq!(sel, Some(0), "selected block starts at line 0");
+        assert!(
+            lines.len() > 1,
+            "selected block must wrap, got {} line(s):\n{}",
+            lines.len(),
+            lines.iter().map(line_text).collect::<Vec<_>>().join("\n"),
+        );
+        // First row carries the bullet; the next is a continuation that
+        // re-indents under the text column (two leading spaces).
+        assert!(line_text(&lines[0]).contains("- "));
+        assert!(line_text(&lines[1]).starts_with("  "));
+    }
 
     #[test]
     fn embed_only_handle_detects_bare_token() {

--- a/crates/outl-tui/src/view/wrap.rs
+++ b/crates/outl-tui/src/view/wrap.rs
@@ -27,9 +27,11 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 /// every row so the indent structure reads the same top to bottom.
 ///
 /// `text_width == 0` (or a prefix already wider than the pane) means
-/// "don't wrap" — the caller passes 0 for cursor rows and headless
-/// renders, and we'd rather overflow a pathologically narrow pane than
-/// loop. This is the hot path for the common short block, so it stays
+/// "don't wrap" — the caller passes 0 for headless renders, and we'd
+/// rather overflow a pathologically narrow pane than loop. Cursor rows
+/// *do* wrap now (#99): the cursor is baked into `content` as a styled
+/// span before this call, so reflowing carries it onto its wrapped row.
+/// This is the hot path for the common short block, so it stays
 /// allocation-light: one `Line` straight through.
 pub(crate) fn push_wrapped(
     guides: Vec<Span<'static>>,
@@ -275,8 +277,8 @@ mod tests {
 
     #[test]
     fn push_wrapped_zero_width_never_wraps() {
-        // text_width 0 (cursor rows, headless renders) is the
-        // "don't wrap" sentinel — one line straight through.
+        // text_width 0 (headless renders) is the "don't wrap"
+        // sentinel — one line straight through.
         let mut out = Vec::new();
         push_wrapped(
             vec![],


### PR DESCRIPTION
The selected block in Normal mode and the block being edited in Insert never wrapped, because cursor rows passed width 0, the "don't wrap" sentinel. A long line ran off the right edge and only reflowed once the cursor left the block, so it looked like wrapping was broken until you navigated away and back (#99).

The cursor is baked into the spans by emit_row_with_cursor before the wrap runs, so reflowing just carries it onto its wrapped row with nothing left to desync. Cursor rows now pass the real pane width. Width 0 stays the sentinel only for headless renders. Added render tests for the wrapped cursor, the surviving caret, and the single block-cursor cell across a break.

Fixes #99