### PR TITLE
fix: rebuild block docs on demand instead of keeping them resident

### DIFF
--- a/crates/outl-core/CLAUDE.md
+++ b/crates/outl-core/CLAUDE.md
@@ -29,6 +29,27 @@ Treat every change as production-bound.
     See `docs/storage.md` → Concurrency / Failure modes.
 - Domain models: `Workspace`, `Page`, `Journal`, `Block`, `Property`, `Tag`
 
+### Block text is two-tier, not one live `Doc` per block
+
+`Workspace`'s `ContentStore` does **not** keep a live Yrs `Doc` resident for every block.
+That was the cause of issue #108: a vault in the hundreds-of-thousands-of-blocks range held 0.5-1GB of resident docs and iOS jetsam killed the app on open.
+
+Instead it keeps two tiers, both reconstructed on open from the op log:
+
+- `text: HashMap<NodeId, String>` — the materialized string of every block.
+  The hot read path behind `Workspace::block_text`.
+  Cheap, roughly the text size.
+- `cache: DocCache` — a bounded LRU (`DOC_CACHE_CAP = 512`) of live `Doc`s, only for blocks being edited or merged right now.
+  A cold block is rebuilt on demand via `Workspace::ensure_doc`, which replays that block's `Edit` ops from the log into a fresh `Doc`.
+  Yrs is a CRDT, so update order does not change the result — convergence is preserved.
+
+`open_with_storage` replays in **two passes**.
+Pass 1 applies every op to the tree/log (`Edit` is a no-op on the tree).
+Pass 2 groups `Edit` ops by node and materializes one `Doc` at a time, so the open-time memory peak is a single live doc rather than one per block.
+
+This is a materialization change only: the op log stays the source of truth, the `Doc`/string are projections, and the public surface (`block_text`, `build_text_replace_update`, `apply`) is unchanged.
+The resident `OpLog` still holds every `Op::Edit`'s `text_op` bytes (the cheaper second copy of history); shrinking that is the separate per-page op-log shards work, not this change.
+
 ## What this crate does NOT own
 
 - Markdown parsing/rendering → `outl-md`

--- a/crates/outl-core/CLAUDE.md
+++ b/crates/outl-core/CLAUDE.md
@@ -40,7 +40,7 @@ Instead it keeps two tiers, both reconstructed on open from the op log:
   The hot read path behind `Workspace::block_text`.
   Cheap, roughly the text size.
 - `cache: DocCache` — a bounded LRU (`DOC_CACHE_CAP = 512`) of live `Doc`s, only for blocks being edited or merged right now.
-  A cold block is rebuilt on demand via `Workspace::ensure_doc`, which replays that block's `Edit` ops from the log into a fresh `Doc`.
+  A cold block is rebuilt on demand via `ContentStore::ensure_doc` (private, in `src/content.rs`), which replays that block's `Edit` ops from the log into a fresh `Doc`.
   Yrs is a CRDT, so update order does not change the result — convergence is preserved.
 
 `open_with_storage` replays in **two passes**.

--- a/crates/outl-core/src/content.rs
+++ b/crates/outl-core/src/content.rs
@@ -149,14 +149,14 @@ impl ContentStore {
         if self.cache.contains(node) {
             return;
         }
-        let updates: Vec<Vec<u8>> = log
-            .iter()
-            .filter_map(|logged| match &logged.op {
-                Op::Edit { node: n, text_op } if *n == node => Some(text_op.clone()),
-                _ => None,
-            })
-            .collect();
-        let doc = build_doc(updates.iter().map(Vec::as_slice));
+        // Replay the block's edits straight from the log. `log` is a
+        // separate borrow from `self.cache`, so we can hand `build_doc`
+        // borrowed slices instead of cloning the block's whole history
+        // into a transient `Vec<Vec<u8>>` first.
+        let doc = build_doc(log.iter().filter_map(|logged| match &logged.op {
+            Op::Edit { node: n, text_op } if *n == node => Some(text_op.as_slice()),
+            _ => None,
+        }));
         self.cache.insert(node, doc);
     }
 
@@ -182,34 +182,37 @@ impl ContentStore {
     /// cold, and keeps the materialized string in sync.
     pub(crate) fn replace_text(&mut self, node: NodeId, log: &OpLog, new_text: &str) -> Vec<u8> {
         self.ensure_doc(node, log);
-        let update = self
+        // `ensure_doc` just cached this node, so the lookup can't miss. If
+        // it ever did, returning an empty update would silently drop the
+        // edit, so fail loud instead.
+        let doc = self
             .cache
             .get_mut(node)
-            .map(|doc| {
-                let text = doc.get_or_insert_text("content");
+            .expect("ensure_doc guarantees the node's doc is cached");
+        let text = doc.get_or_insert_text("content");
 
-                // Snapshot the state vector before our mutation so we can
-                // encode only the resulting delta.
-                let sv_before = {
-                    let txn = doc.transact();
-                    txn.state_vector()
-                };
+        // Snapshot the state vector before our mutation so we can encode
+        // only the resulting delta.
+        let sv_before = {
+            let txn = doc.transact();
+            txn.state_vector()
+        };
 
-                {
-                    let mut txn = doc.transact_mut();
-                    let len = text.len(&txn);
-                    if len > 0 {
-                        text.remove_range(&mut txn, 0, len);
-                    }
-                    if !new_text.is_empty() {
-                        text.insert(&mut txn, 0, new_text);
-                    }
-                }
+        {
+            let mut txn = doc.transact_mut();
+            let len = text.len(&txn);
+            if len > 0 {
+                text.remove_range(&mut txn, 0, len);
+            }
+            if !new_text.is_empty() {
+                text.insert(&mut txn, 0, new_text);
+            }
+        }
 
-                let txn = doc.transact();
-                txn.encode_state_as_update_v1(&sv_before)
-            })
-            .unwrap_or_default();
+        let update = {
+            let txn = doc.transact();
+            txn.encode_state_as_update_v1(&sv_before)
+        };
         self.text.insert(node, new_text.to_string());
         update
     }

--- a/crates/outl-core/src/content.rs
+++ b/crates/outl-core/src/content.rs
@@ -1,0 +1,229 @@
+//! Per-block text materialization.
+//!
+//! The structural CRDT (`Tree`) is text-free; block text convergence rides
+//! on Yrs. [`ContentStore`] owns that side of a [`Workspace`], and it is
+//! deliberately the *only* thing that writes the two text tiers so they
+//! can't drift:
+//!
+//! - `text`: the materialized string of every block, the hot read path.
+//!   Cheap, roughly the text size.
+//! - `cache`: a bounded LRU of live Yrs `Doc`s, only for blocks being
+//!   edited or merged right now. Rebuilt on demand from the op log.
+//!
+//! Holding a live `Doc` for every block is what pushed large vaults past
+//! the iOS memory limit (issue #108); the materialized string keeps
+//! steady-state RAM flat regardless of vault size.
+//!
+//! [`Workspace`]: crate::workspace::Workspace
+
+use crate::id::NodeId;
+use crate::log::OpLog;
+use crate::op::Op;
+use std::collections::{HashMap, VecDeque};
+use yrs::updates::decoder::Decode;
+use yrs::{Doc, GetString, ReadTxn, Text, Transact};
+
+/// How many live Yrs documents stay resident at once.
+///
+/// Only blocks being actively edited (or merging an incoming update) need
+/// a live `Doc`; every read is served from the materialized-text map. A
+/// few hundred live docs is a couple of MB, far under the iOS memory
+/// limit even on vaults in the hundreds of thousands of blocks.
+pub(crate) const DOC_CACHE_CAP: usize = 512;
+
+/// Build a fresh Yrs `Doc` by replaying a block's `Edit` updates.
+///
+/// Yrs is a CRDT, so the order updates are applied in does not change the
+/// resulting document. Malformed updates (corrupted peers) are skipped.
+fn build_doc<'a>(updates: impl Iterator<Item = &'a [u8]>) -> Doc {
+    let doc = Doc::new();
+    {
+        let _text = doc.get_or_insert_text("content");
+        let mut txn = doc.transact_mut();
+        for update in updates {
+            if let Ok(decoded) = yrs::Update::decode_v1(update) {
+                let _ = txn.apply_update(decoded);
+            }
+        }
+    }
+    doc
+}
+
+/// Materialize a `Doc`'s `content` text into a plain string.
+fn doc_string(doc: &Doc) -> String {
+    let text = doc.get_or_insert_text("content");
+    let txn = doc.transact();
+    text.get_string(&txn)
+}
+
+/// Bounded LRU of live Yrs documents.
+///
+/// A `Doc` is only needed to *mutate* a block (encode an edit delta) or to
+/// merge an incoming remote update. Reads come from the materialized
+/// string instead, so at most [`DOC_CACHE_CAP`] docs stay alive; a cold
+/// block being edited is rebuilt on demand from the op log.
+struct DocCache {
+    docs: HashMap<NodeId, Doc>,
+    /// Recency queue; the front is the least-recently-used node.
+    order: VecDeque<NodeId>,
+    cap: usize,
+}
+
+impl DocCache {
+    fn new(cap: usize) -> Self {
+        Self {
+            docs: HashMap::new(),
+            order: VecDeque::new(),
+            cap,
+        }
+    }
+
+    fn contains(&self, node: NodeId) -> bool {
+        self.docs.contains_key(&node)
+    }
+
+    fn touch(&mut self, node: NodeId) {
+        if let Some(pos) = self.order.iter().position(|n| *n == node) {
+            self.order.remove(pos);
+        }
+        self.order.push_back(node);
+    }
+
+    fn get_mut(&mut self, node: NodeId) -> Option<&mut Doc> {
+        if self.docs.contains_key(&node) {
+            self.touch(node);
+            self.docs.get_mut(&node)
+        } else {
+            None
+        }
+    }
+
+    fn insert(&mut self, node: NodeId, doc: Doc) {
+        if !self.docs.contains_key(&node) && self.docs.len() >= self.cap {
+            if let Some(evicted) = self.order.pop_front() {
+                self.docs.remove(&evicted);
+            }
+        }
+        self.docs.insert(node, doc);
+        self.touch(node);
+    }
+}
+
+/// Per-node block text, the two-tier store behind `Workspace`'s text API.
+pub(crate) struct ContentStore {
+    text: HashMap<NodeId, String>,
+    cache: DocCache,
+}
+
+impl Default for ContentStore {
+    fn default() -> Self {
+        Self {
+            text: HashMap::new(),
+            cache: DocCache::new(DOC_CACHE_CAP),
+        }
+    }
+}
+
+impl ContentStore {
+    /// Materialized text of a block, if it has any.
+    pub(crate) fn text(&self, node: NodeId) -> Option<String> {
+        self.text.get(&node).cloned()
+    }
+
+    /// Materialize a node's text from its `Edit` updates without caching
+    /// the `Doc`. Used during open so the memory peak stays at a single
+    /// live doc instead of one per block.
+    pub(crate) fn materialize<'a>(
+        &mut self,
+        node: NodeId,
+        updates: impl Iterator<Item = &'a [u8]>,
+    ) {
+        let doc = build_doc(updates);
+        self.text.insert(node, doc_string(&doc));
+    }
+
+    /// Ensure `node`'s `Doc` is resident in the cache, rebuilding it from
+    /// the block's `Edit` ops in `log` if it was evicted (or never loaded).
+    /// No-op when already cached.
+    fn ensure_doc(&mut self, node: NodeId, log: &OpLog) {
+        if self.cache.contains(node) {
+            return;
+        }
+        let updates: Vec<Vec<u8>> = log
+            .iter()
+            .filter_map(|logged| match &logged.op {
+                Op::Edit { node: n, text_op } if *n == node => Some(text_op.clone()),
+                _ => None,
+            })
+            .collect();
+        let doc = build_doc(updates.iter().map(Vec::as_slice));
+        self.cache.insert(node, doc);
+    }
+
+    /// Merge a raw Yrs update into a node's live `Doc` and refresh its
+    /// materialized string. Rebuilds the doc from `log` first if it was
+    /// cold. Both tiers stay in sync because only this method writes them.
+    pub(crate) fn merge_update(&mut self, node: NodeId, log: &OpLog, update: &[u8]) {
+        self.ensure_doc(node, log);
+        if let Some(doc) = self.cache.get_mut(node) {
+            {
+                let _text = doc.get_or_insert_text("content");
+                let mut txn = doc.transact_mut();
+                if let Ok(decoded) = yrs::Update::decode_v1(update) {
+                    let _ = txn.apply_update(decoded);
+                }
+            }
+            self.text.insert(node, doc_string(doc));
+        }
+    }
+
+    /// Rewrite a node's text to `new_text` and return the Yrs delta that
+    /// encodes the change. Rebuilds the doc from `log` first if it was
+    /// cold, and keeps the materialized string in sync.
+    pub(crate) fn replace_text(&mut self, node: NodeId, log: &OpLog, new_text: &str) -> Vec<u8> {
+        self.ensure_doc(node, log);
+        let update = self
+            .cache
+            .get_mut(node)
+            .map(|doc| {
+                let text = doc.get_or_insert_text("content");
+
+                // Snapshot the state vector before our mutation so we can
+                // encode only the resulting delta.
+                let sv_before = {
+                    let txn = doc.transact();
+                    txn.state_vector()
+                };
+
+                {
+                    let mut txn = doc.transact_mut();
+                    let len = text.len(&txn);
+                    if len > 0 {
+                        text.remove_range(&mut txn, 0, len);
+                    }
+                    if !new_text.is_empty() {
+                        text.insert(&mut txn, 0, new_text);
+                    }
+                }
+
+                let txn = doc.transact();
+                txn.encode_state_as_update_v1(&sv_before)
+            })
+            .unwrap_or_default();
+        self.text.insert(node, new_text.to_string());
+        update
+    }
+
+    /// Number of live `Doc`s currently resident. Test-only window into the
+    /// bound that keeps large vaults under the iOS memory limit (#108).
+    #[cfg(test)]
+    pub(crate) fn live_doc_count(&self) -> usize {
+        self.cache.docs.len()
+    }
+
+    /// Whether `node`'s `Doc` is currently resident in the cache.
+    #[cfg(test)]
+    pub(crate) fn is_cached(&self, node: NodeId) -> bool {
+        self.cache.contains(node)
+    }
+}

--- a/crates/outl-core/src/lib.rs
+++ b/crates/outl-core/src/lib.rs
@@ -13,6 +13,7 @@
 #![warn(missing_docs)]
 
 pub mod block;
+mod content;
 pub mod fractional;
 pub mod hlc;
 pub mod id;

--- a/crates/outl-core/src/log.rs
+++ b/crates/outl-core/src/log.rs
@@ -60,6 +60,14 @@ impl OpLog {
         self.ops.iter()
     }
 
+    /// Op at index `i` in HLC order, if any.
+    ///
+    /// Indices are only stable between reorders; callers that hold one
+    /// across an `apply_op` must re-derive it.
+    pub fn get(&self, i: usize) -> Option<&LogOp> {
+        self.ops.get(i)
+    }
+
     /// Whether the log already contains an op with this HLC.
     ///
     /// Implementation uses binary search over the HLC-sorted ops, so this

--- a/crates/outl-core/src/workspace.rs
+++ b/crates/outl-core/src/workspace.rs
@@ -14,6 +14,7 @@
 //! Higher-level methods (page CRUD, journal CRUD, block edit shortcuts)
 //! live in `outl-actions` and `outl-cli`, not here.
 
+use crate::content::ContentStore;
 use crate::id::{ActorId, NodeId};
 use crate::log::OpLog;
 use crate::op::{LogOp, Op};
@@ -21,8 +22,6 @@ use crate::storage::{Storage, StorageError};
 use crate::tree::Tree;
 use std::collections::HashMap;
 use std::path::PathBuf;
-use yrs::updates::decoder::Decode;
-use yrs::{Doc, GetString, ReadTxn, Text, Transact};
 
 /// Errors a workspace may surface to its caller.
 #[derive(Debug, thiserror::Error)]
@@ -30,36 +29,6 @@ pub enum WorkspaceError {
     /// Underlying storage failure.
     #[error(transparent)]
     Storage(#[from] StorageError),
-}
-
-/// Per-node Yrs documents holding block text.
-///
-/// Tree-level CRDT is structural only; per-block text convergence rides
-/// on Yrs. The store is private to the workspace and reconstructed on
-/// open from the op log.
-#[derive(Default)]
-struct ContentStore {
-    docs: HashMap<NodeId, Doc>,
-}
-
-impl ContentStore {
-    fn apply_update(&mut self, node: NodeId, update: &[u8]) {
-        let doc = self.docs.entry(node).or_default();
-        let mut txn = doc.transact_mut();
-        if let Ok(decoded) = yrs::Update::decode_v1(update) {
-            let _ = txn.apply_update(decoded);
-        }
-        // Silent ignore of malformed updates — those come from corrupted
-        // peers and shouldn't crash the local workspace. Surfaced via
-        // tracing instead.
-    }
-
-    fn text(&self, node: NodeId) -> Option<String> {
-        let doc = self.docs.get(&node)?;
-        let text = doc.get_or_insert_text("content");
-        let txn = doc.transact();
-        Some(text.get_string(&txn))
-    }
 }
 
 /// Top-level workspace.
@@ -105,13 +74,35 @@ impl Workspace {
             content: ContentStore::default(),
             storage,
         };
-        // Replay the persisted log.
+        // Pass 1: structural. Apply every op to the tree (`Edit` is a
+        // no-op there) and the log. Text is materialized in pass 2 so the
+        // open-time memory peak stays at a single live `Doc` instead of
+        // one per block — that peak is what jetsam was killing on iOS.
         let ops = ws.storage.all_ops()?;
         for op in ops {
-            if let Op::Edit { node, text_op } = &op.op {
-                ws.content.apply_update(*node, text_op);
-            }
             ws.tree.apply_op(&mut ws.log, op);
+        }
+
+        // Pass 2: text. Group `Edit` ops by node (indices only, no byte
+        // copies), then rebuild one `Doc` at a time, materialize its
+        // string, and drop it before moving on.
+        let mut edits_by_node: HashMap<NodeId, Vec<usize>> = HashMap::new();
+        for (i, logged) in ws.log.iter().enumerate() {
+            if let Op::Edit { node, .. } = &logged.op {
+                edits_by_node.entry(*node).or_default().push(i);
+            }
+        }
+        for (node, indices) in edits_by_node {
+            ws.content.materialize(
+                node,
+                indices.iter().filter_map(|&i| match ws.log.get(i) {
+                    Some(LogOp {
+                        op: Op::Edit { text_op, .. },
+                        ..
+                    }) => Some(text_op.as_slice()),
+                    _ => None,
+                }),
+            );
         }
         Ok(ws)
     }
@@ -124,7 +115,10 @@ impl Workspace {
     /// is responsible for surfacing the error and/or invoking `outl doctor`.
     pub fn apply(&mut self, op: LogOp) -> Result<(), WorkspaceError> {
         if let Op::Edit { node, text_op } = &op.op {
-            self.content.apply_update(*node, text_op);
+            // Merge the update into the block's text. The Doc is rebuilt
+            // from the log here, before this op is appended below, so the
+            // merge sees the prior state.
+            self.content.merge_update(*node, &self.log, text_op);
         }
         self.tree.apply_op(&mut self.log, op.clone());
         self.storage.append_op(&op)?;
@@ -146,6 +140,15 @@ impl Workspace {
         self.content.text(node)
     }
 
+    /// Number of live Yrs `Doc`s currently resident in the content cache.
+    ///
+    /// Test-only window into the bound that keeps large vaults under the
+    /// iOS memory limit (issue #108).
+    #[cfg(test)]
+    fn live_doc_count(&self) -> usize {
+        self.content.live_doc_count()
+    }
+
     /// Build a Yrs `update_v1` payload that, once wrapped in
     /// `Op::Edit { node, text_op }` and pushed through [`Self::apply`],
     /// rewrites the block's text to `new_text` exactly.
@@ -163,38 +166,18 @@ impl Workspace {
         if current == new_text {
             return Vec::new();
         }
-        let doc = self.content.docs.entry(node).or_default();
-        let text = doc.get_or_insert_text("content");
-
-        // Snapshot the state vector before our mutation so we can
-        // encode only the resulting delta.
-        let sv_before = {
-            let txn = doc.transact();
-            txn.state_vector()
-        };
-
-        {
-            let mut txn = doc.transact_mut();
-            let len = text.len(&txn);
-            if len > 0 {
-                text.remove_range(&mut txn, 0, len);
-            }
-            if !new_text.is_empty() {
-                text.insert(&mut txn, 0, new_text);
-            }
-        }
-
-        let txn = doc.transact();
-        txn.encode_state_as_update_v1(&sv_before)
+        self.content.replace_text(node, &self.log, new_text)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::content::DOC_CACHE_CAP;
     use crate::fractional::Fractional;
     use crate::hlc::HlcGenerator;
     use crate::op::Op;
+    use yrs::{Doc, Text, Transact};
 
     fn make_op(g: &HlcGenerator, op: Op) -> LogOp {
         let ts = g.next();
@@ -269,5 +252,155 @@ mod tests {
         .unwrap();
 
         assert_eq!(ws.block_text(n).as_deref(), Some("hello outl"));
+    }
+
+    /// Edit one block, then create + edit a fresh one. Reopening rebuilds
+    /// the text of both from the log even though neither Doc was kept
+    /// resident across the close.
+    #[test]
+    fn reopen_rebuilds_text_without_resident_docs() {
+        let actor = ActorId::new();
+        let g = HlcGenerator::new(actor);
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path().to_path_buf();
+
+        let storage = Box::new(crate::storage::JsonlStorage::open(dir.clone(), actor).unwrap());
+        let mut ws = Workspace::open_with_storage(actor, storage, None).unwrap();
+
+        let mut ids = Vec::new();
+        for i in 0..5 {
+            let n = NodeId::new();
+            ids.push(n);
+            ws.apply(make_op(
+                &g,
+                Op::Create {
+                    node: n,
+                    parent: NodeId::root(),
+                    position: Fractional::first(),
+                },
+            ))
+            .unwrap();
+            let update = ws.build_text_replace_update(n, &format!("block {i}"));
+            ws.apply(make_op(
+                &g,
+                Op::Edit {
+                    node: n,
+                    text_op: update,
+                },
+            ))
+            .unwrap();
+        }
+        drop(ws);
+
+        let storage = Box::new(crate::storage::JsonlStorage::open(dir, actor).unwrap());
+        let ws2 = Workspace::open_with_storage(actor, storage, None).unwrap();
+        for (i, n) in ids.iter().enumerate() {
+            assert_eq!(
+                ws2.block_text(*n).as_deref(),
+                Some(format!("block {i}").as_str())
+            );
+        }
+        // Pass 2 materializes strings and drops every Doc, so nothing is
+        // resident right after open — the whole point of issue #108.
+        assert_eq!(ws2.live_doc_count(), 0);
+    }
+
+    /// The live-Doc cache never grows past its cap, no matter how many
+    /// distinct blocks get edited in a session.
+    #[test]
+    fn doc_cache_is_bounded() {
+        let actor = ActorId::new();
+        let g = HlcGenerator::new(actor);
+        let mut ws = Workspace::open_in_memory(actor).unwrap();
+
+        let over = DOC_CACHE_CAP + 50;
+        for i in 0..over {
+            let n = NodeId::new();
+            ws.apply(make_op(
+                &g,
+                Op::Create {
+                    node: n,
+                    parent: NodeId::root(),
+                    position: Fractional::first(),
+                },
+            ))
+            .unwrap();
+            let update = ws.build_text_replace_update(n, &format!("b{i}"));
+            ws.apply(make_op(
+                &g,
+                Op::Edit {
+                    node: n,
+                    text_op: update,
+                },
+            ))
+            .unwrap();
+            assert!(ws.live_doc_count() <= DOC_CACHE_CAP);
+        }
+        assert_eq!(ws.live_doc_count(), DOC_CACHE_CAP);
+    }
+
+    /// A block evicted from the cache is rebuilt from the log on the next
+    /// edit, preserving its text instead of losing history.
+    #[test]
+    fn evicted_block_rebuilds_from_log() {
+        let actor = ActorId::new();
+        let g = HlcGenerator::new(actor);
+        let mut ws = Workspace::open_in_memory(actor).unwrap();
+
+        let first = NodeId::new();
+        ws.apply(make_op(
+            &g,
+            Op::Create {
+                node: first,
+                parent: NodeId::root(),
+                position: Fractional::first(),
+            },
+        ))
+        .unwrap();
+        let update = ws.build_text_replace_update(first, "hello");
+        ws.apply(make_op(
+            &g,
+            Op::Edit {
+                node: first,
+                text_op: update,
+            },
+        ))
+        .unwrap();
+
+        // Edit enough other blocks to evict `first` from the cache.
+        for i in 0..DOC_CACHE_CAP + 10 {
+            let n = NodeId::new();
+            ws.apply(make_op(
+                &g,
+                Op::Create {
+                    node: n,
+                    parent: NodeId::root(),
+                    position: Fractional::first(),
+                },
+            ))
+            .unwrap();
+            let u = ws.build_text_replace_update(n, &format!("x{i}"));
+            ws.apply(make_op(
+                &g,
+                Op::Edit {
+                    node: n,
+                    text_op: u,
+                },
+            ))
+            .unwrap();
+        }
+        assert!(!ws.content.is_cached(first));
+
+        // Rebuild on demand: appending to the evicted block keeps "hello".
+        let update = ws.build_text_replace_update(first, "hello world");
+        ws.apply(make_op(
+            &g,
+            Op::Edit {
+                node: first,
+                text_op: update,
+            },
+        ))
+        .unwrap();
+        assert_eq!(ws.block_text(first).as_deref(), Some("hello world"));
     }
 }

--- a/crates/outl-core/tests/concurrent_text_convergence.rs
+++ b/crates/outl-core/tests/concurrent_text_convergence.rs
@@ -1,0 +1,133 @@
+//! Cross-device convergence of block *text*, exercised at the `Workspace`
+//! layer (not the bare `Tree`).
+//!
+//! The rest of the battery drives the structural CRDT through `Replica`
+//! (`Tree` + `OpLog`) and never touches the `ContentStore` that
+//! materializes block text. This test closes that gap: two workspaces
+//! edit the same block concurrently, cross-deliver the `Op::Edit`s, and
+//! must converge to the same string — the property the issue #108
+//! two-tier `ContentStore` rewrite must not break.
+
+use outl_core::fractional::Fractional;
+use outl_core::hlc::HlcGenerator;
+use outl_core::id::{ActorId, NodeId};
+use outl_core::op::{LogOp, Op};
+use outl_core::Workspace;
+
+fn logop(g: &HlcGenerator, op: Op) -> LogOp {
+    let ts = g.next();
+    LogOp {
+        ts,
+        actor: ts.actor,
+        op,
+    }
+}
+
+/// Two actors edit the same block without seeing each other's edit, then
+/// exchange ops. Both replicas must end on the same text, and redelivery
+/// (sync re-sending an op) must not change it.
+#[test]
+fn concurrent_edits_converge_and_are_idempotent() {
+    let a1 = ActorId::new();
+    let a2 = ActorId::new();
+    let g1 = HlcGenerator::new(a1);
+    let g2 = HlcGenerator::new(a2);
+
+    let mut ws1 = Workspace::open_in_memory(a1).unwrap();
+    let mut ws2 = Workspace::open_in_memory(a2).unwrap();
+
+    // Shared block under root: actor 1 creates it, both apply the Create.
+    let b = NodeId::new();
+    let create = logop(
+        &g1,
+        Op::Create {
+            node: b,
+            parent: NodeId::root(),
+            position: Fractional::first(),
+        },
+    );
+    ws1.apply(create.clone()).unwrap();
+    ws2.apply(create).unwrap();
+
+    // Concurrent edits: neither workspace has seen the other's yet.
+    let u1 = ws1.build_text_replace_update(b, "hello");
+    let edit1 = logop(
+        &g1,
+        Op::Edit {
+            node: b,
+            text_op: u1,
+        },
+    );
+    ws1.apply(edit1.clone()).unwrap();
+
+    let u2 = ws2.build_text_replace_update(b, "world");
+    let edit2 = logop(
+        &g2,
+        Op::Edit {
+            node: b,
+            text_op: u2,
+        },
+    );
+    ws2.apply(edit2.clone()).unwrap();
+
+    assert_eq!(ws1.block_text(b).as_deref(), Some("hello"));
+    assert_eq!(ws2.block_text(b).as_deref(), Some("world"));
+
+    // Cross-deliver.
+    ws1.apply(edit2.clone()).unwrap();
+    ws2.apply(edit1.clone()).unwrap();
+
+    let s1 = ws1.block_text(b);
+    let s2 = ws2.block_text(b);
+    assert_eq!(s1, s2, "replicas diverged on block text: {s1:?} vs {s2:?}");
+    let converged = s1.expect("block has text");
+
+    // Redelivery of every op is a no-op on the converged text.
+    for op in [edit1, edit2] {
+        ws1.apply(op.clone()).unwrap();
+        ws2.apply(op).unwrap();
+    }
+    assert_eq!(ws1.block_text(b).as_deref(), Some(converged.as_str()));
+    assert_eq!(ws2.block_text(b).as_deref(), Some(converged.as_str()));
+}
+
+/// A workspace reloaded from storage rebuilds the same converged text from
+/// the op log alone, with no resident `Doc` carried across the reopen.
+#[test]
+fn converged_text_survives_reopen() {
+    let actor = ActorId::new();
+    let g = HlcGenerator::new(actor);
+    let tmp = tempfile::TempDir::new().unwrap();
+    let dir = tmp.path().to_path_buf();
+
+    let b = NodeId::new();
+    let converged = {
+        let storage = Box::new(outl_core::storage::JsonlStorage::open(dir.clone(), actor).unwrap());
+        let mut ws = Workspace::open_with_storage(actor, storage, None).unwrap();
+        ws.apply(logop(
+            &g,
+            Op::Create {
+                node: b,
+                parent: NodeId::root(),
+                position: Fractional::first(),
+            },
+        ))
+        .unwrap();
+        for text in ["draft", "draft v2", "final"] {
+            let u = ws.build_text_replace_update(b, text);
+            ws.apply(logop(
+                &g,
+                Op::Edit {
+                    node: b,
+                    text_op: u,
+                },
+            ))
+            .unwrap();
+        }
+        ws.block_text(b).expect("block has text")
+    };
+
+    let storage = Box::new(outl_core::storage::JsonlStorage::open(dir, actor).unwrap());
+    let ws2 = Workspace::open_with_storage(actor, storage, None).unwrap();
+    assert_eq!(ws2.block_text(b).as_deref(), Some(converged.as_str()));
+}


### PR DESCRIPTION
A vault of 80k blocks was unopenable on iOS. Every block that was ever edited kept its own live Yrs document resident for the whole session, so RSS climbed past the jetsam limit and the OS killed the app on open.

ContentStore now keeps a materialized text string per block for reads and only a bounded LRU of live docs for the blocks being edited, rebuilt from the op log on demand. Open replays in two passes so the memory peak is a single live doc, not one per block. Resident text RAM drops from ~1GB to a few MB on that vault, and the move-op CRDT kernel is untouched.

Fixes #108  