### PR TITLE
fix(desktop): let settings modal body scroll when content overflows

### DIFF
--- a/crates/outl-desktop/src/components/SettingsModal.tsx
+++ b/crates/outl-desktop/src/components/SettingsModal.tsx
@@ -82,8 +82,8 @@ export function SettingsModal() {
           if (e.target === e.currentTarget) close();
         }}
       >
-        <div class="mt-24 w-[480px] max-w-[90vw] overflow-hidden rounded-lg border border-(--color-outl-fg)/15 bg-(--color-outl-bg-elev)/95 shadow-2xl">
-          <header class="border-b border-(--color-outl-fg)/10 px-5 py-3">
+        <div class="mt-24 flex max-h-[calc(100vh-7rem)] w-[480px] max-w-[90vw] flex-col overflow-hidden rounded-lg border border-(--color-outl-fg)/15 bg-(--color-outl-bg-elev)/95 shadow-2xl">
+          <header class="shrink-0 border-b border-(--color-outl-fg)/10 px-5 py-3">
             <h2 class="text-lg font-semibold">Settings</h2>
           </header>
 
@@ -91,7 +91,7 @@ export function SettingsModal() {
             when={draft()}
             fallback={<div class="px-5 py-6 opacity-60">Loading…</div>}
           >
-            <div class="space-y-4 px-5 py-4">
+            <div class="min-h-0 flex-1 space-y-4 overflow-y-auto px-5 py-4">
               <label class="flex items-center justify-between gap-4">
                 <div>
                   <div class="text-sm font-medium">Vim mode</div>
@@ -181,7 +181,7 @@ export function SettingsModal() {
             </div>
           </Show>
 
-          <footer class="flex justify-end gap-2 border-t border-(--color-outl-fg)/10 px-5 py-3">
+          <footer class="flex shrink-0 justify-end gap-2 border-t border-(--color-outl-fg)/10 px-5 py-3">
             <button
               type="button"
               onClick={close}


### PR DESCRIPTION
The settings modal had a fixed layout, so on short windows the growing settings list pushed the footer (Save/Cancel) off-screen with no way to reach it. This caps the modal at the viewport height (`max-h-[calc(100vh-7rem)]`), makes the body the scroll container (`min-h-0 flex-1 overflow-y-auto`), and pins the header and footer (`shrink-0`).

## Tests

- `bun --filter outl-desktop test` — 69 passed.
- `tsc --noEmit` clean.