### PR TITLE
fix: load full edit history from storage when rebuilding docs after snapshot boot

### DIFF
--- a/crates/outl-core/src/content.rs
+++ b/crates/outl-core/src/content.rs
@@ -225,9 +225,22 @@ impl ContentStore {
     }
 
     /// Whether `node`'s `Doc` is currently resident in the cache.
-    #[cfg(test)]
     pub(crate) fn is_cached(&self, node: NodeId) -> bool {
         self.cache.contains(node)
+    }
+
+    /// Build and cache a `Doc` from the given updates, also refreshing
+    /// the materialized text. Used when the in-memory log is incomplete
+    /// (snapshot boot) and the full `Edit` history must be loaded from
+    /// storage to rebuild a correct Doc (#129).
+    pub(crate) fn cache_doc<'a>(&mut self, node: NodeId, updates: impl Iterator<Item = &'a [u8]>) {
+        if self.cache.contains(node) {
+            return;
+        }
+        let doc = build_doc(updates);
+        let s = doc_string(&doc);
+        self.text.insert(node, s);
+        self.cache.insert(node, doc);
     }
 
     /// Borrow the materialized text map. The snapshot path serializes it

--- a/crates/outl-core/src/workspace.rs
+++ b/crates/outl-core/src/workspace.rs
@@ -69,6 +69,13 @@ pub struct Workspace {
     /// `0` disables the in-band trigger (the CLI sets this — it's
     /// ephemeral and shouldn't churn the snapshots dir).
     snapshot_threshold: u32,
+    /// Whether `self.log` carries every op ever persisted (`true` after
+    /// full replay) or only the delta posted after a snapshot cutoff
+    /// (`false` after snapshot boot). When `false`, `Doc` rebuilds that
+    /// need the full `Edit` history for a node load it from storage via
+    /// [`Self::ensure_doc_for_edit`] — the in-memory log alone would
+    /// miss pre-snapshot edits and produce a wrong Doc state (#129).
+    log_complete: bool,
 }
 
 impl Workspace {
@@ -106,6 +113,7 @@ impl Workspace {
             snapshot_workers: Vec::new(),
             ops_since_snapshot: 0,
             snapshot_threshold: Workspace::DEFAULT_SNAPSHOT_THRESHOLD,
+            log_complete: true,
         };
 
         let booted_from_snapshot = match ws.boot_from_snapshot() {
@@ -117,7 +125,11 @@ impl Workspace {
             }
         };
 
-        if !booted_from_snapshot {
+        if booted_from_snapshot {
+            // The in-memory log only has delta ops; `Doc` rebuilds that
+            // need the full `Edit` history load it from storage (#129).
+            ws.log_complete = false;
+        } else {
             ws.boot_from_full_replay()?;
         }
 
@@ -170,31 +182,31 @@ impl Workspace {
         }
 
         // Re-materialize only the nodes whose text changed after the
-        // snapshot. Their `Edit` ops are replayed from the *full* log
-        // (Yrs is a CRDT, so re-applying the snapshot-era edits is
-        // idempotent) to keep a single text-derivation path.
+        // snapshot. The in-memory log only has delta ops (pre-snapshot
+        // ops are in storage), so we load the FULL `Edit` history for
+        // each edited node from storage. Replaying everything through a
+        // fresh `Doc` — pre-snapshot edits included — is what makes the
+        // resulting text match the full-replay path (#129).
         let rematerialized_count = edited_in_delta.len();
-        for node in edited_in_delta {
-            let indices: Vec<usize> = self
-                .log
+        for node in &edited_in_delta {
+            let ops = match self.storage.ops_for_node(*node) {
+                Ok(o) => o,
+                Err(e) => {
+                    warn!("skipping re-materialize for {node}: {e}");
+                    continue;
+                }
+            };
+            let updates: Vec<&[u8]> = ops
                 .iter()
-                .enumerate()
-                .filter_map(|(i, l)| match &l.op {
-                    Op::Edit { node: n, .. } if *n == node => Some(i),
+                .filter_map(|l| match &l.op {
+                    Op::Edit {
+                        node: n, text_op, ..
+                    } if n == node => Some(text_op.as_slice()),
                     _ => None,
                 })
                 .collect();
-            if !indices.is_empty() {
-                self.content.materialize(
-                    node,
-                    indices.iter().filter_map(|&i| match self.log.get(i) {
-                        Some(LogOp {
-                            op: Op::Edit { text_op, .. },
-                            ..
-                        }) => Some(text_op.as_slice()),
-                        _ => None,
-                    }),
-                );
+            if !updates.is_empty() {
+                self.content.materialize(*node, updates.into_iter());
             }
         }
 
@@ -252,6 +264,42 @@ impl Workspace {
         Ok(())
     }
 
+    /// Ensure the Yrs `Doc` for `node` is in the content cache with the
+    /// FULL `Edit` history applied.
+    ///
+    /// After snapshot boot, `self.log` only carries delta ops (the
+    /// pre-snapshot ops live in storage). Rebuilding a `Doc` from the
+    /// incomplete log would miss those edits, producing a wrong state
+    /// vector and, in turn, updates that concatenate instead of replace
+    /// on full replay (#129). When `log_complete` is `false`, we load
+    /// the node's entire `Edit` history from storage before the
+    /// `ContentStore`'s internal `ensure_doc` kicks in.
+    fn ensure_doc_for_edit(&mut self, node: NodeId) {
+        if self.content.is_cached(node) {
+            return;
+        }
+        if self.log_complete {
+            return; // ContentStore::ensure_doc rebuilds from the full log.
+        }
+        let ops = match self.storage.ops_for_node(node) {
+            Ok(o) => o,
+            Err(e) => {
+                warn!("could not load ops for {node} from storage: {e}");
+                return;
+            }
+        };
+        let updates: Vec<&[u8]> = ops
+            .iter()
+            .filter_map(|l| match &l.op {
+                Op::Edit {
+                    node: n, text_op, ..
+                } if *n == node => Some(text_op.as_slice()),
+                _ => None,
+            })
+            .collect();
+        self.content.cache_doc(node, updates.into_iter());
+    }
+
     /// Apply an op locally and persist it.
     ///
     /// The op is appended to the in-memory log, dispatched to the Yrs
@@ -263,6 +311,7 @@ impl Workspace {
             // Merge the update into the block's text. The Doc is rebuilt
             // from the log here, before this op is appended below, so the
             // merge sees the prior state.
+            self.ensure_doc_for_edit(*node);
             self.content.merge_update(*node, &self.log, text_op);
         }
         self.tree.apply_op(&mut self.log, op.clone());
@@ -451,6 +500,7 @@ impl Workspace {
         if current == new_text {
             return Vec::new();
         }
+        self.ensure_doc_for_edit(node);
         self.content.replace_text(node, &self.log, new_text)
     }
 }

--- a/crates/outl-core/src/workspace.rs
+++ b/crates/outl-core/src/workspace.rs
@@ -189,13 +189,17 @@ impl Workspace {
         // resulting text match the full-replay path (#129).
         let rematerialized_count = edited_in_delta.len();
         for node in &edited_in_delta {
-            let ops = match self.storage.ops_for_node(*node) {
+            let mut ops = match self.storage.ops_for_node(*node) {
                 Ok(o) => o,
                 Err(e) => {
                     warn!("skipping re-materialize for {node}: {e}");
                     continue;
                 }
             };
+            // `ops_for_node`'s order is backend-dependent (JsonlStorage's
+            // in-memory cache can be unsorted after appends). Sort by HLC so
+            // the Doc is rebuilt in the same order as the full-replay path.
+            ops.sort_by_key(|l| l.ts);
             let updates: Vec<&[u8]> = ops
                 .iter()
                 .filter_map(|l| match &l.op {
@@ -281,13 +285,18 @@ impl Workspace {
         if self.log_complete {
             return; // ContentStore::ensure_doc rebuilds from the full log.
         }
-        let ops = match self.storage.ops_for_node(node) {
+        let mut ops = match self.storage.ops_for_node(node) {
             Ok(o) => o,
             Err(e) => {
                 warn!("could not load ops for {node} from storage: {e}");
                 return;
             }
         };
+        // Sort by HLC before replay: `ops_for_node`'s return order is
+        // backend-dependent, and rebuilding the Doc in the same order as the
+        // full-replay path keeps the state vector deterministic across
+        // backends and sessions.
+        ops.sort_by_key(|l| l.ts);
         let updates: Vec<&[u8]> = ops
             .iter()
             .filter_map(|l| match &l.op {

--- a/crates/outl-core/tests/snapshot_equivalence.rs
+++ b/crates/outl-core/tests/snapshot_equivalence.rs
@@ -143,16 +143,12 @@ fn snapshot_and_delta_match_full_replay() {
     );
     drop(ws);
 
-    // 3. Apply delta: create a brand-new node + edit it. We avoid
-    //    re-editing a node that already had an `Edit` pre-snapshot —
-    //    `materialize` (used by both boot paths) re-derives a node's
-    //    text from its full Edit history on a fresh Doc, and a known
-    //    Yrs quirk with sequential same-actor `replace_text` updates
-    //    can concatenate rather than replace when re-applied out of
-    //    the original Doc's state-vector context. That bug is
-    //    independent of the snapshot path; both `from_snapshot` and
-    //    `from_full` would diverge from the live state the same way.
-    //    Tracked separately.
+    // 3. Apply delta: create a brand-new node + edit it, AND re-edit n1
+    //    (which was already edited pre-snapshot). The re-edit path used
+    //    to concatenate instead of replace because the in-memory log
+    //    after snapshot boot only carried delta ops, so the Doc rebuild
+    //    missed the pre-snapshot Edit (#129). With the fix, the full
+    //    Edit history is loaded from storage and the Doc is correct.
     let mut ws2 = Workspace::open_with_storage(
         actor,
         Box::new(JsonlStorage::open(ops_dir.clone(), actor).unwrap()),
@@ -180,9 +176,20 @@ fn snapshot_and_delta_match_full_replay() {
     ))
     .unwrap();
 
+    // Re-edit n1 — the exact scenario from #129. Both boot paths must
+    // see "hello world edited" (not "hello worldhello world edited").
+    let reedit = ws2.build_text_replace_update(n1, "hello world edited");
+    ws2.apply(logop(
+        &g,
+        Op::Edit {
+            node: n1,
+            text_op: reedit,
+        },
+    ))
+    .unwrap();
+
     // A structural op on a pre-existing node (no Edit conflict) —
-    // exercises the post-snapshot Move path without triggering the
-    // multi-Edit-per-node Yrs quirk.
+    // exercises the post-snapshot Move path.
     ws2.apply(logop(
         &g,
         Op::Move {

--- a/crates/outl-core/tests/text_replace_rebuild.rs
+++ b/crates/outl-core/tests/text_replace_rebuild.rs
@@ -267,7 +267,9 @@ fn multi_actor_edit_converges_on_replay() {
         None,
     )
     .unwrap();
-    // Last-write-wins by HLC ordering; B's edit has a later timestamp.
+    // The two actors edit with independent HLC generators, so which write
+    // wins is not fixed here — the guarantee under test is that the reopen
+    // resolves to exactly one edit's text, never a concatenation of both.
     let text = ws.block_text(n);
     assert!(
         text.as_deref() == Some("from A") || text.as_deref() == Some("from B"),

--- a/crates/outl-core/tests/text_replace_rebuild.rs
+++ b/crates/outl-core/tests/text_replace_rebuild.rs
@@ -1,0 +1,277 @@
+//! Block-text rebuild correctness across snapshot boundaries.
+//!
+//! Sequential same-actor `build_text_replace_update` on a node that was
+//! edited pre-snapshot, then re-edited post-snapshot, must produce the
+//! replacement (not concatenation) on every boot path.
+//!
+//! Root cause: after snapshot boot, the in-memory `OpLog` only carries
+//! delta ops (the pre-snapshot ops live in storage). When the content
+//! store rebuilt a `Doc` from the incomplete log, the `state_vector`
+//! captured before the second edit was wrong, so the encoded update
+//! conflicted with the first edit's blocks on full replay — the
+//! `remove_range` became a no-op and both inserts survived.
+
+use outl_core::fractional::Fractional;
+use outl_core::hlc::HlcGenerator;
+use outl_core::id::{ActorId, NodeId};
+use outl_core::op::{LogOp, Op};
+use outl_core::storage::JsonlStorage;
+use outl_core::workspace::Workspace;
+
+use tempfile::TempDir;
+
+fn logop(g: &HlcGenerator, op: Op) -> LogOp {
+    let ts = g.next();
+    LogOp {
+        ts,
+        actor: ts.actor,
+        op,
+    }
+}
+
+/// The exact scenario from the issue: two sequential edits on the same
+/// node, snapshot in between, reopen via both boot paths.
+#[test]
+fn reedit_after_snapshot_matches_full_replay() {
+    let tmp = TempDir::new().unwrap();
+    let dotl = tmp.path().join(".outl");
+    let ops_dir = dotl.join("ops");
+    let snapshots_dir = dotl.join("snapshots");
+    let actor = ActorId::new();
+    let g = HlcGenerator::new(actor);
+
+    // 1. Create a node, edit it, snapshot.
+    let mut ws = Workspace::open_with_storage(
+        actor,
+        Box::new(JsonlStorage::open(ops_dir.clone(), actor).unwrap()),
+        None,
+    )
+    .unwrap();
+    let n = NodeId::new();
+    ws.apply(logop(
+        &g,
+        Op::Create {
+            node: n,
+            parent: NodeId::root(),
+            position: Fractional::first(),
+        },
+    ))
+    .unwrap();
+    let u1 = ws.build_text_replace_update(n, "hello");
+    ws.apply(logop(
+        &g,
+        Op::Edit {
+            node: n,
+            text_op: u1,
+        },
+    ))
+    .unwrap();
+    assert_eq!(ws.block_text(n).as_deref(), Some("hello"));
+    ws.save_snapshot().unwrap();
+    drop(ws);
+
+    // 2. Reopen (snapshot boot), re-edit the same node.
+    let mut ws2 = Workspace::open_with_storage(
+        actor,
+        Box::new(JsonlStorage::open(ops_dir.clone(), actor).unwrap()),
+        None,
+    )
+    .unwrap();
+    assert_eq!(ws2.block_text(n).as_deref(), Some("hello"));
+    let u2 = ws2.build_text_replace_update(n, "hello world");
+    ws2.apply(logop(
+        &g,
+        Op::Edit {
+            node: n,
+            text_op: u2,
+        },
+    ))
+    .unwrap();
+    assert_eq!(ws2.block_text(n).as_deref(), Some("hello world"));
+    drop(ws2);
+
+    // 3. Reopen WITH snapshot (snapshot + delta path).
+    let from_snapshot = Workspace::open_with_storage(
+        actor,
+        Box::new(JsonlStorage::open(ops_dir.clone(), actor).unwrap()),
+        None,
+    )
+    .unwrap();
+
+    // 4. Remove snapshot, reopen via full replay.
+    std::fs::remove_dir_all(&snapshots_dir).unwrap();
+    let from_full = Workspace::open_with_storage(
+        actor,
+        Box::new(JsonlStorage::open(ops_dir.clone(), actor).unwrap()),
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(
+        from_snapshot.block_text(n).as_deref(),
+        Some("hello world"),
+        "snapshot+delta path must produce the replacement"
+    );
+    assert_eq!(
+        from_full.block_text(n).as_deref(),
+        Some("hello world"),
+        "full-replay path must produce the replacement, not concatenation"
+    );
+}
+
+/// Three sequential edits across two sessions (snapshot after the first,
+/// reopen, second + third edits, reopen again) — the original repro from
+/// the issue body, extended to cover multi-edit chains.
+#[test]
+fn three_edits_across_sessions() {
+    let tmp = TempDir::new().unwrap();
+    let dotl = tmp.path().join(".outl");
+    let ops_dir = dotl.join("ops");
+    let actor = ActorId::new();
+    let g = HlcGenerator::new(actor);
+
+    let mut ws = Workspace::open_with_storage(
+        actor,
+        Box::new(JsonlStorage::open(ops_dir.clone(), actor).unwrap()),
+        None,
+    )
+    .unwrap();
+    let n = NodeId::new();
+    ws.apply(logop(
+        &g,
+        Op::Create {
+            node: n,
+            parent: NodeId::root(),
+            position: Fractional::first(),
+        },
+    ))
+    .unwrap();
+
+    for text in ["alpha", "beta", "gamma"] {
+        let u = ws.build_text_replace_update(n, text);
+        ws.apply(logop(
+            &g,
+            Op::Edit {
+                node: n,
+                text_op: u,
+            },
+        ))
+        .unwrap();
+    }
+    assert_eq!(ws.block_text(n).as_deref(), Some("gamma"));
+    ws.save_snapshot().unwrap();
+    drop(ws);
+
+    // Reopen and edit twice more.
+    let mut ws2 = Workspace::open_with_storage(
+        actor,
+        Box::new(JsonlStorage::open(ops_dir.clone(), actor).unwrap()),
+        None,
+    )
+    .unwrap();
+    assert_eq!(ws2.block_text(n).as_deref(), Some("gamma"));
+    for text in ["delta", "epsilon"] {
+        let u = ws2.build_text_replace_update(n, text);
+        ws2.apply(logop(
+            &g,
+            Op::Edit {
+                node: n,
+                text_op: u,
+            },
+        ))
+        .unwrap();
+    }
+    assert_eq!(ws2.block_text(n).as_deref(), Some("epsilon"));
+    drop(ws2);
+
+    // Full replay.
+    let ws3 = Workspace::open_with_storage(
+        actor,
+        Box::new(JsonlStorage::open(ops_dir.clone(), actor).unwrap()),
+        None,
+    )
+    .unwrap();
+    assert_eq!(
+        ws3.block_text(n).as_deref(),
+        Some("epsilon"),
+        "five sequential edits must survive full replay"
+    );
+}
+
+/// Two different actors editing the same block, then full replay — a
+/// concurrent-edit path that must also converge correctly.
+#[test]
+fn multi_actor_edit_converges_on_replay() {
+    let tmp = TempDir::new().unwrap();
+    let dotl = tmp.path().join(".outl");
+    let ops_dir = dotl.join("ops");
+
+    let actor_a = ActorId::new();
+    let actor_b = ActorId::new();
+    let ga = HlcGenerator::new(actor_a);
+    let gb = HlcGenerator::new(actor_b);
+
+    // Actor A creates and edits.
+    let mut ws_a = Workspace::open_with_storage(
+        actor_a,
+        Box::new(JsonlStorage::open(ops_dir.clone(), actor_a).unwrap()),
+        None,
+    )
+    .unwrap();
+    let n = NodeId::new();
+    ws_a.apply(logop(
+        &ga,
+        Op::Create {
+            node: n,
+            parent: NodeId::root(),
+            position: Fractional::first(),
+        },
+    ))
+    .unwrap();
+    let u1 = ws_a.build_text_replace_update(n, "from A");
+    ws_a.apply(logop(
+        &ga,
+        Op::Edit {
+            node: n,
+            text_op: u1,
+        },
+    ))
+    .unwrap();
+    ws_a.save_snapshot().unwrap();
+    drop(ws_a);
+
+    // Actor B opens the same workspace and edits the same node.
+    let mut ws_b = Workspace::open_with_storage(
+        actor_b,
+        Box::new(JsonlStorage::open(ops_dir.clone(), actor_b).unwrap()),
+        None,
+    )
+    .unwrap();
+    assert_eq!(ws_b.block_text(n).as_deref(), Some("from A"));
+    let u2 = ws_b.build_text_replace_update(n, "from B");
+    ws_b.apply(logop(
+        &gb,
+        Op::Edit {
+            node: n,
+            text_op: u2,
+        },
+    ))
+    .unwrap();
+    assert_eq!(ws_b.block_text(n).as_deref(), Some("from B"));
+    drop(ws_b);
+
+    // Reopen (full replay across both actors' files).
+    let ws = Workspace::open_with_storage(
+        actor_a,
+        Box::new(JsonlStorage::open(ops_dir.clone(), actor_a).unwrap()),
+        None,
+    )
+    .unwrap();
+    // Last-write-wins by HLC ordering; B's edit has a later timestamp.
+    let text = ws.block_text(n);
+    assert!(
+        text.as_deref() == Some("from A") || text.as_deref() == Some("from B"),
+        "multi-actor edit must not concatenate: {:?}",
+        text
+    );
+}


### PR DESCRIPTION
After snapshot boot the in-memory OpLog only carried delta ops, so ensure_doc rebuilt Yrs Docs from an incomplete history. The state vector captured before the next edit was wrong, and the encoded update conflicted with pre-snapshot blocks on full replay. Text concatenated instead of replacing ("hellohello world" instead of "hello world").

Added a log_complete flag to Workspace. When false (snapshot boot), ensure_doc_for_edit loads all Edit ops for the node from storage before rebuilding the Doc. The LRU cache absorbs repeat hits. Also fixed boot_from_snapshot's own rematerialization loop, which had the same incomplete-log bug.

Fixes #129