### PR TITLE
fix: iroh sync survives custom-CA proxies and stale VPN peer addrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ Format inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the
 
 ### Fixed
 
+- **iroh sync survives restrictive networks — custom-CA proxies and post-VPN stale peer addrs (issue #133).**
+  Two blockers that stopped Mac ↔ iOS sync on corporate / VPN networks are fixed in code.
+  **Relay TLS with a custom root CA:** a network with a TLS-inspection proxy (its root CA installed in the OS keychain) had every relay handshake rejected with `invalid peer certificate: UnknownIssuer`, because iroh trusted only Mozilla's bundled roots — not the OS trust store that macOS / `curl` / Safari already honour.
+  outl now delegates relay-TLS validation to the OS keychain (iroh's `platform-verifier` + `CaTlsConfig::system()`, wired once in `bind::n0_builder_ipv4_only`), so a keychain-trusted proxy cert is accepted.
+  **Stale VPN/tunnel IPs after pairing:** a device paired while on a VPN captured its tunnel IPs (`10.x`, `100.x` CGNAT, a public WAN addr) into `peers.json` alongside the real LAN address, and iroh 1.0.0's multipath opened a path to each — stalling even same-WiFi direct sync on the dead paths (`MultipathNotNegotiated`) with the reachable `192.168.x` addr right there.
+  A dial now keeps only the direct IPv4 addresses that share a subnet with a local interface, dropping unreachable tunnel IPs before they can stall the connect (the relay still covers genuine cross-network peers).
+  A third failure mode — a proxy that blocks the relay's WebSocket `Upgrade` and returns `502` — is environmental (iroh 1.0.0 has no non-WebSocket relay transport); the workaround is a self-hosted `[sync] relay_url`, now documented under `docs/relay.md` → "Troubleshooting: restrictive networks".
 - **Underscores inside a word no longer render as italics.**
   The inline tokenizer paired any `_…_` as emphasis, so pasted identifiers like `chamados_chat`, `inc_lag1`, `prod.ml_atendimento`, or `databricks_2_train` rendered half-slanted.
   outl now follows CommonMark: `_` only opens or closes emphasis at a word boundary, never intra-word (`*` stays the intra-word marker).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3836,6 +3836,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "igd-next"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4208,6 +4218,7 @@ dependencies = [
  "reqwest 0.13.4",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_bytes",
  "strum",
@@ -6177,6 +6188,7 @@ dependencies = [
  "bytes",
  "chrono",
  "dirs",
+ "if-addrs",
  "iroh",
  "iroh-gossip",
  "n0-future",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,16 @@ yrs = "0.27"
 # the n0 discovery stack behind the default feature set. Disabling it strips
 # TLS and the endpoint fails to bind. There is no `discovery-n0` feature in
 # 1.0.0 — discovery presets live in `iroh::endpoint::presets`.
-iroh = "1.0.0"
+#
+# `platform-verifier` pulls in `rustls-platform-verifier` so we can delegate
+# relay-TLS validation to the OS keychain via `CaTlsConfig::system()` (see
+# `outl-sync-iroh/src/bind.rs`). Without it iroh's default
+# `CaTlsConfig::EmbeddedWebPki` (Mozilla's bundled roots) rejects any relay cert
+# issued by a custom root CA installed in the OS keychain — e.g. a corporate
+# TLS-inspection proxy — with `invalid peer certificate: UnknownIssuer`, even
+# though macOS / curl / Safari trust it fine. Enabling the feature is NOT enough
+# on its own: `system()` must be passed explicitly (default stays EmbeddedWebPki).
+iroh = { version = "1.0.0", features = ["platform-verifier"] }
 iroh-gossip = "0.101.0"
 
 # Markdown

--- a/crates/outl-sync-iroh/CLAUDE.md
+++ b/crates/outl-sync-iroh/CLAUDE.md
@@ -216,7 +216,7 @@ Shared seed/read/wait helpers stay in `tests/common/mod.rs` (read-only); saga-sp
 | 3. Mismatched ids are rejected | `delta_sync_rejects_mismatched_workspace_id` (pre-existing) | `tests/integration.rs` |
 | 4. Pairing adoption (joiner adopts host id, syncs as one) | `gui_pairing_over_live_sync_endpoint` (pre-existing; asserts adopted id persisted in both peers.json) | `tests/integration.rs` |
 | 5. Single endpoint per identity (pair AND sync over the live sync endpoint, no relay hijack) | `gui_pairing_over_live_sync_endpoint` (pre-existing; pairing rides the live sync endpoint, no second bind) | `tests/integration.rs` |
-| 6. Relay-only dial / reachability resolution order | the four `iroh_endpoint_addr_*` tests (prefers relay-only + drops stale direct addrs, falls back to stored addrs, falls back to bare node id, recovers from corrupt stored addr) | `src/peers.rs` `#[cfg(test)]` |
+| 6. Reachability resolution + off-LAN/IPv6 direct-addr filter (issue #133) | `iroh_endpoint_addr_*` + `is_reachable_lan_ipv4_*` (keep on-LAN IPv4, drop IPv6 + stale VPN IPs, fall back to stored/bare/corrupt) | `src/peers.rs` `#[cfg(test)]` |
 | 7. Bidirectional push materializes on BOTH sides AND fires BOTH reload signals | `bidirectional_sync_fires_reload_signal_on_both_sides` (set convergence + `peer_ready_tx` on initiator AND responder) | `tests/regression.rs` |
 | 7. (set-convergence half) both sides hold all ops | `bidirectional_delta_sync` (pre-existing) | `tests/integration.rs` |
 | 8. Membership merge is ADD-only (never clobber a local entry, drop self, drop undialable) | `merge_unknown_never_clobbers_a_known_entry` + `merge_skips_self` / `merge_adds_unknown_and_dedups_known` / `merge_skips_unreachable_peer` | `src/peers.rs`, `src/engine_membership.rs` `#[cfg(test)]` |
@@ -326,30 +326,26 @@ The transport on MCP/GUI is a **latency** optimization (real-time vs next catch-
 URL + **direct socket addrs** — base64-JSON-encoded in the `endpoint_addr`
 field, not just the bare node id.
 
-**Why:** a bare node id forces every connect (boot, catch-up, status probe) to depend on n0 discovery resolving a route, which does not resolve reliably between real devices.
-The status dot showed offline and the first sync never pulled history.
-Two devices on the same WiFi can connect instantly via direct addresses — but only if those addresses were captured and stored.
-They weren't: the old `PeerEntry` stored `relay_url: null` and no addrs.
+**Why:** a bare node id makes every connect depend on n0 discovery resolving a route, unreliable between real devices (offline dot, first sync never pulled history).
+Same-WiFi devices connect instantly via direct addrs — but only if captured; the old `PeerEntry` stored `relay_url: null` and no addrs.
 
-**Capture (`pairing::ready_addr`):** `endpoint.addr()` right after `bind()` is typically empty.
-Before minting the ticket (host) or sending the payload (joiner), both sides call `ready_addr`, which awaits `endpoint.online()` under a mandatory 5s timeout (`online` pends forever with no relay/WAN).
-After that the addr carries the relay + discovered LAN direct addrs.
-On timeout we proceed anyway — the local net report has usually already filled in the direct addrs, all two same-WiFi devices need.
+**Capture (`pairing::ready_addr`):** `endpoint.addr()` right after `bind()` is typically empty, so both sides call `ready_addr` before minting the ticket / sending the payload.
+It awaits `endpoint.online()` under a mandatory 5s timeout (pends forever with no relay/WAN), after which the addr carries the relay + LAN direct addrs; on timeout we proceed anyway (the local net report usually already filled them).
 
-**Exchange:** the host mints the ticket from its ready addr, so the joiner stores a reachable host; the joiner sends its own ready `EndpointAddr` in the pairing payload, so the host stores a reachable joiner.
-Each side persists the other's full addr.
+**Exchange:** host mints the ticket from its ready addr (joiner stores a reachable host); joiner sends its ready `EndpointAddr` in the payload (host stores a reachable joiner).
 
-**Resolution order** (`PeerEntry::iroh_endpoint_addr`): stored `endpoint_addr` → keep the relay + the **IPv4** direct addrs, **drop IPv6**; else id + `relay_url`; else bare id.
+**Resolution order** (`PeerEntry::iroh_endpoint_addr`): stored `endpoint_addr` → keep the relay + the **on-LAN IPv4** direct addrs, **drop IPv6** and **drop off-LAN IPv4**; else id + `relay_url`; else bare id.
 A corrupt `endpoint_addr` logs a warning and falls through, never failing the dial.
 
 **Why not relay-only:** it dropped all direct addrs, so a flaky relay broke even same-WiFi sync.
-Keeping IPv4 direct fixes it; IPv6 is dropped (a dead one stalls multipath for minutes).
+Keeping on-LAN IPv4 direct fixes it (IPv6 + off-LAN IPv4 dropped — a dead one stalls multipath).
 
-**Back-compat:** `endpoint_addr` is `#[serde(default)]`, so old `peers.json` entries (just `node_id` + `relay_url`) still deserialize and dial via the fallback.
-`relay_url` is kept for display + back-compat.
+**Off-LAN IPv4 drop (issue #133):** a VPN-paired peer stores tunnel IPs (`10.x`, `100.x`, WAN) beside its LAN addr, stalling iroh's multipath on the dead ones.
+`iroh_endpoint_addr` keeps only IPv4 on a **local** subnet (`is_reachable_lan_ipv4` + `if-addrs`; injectable `iroh_endpoint_addr_with_ifaces`), fail-open on error.
 
-The ticket codec and the `endpoint_addr` codec are the **same** function (`peers::encode_endpoint_addr` / `decode_endpoint_addr`).
-`encode_ticket` / `decode_ticket` delegate to it — a pairing ticket IS a `PeerEntry.endpoint_addr`.
+**Back-compat:** `endpoint_addr` is `#[serde(default)]`, so old `peers.json` entries (`node_id` + `relay_url` only) still deserialize and dial via the fallback; `relay_url` is kept for display.
+
+Ticket codec == `endpoint_addr` codec (`peers::encode_endpoint_addr` / `decode_endpoint_addr`); `encode_ticket` / `decode_ticket` delegate to it — a pairing ticket IS a `PeerEntry.endpoint_addr`.
 
 ## STOPGAP: IPv4-only bind (iroh 1.0.0 multipath workaround)
 

--- a/crates/outl-sync-iroh/Cargo.toml
+++ b/crates/outl-sync-iroh/Cargo.toml
@@ -32,6 +32,11 @@ qrcode = "0.14"
 # `bytes` is the payload type `GossipSender::broadcast` takes.
 base64 = "0.22"
 bytes = "1"
+# `if-addrs` enumerates the local machine's interfaces (ip + netmask) so a dial
+# can drop a peer's stored direct addrs that are NOT on any local subnet — stale
+# VPN / tunnel IPs captured at pairing time that would otherwise stall iroh's
+# multipath (`MultipathNotNegotiated`). See `PeerEntry::iroh_endpoint_addr`.
+if-addrs = "0.15"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/outl-sync-iroh/src/bind.rs
+++ b/crates/outl-sync-iroh/src/bind.rs
@@ -36,6 +36,7 @@
 
 use iroh::endpoint::presets;
 use iroh::endpoint::Builder;
+use iroh::tls::CaTlsConfig;
 use iroh::{RelayMode, RelayUrl};
 use tracing::warn;
 
@@ -75,7 +76,18 @@ pub(crate) fn n0_builder_ipv4_only(relay_url: Option<&str>) -> Builder {
     // `bind_addr("0.0.0.0:0")` re-adds IPv4 only. `bind_addr` only errors on an
     // unparseable socket address, and this constant is a valid literal, so the
     // `expect` cannot fire.
+    //
+    // `ca_tls_config(CaTlsConfig::system())` delegates relay-TLS trust to the OS
+    // keychain (`rustls-platform-verifier`, gated by the `platform-verifier`
+    // feature) instead of iroh's default `CaTlsConfig::EmbeddedWebPki` (Mozilla's
+    // bundled roots). Any environment with a custom root CA in the OS trust store
+    // — e.g. a corporate TLS-inspection proxy — has its relay certs accepted like
+    // macOS / curl / Safari already do, instead of failing every relay handshake
+    // with `invalid peer certificate: UnknownIssuer`. Enabling the feature alone
+    // is not sufficient: the default stays `EmbeddedWebPki` unless `system()` is
+    // passed explicitly.
     let builder = iroh::Endpoint::builder(presets::N0)
+        .ca_tls_config(CaTlsConfig::system())
         .clear_ip_transports()
         .bind_addr(IPV4_UNSPECIFIED)
         .expect("0.0.0.0:0 is a valid IPv4 socket address");

--- a/crates/outl-sync-iroh/src/engine_catchup.rs
+++ b/crates/outl-sync-iroh/src/engine_catchup.rs
@@ -75,11 +75,16 @@ pub(crate) async fn catch_up_loop(
     // Default resolver: reload peers.json each tick and build a full
     // EndpointAddr (id + relay) for every known peer.
     let resolver = move || match PeersStore::load_or_default(&peers_path) {
-        Ok(store) => store
-            .list()
-            .iter()
-            .filter_map(|p| p.iroh_endpoint_addr().ok())
-            .collect::<Vec<_>>(),
+        Ok(store) => {
+            // Enumerate local interfaces once per tick, not once per peer:
+            // `iroh_endpoint_addr` would call `getifaddrs` for every entry.
+            let ifaces = crate::peers::local_v4_ifaces();
+            store
+                .list()
+                .iter()
+                .filter_map(|p| p.iroh_endpoint_addr_with_ifaces(&ifaces).ok())
+                .collect::<Vec<_>>()
+        }
         Err(e) => {
             debug!("catch-up: reload peers.json failed: {e}");
             Vec::new()
@@ -128,11 +133,14 @@ pub(crate) async fn force_sync_all(
     in_flight: InFlightPeers,
 ) {
     let addrs: Vec<iroh::EndpointAddr> = match PeersStore::load_or_default(&peers_path) {
-        Ok(store) => store
-            .list()
-            .iter()
-            .filter_map(|p| p.iroh_endpoint_addr().ok())
-            .collect(),
+        Ok(store) => {
+            let ifaces = crate::peers::local_v4_ifaces();
+            store
+                .list()
+                .iter()
+                .filter_map(|p| p.iroh_endpoint_addr_with_ifaces(&ifaces).ok())
+                .collect()
+        }
         Err(e) => {
             debug!("sync-now: reload peers.json failed: {e}");
             return;

--- a/crates/outl-sync-iroh/src/peers.rs
+++ b/crates/outl-sync-iroh/src/peers.rs
@@ -17,7 +17,7 @@ use tracing::{debug, warn};
 /// stored direct addr shares a subnet with this machine — i.e. is reachable over
 /// the LAN at all. See [`is_reachable_lan_ipv4`].
 #[derive(Debug, Clone, Copy)]
-struct LocalV4 {
+pub(crate) struct LocalV4 {
     ip: Ipv4Addr,
     mask: Ipv4Addr,
 }
@@ -27,7 +27,13 @@ struct LocalV4 {
 /// Returns an empty `Vec` on any enumeration error — callers treat "no known
 /// interfaces" as **fail-open** (keep every IPv4 direct addr, the pre-filter
 /// behaviour) rather than dropping reachability on a transient syscall failure.
-fn local_v4_ifaces() -> Vec<LocalV4> {
+///
+/// This walks the OS interface list (`getifaddrs`), so a caller resolving a
+/// **batch** of peers (the catch-up resolver, `force_sync_all`) should call it
+/// **once** and pass the result to each
+/// [`PeerEntry::iroh_endpoint_addr_with_ifaces`], instead of letting the
+/// per-peer [`PeerEntry::iroh_endpoint_addr`] re-enumerate on every entry.
+pub(crate) fn local_v4_ifaces() -> Vec<LocalV4> {
     match if_addrs::get_if_addrs() {
         Ok(ifaces) => ifaces
             .into_iter()
@@ -63,11 +69,14 @@ fn same_subnet_v4(peer: Ipv4Addr, local: &LocalV4) -> bool {
 /// (`MultipathNotNegotiated`, ~30s). Dropping it loses nothing and removes the
 /// stall.
 ///
+/// **Loopback (`127.0.0.0/8`) is always kept**, independent of the interface
+/// list, so loopback dials (tests, same-host peers) never drop even if the OS
+/// enumeration omits `lo0` or reports it with an odd netmask.
 /// **`ifaces` empty ⇒ keep everything** (fail-open — see [`local_v4_ifaces`]).
-/// Loopback (`127.0.0.1`) always matches the `lo0` interface, so loopback dials
-/// (tests, same-host peers) are never dropped.
 fn is_reachable_lan_ipv4(peer: Ipv4Addr, ifaces: &[LocalV4]) -> bool {
-    ifaces.is_empty() || ifaces.iter().any(|iface| same_subnet_v4(peer, iface))
+    peer.is_loopback()
+        || ifaces.is_empty()
+        || ifaces.iter().any(|iface| same_subnet_v4(peer, iface))
 }
 
 /// Build the per-workspace peers path: `<workspace_root>/.outl/peers.json`.
@@ -213,7 +222,14 @@ impl PeerEntry {
     /// [`iroh_endpoint_addr`](Self::iroh_endpoint_addr) with the local IPv4
     /// interface list injected, so the LAN-reachability filter is unit-testable
     /// without depending on the host's real network config.
-    fn iroh_endpoint_addr_with_ifaces(&self, ifaces: &[LocalV4]) -> Result<iroh::EndpointAddr> {
+    ///
+    /// Batch callers (the catch-up resolver, `force_sync_all`) call
+    /// [`local_v4_ifaces`] once and pass the result here for every peer, so the
+    /// interface list is enumerated once per pass instead of once per peer.
+    pub(crate) fn iroh_endpoint_addr_with_ifaces(
+        &self,
+        ifaces: &[LocalV4],
+    ) -> Result<iroh::EndpointAddr> {
         let id = self.iroh_node_id()?;
         // Dial the relay AND the IPv4 direct addrs. On the same LAN the direct
         // IPv4 path connects without touching the relay — which is what saves
@@ -428,6 +444,13 @@ mod tests {
         ));
         // Empty iface list ⇒ fail-open (keep everything).
         assert!(is_reachable_lan_ipv4("10.71.22.9".parse().unwrap(), &[]));
+        // Loopback is kept even when the iface list has NO loopback entry —
+        // the allow-list is explicit, not dependent on enumeration.
+        let wifi_only = vec![iface("192.168.1.50", "255.255.255.0")];
+        assert!(is_reachable_lan_ipv4(
+            "127.0.0.1".parse().unwrap(),
+            &wifi_only
+        ));
     }
 
     /// Bug #6 (reachability resolution, relay branch): with a relay present, the

--- a/crates/outl-sync-iroh/src/peers.rs
+++ b/crates/outl-sync-iroh/src/peers.rs
@@ -8,9 +8,67 @@
 use anyhow::{Context, Result};
 use base64::Engine as _;
 use serde::{Deserialize, Serialize};
+use std::net::{Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 
 use tracing::{debug, warn};
+
+/// One local IPv4 interface (address + netmask), used to decide whether a peer's
+/// stored direct addr shares a subnet with this machine — i.e. is reachable over
+/// the LAN at all. See [`is_reachable_lan_ipv4`].
+#[derive(Debug, Clone, Copy)]
+struct LocalV4 {
+    ip: Ipv4Addr,
+    mask: Ipv4Addr,
+}
+
+/// Enumerate this machine's IPv4 interfaces (address + netmask).
+///
+/// Returns an empty `Vec` on any enumeration error — callers treat "no known
+/// interfaces" as **fail-open** (keep every IPv4 direct addr, the pre-filter
+/// behaviour) rather than dropping reachability on a transient syscall failure.
+fn local_v4_ifaces() -> Vec<LocalV4> {
+    match if_addrs::get_if_addrs() {
+        Ok(ifaces) => ifaces
+            .into_iter()
+            .filter_map(|iface| match iface.addr {
+                if_addrs::IfAddr::V4(v4) => Some(LocalV4 {
+                    ip: v4.ip,
+                    mask: v4.netmask,
+                }),
+                if_addrs::IfAddr::V6(_) => None,
+            })
+            .collect(),
+        Err(e) => {
+            warn!("could not enumerate local interfaces ({e}); keeping all IPv4 direct addrs");
+            Vec::new()
+        }
+    }
+}
+
+/// Does `peer` share a subnet with `local` (i.e. `peer & mask == local & mask`)?
+fn same_subnet_v4(peer: Ipv4Addr, local: &LocalV4) -> bool {
+    let mask = u32::from(local.mask);
+    (u32::from(peer) & mask) == (u32::from(local.ip) & mask)
+}
+
+/// Is `peer` on the same LAN subnet as any local interface?
+///
+/// This is the load-bearing filter for a peer's **stored** direct addrs: a
+/// direct addr on a subnet no local interface belongs to can only ever be a
+/// stale capture (a VPN/tunnel IP grabbed at pairing time, `100.x` CGNAT, a
+/// public WAN addr, …). Dialing it can never establish a direct path — the
+/// relay already covers cross-network reachability — but iroh 1.0.0's multipath
+/// opens a path to it anyway and stalls the whole connect on the dead path
+/// (`MultipathNotNegotiated`, ~30s). Dropping it loses nothing and removes the
+/// stall.
+///
+/// **`ifaces` empty ⇒ keep everything** (fail-open — see [`local_v4_ifaces`]).
+/// Loopback (`127.0.0.1`) always matches the `lo0` interface, so loopback dials
+/// (tests, same-host peers) are never dropped.
+fn is_reachable_lan_ipv4(peer: Ipv4Addr, ifaces: &[LocalV4]) -> bool {
+    ifaces.is_empty() || ifaces.iter().any(|iface| same_subnet_v4(peer, iface))
+}
 
 /// Build the per-workspace peers path: `<workspace_root>/.outl/peers.json`.
 ///
@@ -142,7 +200,20 @@ impl PeerEntry {
     /// 2. Node id + `relay_url` (legacy entries, or if the full addr won't
     ///    decode) — connecting via the relay still beats a bare id.
     /// 3. Bare node id — last resort, relies on n0 discovery resolving a route.
+    ///
+    /// Stored direct addrs are additionally filtered to the local machine's
+    /// current LAN: an IPv4 addr on a subnet no local interface belongs to (a
+    /// stale VPN/tunnel IP captured at pairing time) is dropped, because dialing
+    /// it can never form a direct path yet stalls iroh's multipath. See
+    /// `iroh_endpoint_addr_with_ifaces` for the injectable, unit-tested filter.
     pub fn iroh_endpoint_addr(&self) -> Result<iroh::EndpointAddr> {
+        self.iroh_endpoint_addr_with_ifaces(&local_v4_ifaces())
+    }
+
+    /// [`iroh_endpoint_addr`](Self::iroh_endpoint_addr) with the local IPv4
+    /// interface list injected, so the LAN-reachability filter is unit-testable
+    /// without depending on the host's real network config.
+    fn iroh_endpoint_addr_with_ifaces(&self, ifaces: &[LocalV4]) -> Result<iroh::EndpointAddr> {
         let id = self.iroh_node_id()?;
         // Dial the relay AND the IPv4 direct addrs. On the same LAN the direct
         // IPv4 path connects without touching the relay — which is what saves
@@ -157,6 +228,15 @@ impl PeerEntry {
         // before that bind. (The old code dialed relay-only to dodge the IPv6
         // stall, but that also threw away the LAN-direct path and made every
         // connect hostage to the relay.)
+        //
+        // We ALSO drop IPv4 direct addrs that are NOT on any local subnet: a
+        // peer paired while on a VPN captures its tunnel IPs (`10.x`, `100.x`
+        // CGNAT, a public WAN addr) into `endpoint_addr` alongside the real LAN
+        // address. Those are unreachable from this machine's LAN, but iroh 1.0.0
+        // opens a multipath path to each anyway and stalls the whole connect on
+        // the dead paths — even when the real `192.168.x` addr is right there.
+        // `is_reachable_lan_ipv4` keeps only addrs sharing a subnet with a local
+        // interface; the relay still covers genuine cross-network peers.
         let relay = self
             .relay_url
             .as_ref()
@@ -170,8 +250,10 @@ impl PeerEntry {
                         addr = addr.with_relay_url(url);
                     }
                     for sock in stored.ip_addrs() {
-                        if sock.is_ipv4() {
-                            addr = addr.with_ip_addr(*sock);
+                        if let SocketAddr::V4(v4) = sock {
+                            if is_reachable_lan_ipv4(*v4.ip(), ifaces) {
+                                addr = addr.with_ip_addr(*sock);
+                            }
                         }
                     }
                     return Ok(addr);
@@ -303,6 +385,52 @@ mod tests {
             .with_ip_addr("192.168.7.7:4242".parse().expect("direct addr"))
     }
 
+    /// A fake local interface, so the LAN-reachability filter is deterministic
+    /// regardless of the host running the test.
+    fn iface(ip: &str, mask: &str) -> LocalV4 {
+        LocalV4 {
+            ip: ip.parse().expect("iface ip"),
+            mask: mask.parse().expect("iface mask"),
+        }
+    }
+
+    /// The `192.168.7.0/24` LAN the `addr_with_relay_and_direct` direct addr
+    /// (`192.168.7.7`) lives on, so it survives the reachability filter.
+    fn lan_192_168_7() -> Vec<LocalV4> {
+        vec![iface("192.168.7.1", "255.255.255.0")]
+    }
+
+    /// Issue #3: `same_subnet_v4` / `is_reachable_lan_ipv4` — the pure filter
+    /// that drops stale VPN/tunnel IPv4 while keeping same-LAN and loopback.
+    #[test]
+    fn is_reachable_lan_ipv4_matches_only_local_subnets() {
+        let ifaces = vec![
+            iface("192.168.1.50", "255.255.255.0"), // home WiFi
+            iface("127.0.0.1", "255.0.0.0"),        // loopback
+        ];
+        // Same LAN + loopback: reachable.
+        assert!(is_reachable_lan_ipv4(
+            "192.168.1.83".parse().unwrap(),
+            &ifaces
+        ));
+        assert!(is_reachable_lan_ipv4("127.0.0.1".parse().unwrap(), &ifaces));
+        // VPN / CGNAT / WAN captured on another network: not reachable.
+        assert!(!is_reachable_lan_ipv4(
+            "10.71.22.9".parse().unwrap(),
+            &ifaces
+        ));
+        assert!(!is_reachable_lan_ipv4(
+            "100.78.230.122".parse().unwrap(),
+            &ifaces
+        ));
+        assert!(!is_reachable_lan_ipv4(
+            "188.37.137.132".parse().unwrap(),
+            &ifaces
+        ));
+        // Empty iface list ⇒ fail-open (keep everything).
+        assert!(is_reachable_lan_ipv4("10.71.22.9".parse().unwrap(), &[]));
+    }
+
     /// Bug #6 (reachability resolution, relay branch): with a relay present, the
     /// dial addr keeps the relay AND the IPv4 direct addrs — so a same-LAN peer
     /// connects directly without the (possibly flaky) relay — but DROPS global
@@ -319,7 +447,11 @@ mod tests {
             .with_ip_addr("[2001:db8::1]:4242".parse().expect("ipv6")); // dropped
         let entry = PeerEntry::from_endpoint_addr(&full, None).expect("build entry");
 
-        let resolved = entry.iroh_endpoint_addr().expect("resolve");
+        // Inject the peer's LAN as a local interface so the IPv4 direct addr is
+        // reachable and the assertion isolates the IPv6-drop behaviour.
+        let resolved = entry
+            .iroh_endpoint_addr_with_ifaces(&lan_192_168_7())
+            .expect("resolve");
         assert_eq!(resolved.id, id, "resolved must target the same node id");
         assert_eq!(
             resolved.relay_urls().count(),
@@ -334,6 +466,56 @@ mod tests {
         );
     }
 
+    /// Issue #3 (stale VPN/tunnel IPs in `peers.json`): a peer paired while on a
+    /// VPN captured its tunnel IPs alongside the real LAN address. On resolution
+    /// the dial must keep ONLY the same-LAN direct addr (`192.168.1.83`) and the
+    /// relay, dropping every unreachable tunnel/CGNAT/WAN IPv4 — otherwise iroh's
+    /// multipath stalls on the dead paths (`MultipathNotNegotiated`).
+    #[test]
+    fn iroh_endpoint_addr_drops_stale_vpn_ipv4_keeps_lan() {
+        let id = iroh::SecretKey::generate().public();
+        let relay: iroh::RelayUrl = "https://euc1-1.relay.n0.iroh.link./"
+            .parse()
+            .expect("relay url");
+        // The exact `endpoint_addr` payload from the issue: one real LAN addr
+        // buried among five stale tunnel/CGNAT/WAN addrs.
+        let full = iroh::EndpointAddr::new(id)
+            .with_relay_url(relay)
+            .with_ip_addr("10.71.22.9:62858".parse().unwrap())
+            .with_ip_addr("100.78.230.122:62858".parse().unwrap())
+            .with_ip_addr("100.85.18.51:62858".parse().unwrap())
+            .with_ip_addr("188.37.137.132:62858".parse().unwrap())
+            .with_ip_addr("192.0.0.6:62858".parse().unwrap())
+            .with_ip_addr("192.168.1.83:62858".parse().unwrap());
+        let entry = PeerEntry::from_endpoint_addr(&full, None).expect("build entry");
+
+        // This machine is on the same home WiFi as the peer.
+        let ifaces = vec![
+            iface("192.168.1.50", "255.255.255.0"),
+            iface("127.0.0.1", "255.0.0.0"),
+        ];
+        let resolved = entry
+            .iroh_endpoint_addr_with_ifaces(&ifaces)
+            .expect("resolve");
+
+        let ips: Vec<_> = resolved.ip_addrs().copied().collect();
+        assert_eq!(
+            ips.len(),
+            1,
+            "only the same-LAN direct addr survives, got {ips:?}"
+        );
+        assert_eq!(
+            ips[0],
+            "192.168.1.83:62858".parse().unwrap(),
+            "the survivor is the reachable LAN addr"
+        );
+        assert_eq!(
+            resolved.relay_urls().count(),
+            1,
+            "the relay stays as the cross-network fallback"
+        );
+    }
+
     /// Bug #6 (reachability resolution, no-relay branch): with no relay url, fall
     /// back to the stored full `endpoint_addr` (the loopback case — direct addrs
     /// are all we have, e.g. the integration tests dialing 127.0.0.1). Those
@@ -345,7 +527,9 @@ mod tests {
         // No relay → the resolution order must drop through to endpoint_addr.
         entry.relay_url = None;
 
-        let resolved = entry.iroh_endpoint_addr().expect("resolve");
+        let resolved = entry
+            .iroh_endpoint_addr_with_ifaces(&lan_192_168_7())
+            .expect("resolve");
         assert_eq!(resolved.id, full.id);
         assert!(
             resolved.ip_addrs().next().is_some(),

--- a/crates/outl-sync-iroh/src/peers.rs
+++ b/crates/outl-sync-iroh/src/peers.rs
@@ -250,10 +250,9 @@ impl PeerEntry {
                         addr = addr.with_relay_url(url);
                     }
                     for sock in stored.ip_addrs() {
-                        if let SocketAddr::V4(v4) = sock {
-                            if is_reachable_lan_ipv4(*v4.ip(), ifaces) {
-                                addr = addr.with_ip_addr(*sock);
-                            }
+                        if matches!(sock, SocketAddr::V4(v4) if is_reachable_lan_ipv4(*v4.ip(), ifaces))
+                        {
+                            addr = addr.with_ip_addr(*sock);
                         }
                     }
                     return Ok(addr);

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -174,6 +174,29 @@ For completeness, the shape of standing one up — this is the future-us checkli
 
 ---
 
+## Troubleshooting: restrictive networks (VPN, TLS-inspection proxy)
+
+Corporate / deep-inspection networks and VPNs break relay connectivity in three distinct ways.
+The first is fixed in code; the other two are environmental and need a config or pairing change.
+
+**TLS handshake fails with `UnknownIssuer` (fixed).**
+A network with a custom root CA in the OS keychain (a TLS-inspection proxy) used to have every relay handshake rejected.
+iroh trusted only Mozilla's bundled roots, not your OS trust store, even though macOS / `curl` / Safari accepted the same cert.
+outl now delegates relay-TLS trust to the OS keychain (`rustls-platform-verifier`, wired in `bind::n0_builder_ipv4_only`), so a keychain-trusted proxy cert is accepted.
+No action needed.
+
+**Relay WebSocket upgrade returns `502` (self-host the workaround).**
+Some proxies allow plain HTTPS but block or rewrite the HTTP `Upgrade: websocket` the relay needs, so the connection fails with `expected HTTP 101 Switching Protocols, got status code 502`.
+iroh 1.0.0 has no non-WebSocket relay transport to fall back to, so there is no code fix.
+Point `[sync] relay_url` at a relay on a domain/port the proxy doesn't intercept (see "It's already a config flip" above) — a self-hosted `iroh-relay` on your own domain sidesteps the interception.
+
+**Direct LAN sync stalls after pairing on a VPN (`MultipathNotNegotiated`).**
+If you pair two devices while one is on a VPN, the captured peer address in `peers.json` picks up the VPN's tunnel IPs (`10.x`, `100.x` CGNAT, a public WAN addr) alongside the real `192.168.x` LAN address.
+outl now drops direct addresses that aren't on any local subnet before dialing, so stale tunnel IPs no longer stall the connect.
+If you still hit it on an old `peers.json`, **re-pair with the VPN off** for the cleanest capture, or manually strip the non-LAN `"Ip"` entries (keep only `192.168.x` and the `Relay` entry).
+
+---
+
 ## See also
 
 - [Sync, done right](sync.md) — the transport layer, the op log, the CRDT, and how the iroh transport plugs into `outl-actions::SyncTransport`.


### PR DESCRIPTION
Mac and iOS stopped syncing on corporate and VPN networks. A TLS-inspection proxy with its root CA in the OS keychain got every relay handshake rejected as UnknownIssuer, because iroh only trusted Mozilla's bundled roots. And a device paired while on a VPN stored its tunnel IPs (10.x, 100.x CGNAT, a public WAN addr) in peers.json, so iroh's multipath stalled on the dead paths even with the real LAN address present.

Relay TLS now goes through the OS keychain via iroh's platform-verifier feature and CaTlsConfig::system(), wired once in the shared endpoint builder. A dial keeps only the direct IPv4 addresses on a local subnet, dropping unreachable tunnel IPs before they stall the connect. The relay WebSocket 502 case stays environmental (iroh has no non-websocket relay transport), documented under docs/relay.md with the self-hosted relay_url workaround.

Fixes #133
cc @SSamDav