### PR TITLE
fix: avoid sidecar churn on every ref open

### DIFF
--- a/crates/outl-tauri-shared/src/commands/page.rs
+++ b/crates/outl-tauri-shared/src/commands/page.rs
@@ -230,7 +230,7 @@ pub fn open_ref<S: AppHost>(
         open_or_create_by_ref(ws, state.hlc(), &target).map_err(|e| e.to_string())
     })?;
     with_ws_mut(state, |ws| {
-        if let Err(e) = outl_actions::apply_page_md_with_sidecar(ws, &root, id) {
+        if let Err(e) = outl_actions::apply_page_md_with_sidecar_if_absent(ws, &root, id) {
             // Non-fatal: the op log already has the mutation; the `.md`
             // projection will be retried on the next save / by the
             // orphan scanner on the next boot. Surface both to the local


### PR DESCRIPTION
open_ref projected .md + sidecar on every call. build_sidecar stamps last_synced_at: now(), so each ref-click rewrote the .outl file even when the .md was byte-identical. file-transport users (iCloud / Syncthing) see every click as a write that lands on the other device.

swap to the _if_absent variant introduced in #126: projects only when the .md is missing (new page case still works), skips when it already exists. desktop and mobile share the same body in outl-tauri-shared, so the one-line change covers both clients.

Fixes #127 