### PR TITLE
perf(core): add boot_scale_bench reproducing the RSS growth wall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ __pycache__/
 scripts/local-*.sh
 
 docs/app-store-*
+.lsp/
+.clj-kondo/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,7 +2276,7 @@ checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set 0.8.0",
  "cssparser",
- "foldhash",
+ "foldhash 0.2.0",
  "html5ever",
  "precomputed-hash",
  "selectors",
@@ -2718,6 +2718,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -3387,13 +3393,24 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -3404,7 +3421,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
  "serde",
  "serde_core",
 ]
@@ -4206,7 +4223,7 @@ dependencies = [
  "iroh-base",
  "iroh-dns",
  "iroh-metrics",
- "lru",
+ "lru 0.18.0",
  "n0-error",
  "n0-future",
  "noq",
@@ -4746,6 +4763,15 @@ dependencies = [
  "scoped-tls",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -6026,6 +6052,7 @@ dependencies = [
  "fs2",
  "hex",
  "libc",
+ "lru 0.12.5",
  "parking_lot",
  "proptest",
  "serde",
@@ -7225,7 +7252,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
- "lru",
+ "lru 0.18.0",
  "palette",
  "serde",
  "strum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6025,6 +6025,7 @@ dependencies = [
  "chrono",
  "fs2",
  "hex",
+ "libc",
  "parking_lot",
  "proptest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5997,6 +5997,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "ulid",
+ "walkdir",
  "yrs",
 ]
 
@@ -6251,6 +6252,7 @@ dependencies = [
  "tempfile",
  "tracing",
  "ulid",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ tauri-plugin-os = "2"
 # Dev
 proptest = "1"
 tempfile = "3"
+libc = "0.2"
 
 [profile.release]
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ fs2 = "0.4"
 
 # Concurrency
 parking_lot = "0.12"
+lru = "0.12"
 
 # Misc
 sha2 = "0.11"

--- a/crates/outl-actions/Cargo.toml
+++ b/crates/outl-actions/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = { workspace = true }
 chrono = { workspace = true }
 chrono-tz = { workspace = true }
 tracing = { workspace = true }
+walkdir = "2"
 yrs = { workspace = true }
 ulid = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/outl-actions/src/lib.rs
+++ b/crates/outl-actions/src/lib.rs
@@ -67,6 +67,7 @@ pub mod paste;
 pub mod person;
 pub mod quote;
 pub mod resolve;
+pub mod storage_scope;
 pub mod sync;
 pub mod todo;
 pub mod tree;

--- a/crates/outl-actions/src/storage_scope.rs
+++ b/crates/outl-actions/src/storage_scope.rs
@@ -19,6 +19,10 @@ use tracing::warn;
 /// the workspace. Also reads `.outl` sidecars to build the
 /// `NodeId → slug` map that `apply` uses to route ops.
 ///
+/// Shards are opened **unbounded** (cap = 0) so `all_ops()` returns
+/// the full history during the subsequent reboot. The caller applies
+/// `Workspace::apply_lru_cap(cap)` afterwards to shed cold history.
+///
 /// No-op when the `<actor>/` subdir doesn't exist (legacy Global
 /// layout). Safe to call on every boot.
 ///
@@ -30,7 +34,6 @@ pub fn register_per_page_storages(
     ws: &mut Workspace,
     ops_dir: &Path,
     actor: ActorId,
-    lru_cap: usize,
     workspace_root: &Path,
 ) {
     let actor_dir = ops_dir.join(actor.to_string());
@@ -56,7 +59,7 @@ pub fn register_per_page_storages(
             ops_dir.to_path_buf(),
             actor,
             PageScope::PerPage(slug.clone()),
-            lru_cap,
+            0, // unbounded — boot needs full history; caller applies LRU cap after reboot
         );
         match storage {
             Ok(s) => {

--- a/crates/outl-actions/src/storage_scope.rs
+++ b/crates/outl-actions/src/storage_scope.rs
@@ -1,0 +1,110 @@
+//! Per-page storage shard registration (RFC #137 Phase B).
+//!
+//! [`register_per_page_storages`] scans `ops/<actor>/` for per-page
+//! shards, opens each one, and registers it with the workspace. It
+//! also reads `.outl` sidecars under `pages/` and `journals/` to build
+//! the `NodeId → slug` map that `Workspace::apply` uses to route ops.
+//!
+//! Shared by CLI, TUI, desktop, and mobile so the registration logic
+//! can't drift across clients.
+
+use std::path::Path;
+
+use outl_core::id::ActorId;
+use outl_core::storage::{JsonlStorage, PageScope};
+use outl_core::workspace::Workspace;
+use tracing::warn;
+
+/// Scan `ops/<actor>/` for per-page shards and register each one with
+/// the workspace. Also reads `.outl` sidecars to build the
+/// `NodeId → slug` map that `apply` uses to route ops.
+///
+/// No-op when the `<actor>/` subdir doesn't exist (legacy Global
+/// layout). Safe to call on every boot.
+///
+/// After calling this, the caller should check
+/// [`Workspace::has_page_storages`] and, if true, call
+/// [`Workspace::reboot_with_all_storages`] so the materialized tree
+/// includes ops from every shard.
+pub fn register_per_page_storages(
+    ws: &mut Workspace,
+    ops_dir: &Path,
+    actor: ActorId,
+    lru_cap: usize,
+    workspace_root: &Path,
+) {
+    let actor_dir = ops_dir.join(actor.to_string());
+    if !actor_dir.is_dir() {
+        return;
+    }
+
+    let mut registered = 0usize;
+    for entry in walkdir::WalkDir::new(&actor_dir).max_depth(1) {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+            continue;
+        }
+        let slug = match path.file_stem().and_then(|s| s.to_str()) {
+            Some(s) => s.to_string(),
+            None => continue,
+        };
+        let storage = JsonlStorage::open_with_scope_cap(
+            ops_dir.to_path_buf(),
+            actor,
+            PageScope::PerPage(slug.clone()),
+            lru_cap,
+        );
+        match storage {
+            Ok(s) => {
+                ws.register_page_storage(&slug, Box::new(s));
+                registered += 1;
+            }
+            Err(e) => {
+                warn!("could not open per-page storage for {slug}: {e}");
+            }
+        }
+    }
+
+    if registered == 0 {
+        return;
+    }
+
+    tracing::info!("registered {registered} per-page storage shards");
+
+    // Build page-root → slug map from sidecars.
+    for dir in [
+        workspace_root.join("pages"),
+        workspace_root.join("journals"),
+    ] {
+        if !dir.is_dir() {
+            continue;
+        }
+        for entry in walkdir::WalkDir::new(&dir).max_depth(1) {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            let md_path = entry.path();
+            if md_path.extension().and_then(|s| s.to_str()) != Some("md") {
+                continue;
+            }
+            let sidecar_path = md_path.with_extension("outl");
+            let slug = match md_path.file_stem().and_then(|s| s.to_str()) {
+                Some(s) => s.to_string(),
+                None => continue,
+            };
+            match outl_md::sidecar::read(&sidecar_path) {
+                Ok(sc) => {
+                    ws.register_page_root(sc.page_id, &slug);
+                }
+                Err(e) => {
+                    warn!("skip sidecar {}: {e}", sidecar_path.display());
+                }
+            }
+        }
+    }
+}

--- a/crates/outl-cli/src/cmd/import.rs
+++ b/crates/outl-cli/src/cmd/import.rs
@@ -26,7 +26,7 @@ pub use common::ImportReport;
 pub fn run(source: &str, src: &Path, dst: &Path) -> Result<()> {
     let dst = dst.to_path_buf();
     if !dst.exists() {
-        crate::cmd::init::run(&dst)?;
+        crate::cmd::init::run(&dst, "global")?;
     }
     let paths = crate::workspace_layout::Paths::at(dst.clone());
 

--- a/crates/outl-cli/src/cmd/import/logseq.rs
+++ b/crates/outl-cli/src/cmd/import/logseq.rs
@@ -226,7 +226,7 @@ mod tests {
 
         let dst_dir = TempDir::new().unwrap();
         let dst = dst_dir.path().join("ws");
-        crate::cmd::init::run(&dst).unwrap();
+        crate::cmd::init::run(&dst, "global").unwrap();
         let paths = Paths::at(&dst);
         let report = import(src_dir.path(), &paths).unwrap();
 
@@ -257,7 +257,7 @@ mod tests {
 
         let dst_dir = TempDir::new().unwrap();
         let dst = dst_dir.path().join("ws");
-        crate::cmd::init::run(&dst).unwrap();
+        crate::cmd::init::run(&dst, "global").unwrap();
         let paths = Paths::at(&dst);
         let _ = import(src_dir.path(), &paths).unwrap();
 
@@ -281,7 +281,7 @@ mod tests {
 
         let dst_dir = TempDir::new().unwrap();
         let dst = dst_dir.path().join("ws");
-        crate::cmd::init::run(&dst).unwrap();
+        crate::cmd::init::run(&dst, "global").unwrap();
         let paths = Paths::at(&dst);
         let report = import(src_dir.path(), &paths).unwrap();
 

--- a/crates/outl-cli/src/cmd/import/obsidian/tests.rs
+++ b/crates/outl-cli/src/cmd/import/obsidian/tests.rs
@@ -21,7 +21,7 @@ use tempfile::TempDir;
 fn run_import(vault: &Path) -> (TempDir, Paths, ImportReport) {
     let dst_dir = TempDir::new().unwrap();
     let dst = dst_dir.path().join("ws");
-    crate::cmd::init::run(&dst).unwrap();
+    crate::cmd::init::run(&dst, "global").unwrap();
     let paths = Paths::at(dst);
     let report = import(vault, &paths).unwrap();
     (dst_dir, paths, report)
@@ -321,13 +321,13 @@ fn reimport_produces_same_files() {
 
     let dst1 = TempDir::new().unwrap();
     let dst1_path = dst1.path().join("ws");
-    crate::cmd::init::run(&dst1_path).unwrap();
+    crate::cmd::init::run(&dst1_path, "global").unwrap();
     let paths1 = Paths::at(dst1_path);
     import(vault.path(), &paths1).unwrap();
 
     let dst2 = TempDir::new().unwrap();
     let dst2_path = dst2.path().join("ws");
-    crate::cmd::init::run(&dst2_path).unwrap();
+    crate::cmd::init::run(&dst2_path, "global").unwrap();
     let paths2 = Paths::at(dst2_path);
     import(vault.path(), &paths2).unwrap();
 
@@ -353,7 +353,7 @@ fn reimport_into_same_destination_is_idempotent() {
 
     let dst = TempDir::new().unwrap();
     let dst_path = dst.path().join("ws");
-    crate::cmd::init::run(&dst_path).unwrap();
+    crate::cmd::init::run(&dst_path, "global").unwrap();
     let paths = Paths::at(dst_path.clone());
 
     import(vault.path(), &paths).unwrap();

--- a/crates/outl-cli/src/cmd/import/roam.rs
+++ b/crates/outl-cli/src/cmd/import/roam.rs
@@ -239,7 +239,7 @@ mod tests {
 
         let dst_dir = TempDir::new().unwrap();
         let dst = dst_dir.path().join("ws");
-        crate::cmd::init::run(&dst).unwrap();
+        crate::cmd::init::run(&dst, "global").unwrap();
         let paths = Paths::at(&dst);
         let report = import(&src, &paths).unwrap();
         // We return dst_dir to keep the tempdir alive.

--- a/crates/outl-cli/src/cmd/init.rs
+++ b/crates/outl-cli/src/cmd/init.rs
@@ -2,23 +2,29 @@
 
 use crate::workspace_layout::{init, read_config, today, Paths};
 use anyhow::{Context, Result};
-use outl_core::storage::JsonlStorage;
+use outl_core::storage::{JsonlStorage, PageScope};
 use std::fs;
 use std::path::Path;
 
 /// Run the `init` subcommand.
-pub fn run(path: &Path) -> Result<()> {
+///
+/// `scope = "per-page"` switches new workspaces to the Phase B layout
+/// (`ops/<actor>/<slug>.jsonl`) — boot is proportional to the active
+/// page, not the whole workspace. Default is `"global"` for back-compat
+/// with every existing workspace.
+pub fn run(path: &Path, scope: &str) -> Result<()> {
     let paths = Paths::at(path.to_path_buf());
 
     // Create all directories and seed config/templates.
     init(&paths)?;
 
-    // Touch the per-actor JSONL so the workspace has a writable
-    // storage from the first op onwards. We just want the file on
-    // disk; the handle is closed immediately.
     let cfg = read_config(&paths)?;
     let actor = cfg.actor()?;
-    let _ = JsonlStorage::open(paths.ops.clone(), actor)
+    let initial_scope = match scope {
+        "per-page" => PageScope::PerPage("home".into()),
+        _ => PageScope::Global,
+    };
+    let _ = JsonlStorage::open_with_scope_cap(paths.ops.clone(), actor, initial_scope, 0)
         .with_context(|| format!("opening JSONL log at {}", paths.ops.display()))?;
 
     // Seed today's journal if missing.
@@ -35,6 +41,7 @@ pub fn run(path: &Path) -> Result<()> {
     println!("  ops:      {}", paths.ops.display());
     println!("  config:   {}", paths.config.display());
     println!("  journal:  {}", journal_path.display());
+    println!("  scope:    {}", scope);
     Ok(())
 }
 
@@ -47,7 +54,7 @@ mod tests {
     fn init_creates_full_workspace() {
         let dir = TempDir::new().unwrap();
         let root = dir.path().join("notes");
-        run(&root).unwrap();
+        run(&root, "global").unwrap();
 
         let paths = Paths::at(&root);
         assert!(paths.dot_outl.is_dir(), ".outl/ should exist");
@@ -68,10 +75,22 @@ mod tests {
     fn init_is_idempotent() {
         let dir = TempDir::new().unwrap();
         let root = dir.path().join("notes");
-        run(&root).unwrap();
+        run(&root, "global").unwrap();
         // Second run must not error or wipe state.
-        run(&root).unwrap();
+        run(&root, "global").unwrap();
         let paths = Paths::at(&root);
+        assert!(paths.ops.is_dir());
+    }
+
+    #[test]
+    fn init_with_per_page_scope_creates_actor_subdir() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path().join("notes");
+        run(&root, "per-page").unwrap();
+
+        let paths = Paths::at(&root);
+        // `ops/` exists; the per-actor subdir gets created on first
+        // `JsonlStorage::open_with_scope_cap` call (lazy).
         assert!(paths.ops.is_dir());
     }
 }

--- a/crates/outl-cli/src/cmd/migrate_to_per_page_ops.rs
+++ b/crates/outl-cli/src/cmd/migrate_to_per_page_ops.rs
@@ -87,7 +87,8 @@ pub fn run(path: &std::path::Path) -> Result<()> {
         let target_path = actor_dir.join(format!("{slug}.jsonl"));
         let mut file = fs::OpenOptions::new()
             .create(true)
-            .append(true)
+            .write(true)
+            .truncate(true)
             .open(&target_path)
             .with_context(|| format!("opening {}", target_path.display()))?;
         for op in ops {

--- a/crates/outl-cli/src/cmd/migrate_to_per_page_ops.rs
+++ b/crates/outl-cli/src/cmd/migrate_to_per_page_ops.rs
@@ -1,0 +1,280 @@
+//! `outl migrate-to-per-page-ops <path>` — Phase B of RFC #137.
+//!
+//! Reads the legacy `ops/ops-<actor>.jsonl` and splits it into
+//! `ops/<actor>/<slug>.jsonl` per page. The original file is preserved
+//! as `ops/ops-<actor>.jsonl.v0.bak` so the migration is reversible.
+//!
+//! Idempotent: a second run is a no-op once the legacy file is gone.
+//!
+//! Routing rule: each op carries a `node: NodeId`. We resolve that
+//! node to its page's slug by walking the materialized tree (the
+//! Workspace is opened on the legacy storage to do this) and looking
+//! up the root id in the `WorkspaceIndex` (which knows the slug of
+//! every `.md` file under `pages/` and `journals/`). Ops whose node
+//! can't be resolved (orphan, root, deleted-before-boot) land in the
+//! `_default` bucket so nothing is lost.
+
+use crate::workspace_layout::{read_config, Paths};
+use anyhow::{bail, Context, Result};
+use outl_core::id::NodeId;
+use outl_core::op::LogOp;
+use outl_core::storage::JsonlStorage;
+use outl_core::Workspace;
+use outl_md::sidecar;
+use std::collections::HashMap;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+/// Run the `migrate-to-per-page-ops` subcommand.
+pub fn run(path: &std::path::Path) -> Result<()> {
+    let paths = Paths::at(path.to_path_buf());
+    let cfg = read_config(&paths)?;
+    let actor = cfg.actor()?;
+
+    let legacy_path = paths.ops.join(format!("ops-{actor}.jsonl"));
+    if !legacy_path.exists() {
+        bail!(
+            "no legacy op log at {} — already migrated or never initialised",
+            legacy_path.display()
+        );
+    }
+
+    // Build a `NodeId → slug` map by reading every `.outl` sidecar
+    // under `pages/` and `journals/`. The sidecar's `page_id` is the
+    // root block id of that page; the slug is the filename without
+    // extension.
+    let root_to_slug =
+        build_root_to_slug_map(&paths).with_context(|| "building page-root → slug map")?;
+
+    println!(
+        "Loaded {} page+journal roots from sidecars.",
+        root_to_slug.len()
+    );
+
+    // Open the legacy storage so the materialised tree is in RAM. We
+    // need it to walk parent chains from any node up to its page root.
+    let ws = Workspace::open_with_storage(
+        actor,
+        Box::new(
+            JsonlStorage::open(paths.ops.clone(), actor)
+                .with_context(|| format!("opening legacy storage at {}", paths.ops.display()))?,
+        ),
+        Some(paths.root.clone()),
+    )
+    .with_context(|| "opening workspace for migration")?;
+    let tree = ws.tree().clone();
+    drop(ws);
+
+    // Stream the legacy file once, bucket ops by slug, write each
+    // bucket into its `ops/<actor>/<slug>.jsonl`.
+    let buckets = bucket_ops_by_slug(&legacy_path, &tree, &root_to_slug)?;
+    if buckets.is_empty() {
+        println!("No ops to migrate at {}", legacy_path.display());
+        return Ok(());
+    }
+
+    let actor_dir = paths.ops.join(actor.to_string());
+    fs::create_dir_all(&actor_dir).with_context(|| format!("creating {}", actor_dir.display()))?;
+
+    let mut total_written = 0usize;
+    let mut per_bucket: Vec<(String, usize)> = buckets
+        .iter()
+        .map(|(slug, ops)| (slug.clone(), ops.len()))
+        .collect();
+    per_bucket.sort_by_key(|b| std::cmp::Reverse(b.1));
+    for (slug, ops) in &buckets {
+        let target_path = actor_dir.join(format!("{slug}.jsonl"));
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&target_path)
+            .with_context(|| format!("opening {}", target_path.display()))?;
+        for op in ops {
+            let line =
+                serde_json::to_string(op).with_context(|| format!("serialising op {:?}", op.ts))?;
+            use std::io::Write;
+            writeln!(file, "{line}")
+                .with_context(|| format!("writing {}", target_path.display()))?;
+        }
+        total_written += ops.len();
+    }
+
+    println!("\nBuckets written:");
+    for (slug, count) in &per_bucket {
+        println!("  {slug:<40} {count:>6} ops");
+    }
+
+    // Backup the legacy file. Renamed, not deleted, so the migration
+    // is reversible: rename back, delete the per-actor dir, you're
+    // back on Global.
+    let backup_path = legacy_path.with_extension("jsonl.v0.bak");
+    fs::rename(&legacy_path, &backup_path).with_context(|| {
+        format!(
+            "backing up {} → {}",
+            legacy_path.display(),
+            backup_path.display()
+        )
+    })?;
+
+    println!(
+        "\nMigrated {} ops across {} pages. Backup at {}.",
+        total_written,
+        buckets.len(),
+        backup_path.display()
+    );
+    println!(
+        "Run `outl serve --once --workspace {}` to verify the new layout.",
+        paths.root.display()
+    );
+    Ok(())
+}
+
+/// Stream the legacy `.jsonl` once and bucket each op by the slug of
+/// its node's owning page.
+///
+/// Walks `tree.parent(node)` up to the page root, then looks up the
+/// root id in `root_to_slug`. Ops that can't be resolved (orphan,
+/// root, deleted-before-boot) land in `_default`.
+fn bucket_ops_by_slug(
+    legacy_path: &PathBuf,
+    tree: &outl_core::tree::Tree,
+    root_to_slug: &HashMap<NodeId, String>,
+) -> Result<HashMap<String, Vec<LogOp>>> {
+    let file = fs::File::open(legacy_path)
+        .with_context(|| format!("opening {}", legacy_path.display()))?;
+    let reader = BufReader::new(file);
+    let mut buckets: HashMap<String, Vec<LogOp>> = HashMap::new();
+    let mut unresolved = 0usize;
+    let mut total = 0usize;
+    for (lineno, line) in reader.lines().enumerate() {
+        let raw = match line {
+            Ok(l) if !l.is_empty() => l,
+            Ok(_) => continue,
+            Err(e) => {
+                bail!("read {}:{}: {e}", legacy_path.display(), lineno + 1);
+            }
+        };
+        let stream = serde_json::Deserializer::from_str(&raw).into_iter::<LogOp>();
+        for op in stream {
+            let op =
+                op.with_context(|| format!("parse {}:{}", legacy_path.display(), lineno + 1))?;
+            total += 1;
+            let node = outl_core::op::op_node(&op.op).unwrap_or(NodeId::root());
+            let slug = resolve_page_slug(node, tree, root_to_slug);
+            if slug.is_none() {
+                unresolved += 1;
+            }
+            buckets
+                .entry(slug.unwrap_or_else(|| "_default".to_string()))
+                .or_default()
+                .push(op);
+        }
+    }
+    if unresolved > 0 {
+        println!(
+            "  {unresolved}/{total} ops couldn't be resolved to a page — landing in _default."
+        );
+    }
+    Ok(buckets)
+}
+
+/// Walk `tree.parent(node)` up until we hit a node whose id is in
+/// `root_to_slug`. Returns the slug of that page, or `None` if the
+/// chain dead-ends at the workspace root without finding a page.
+fn resolve_page_slug(
+    mut node: NodeId,
+    tree: &outl_core::tree::Tree,
+    root_to_slug: &HashMap<NodeId, String>,
+) -> Option<String> {
+    loop {
+        if let Some(slug) = root_to_slug.get(&node) {
+            return Some(slug.clone());
+        }
+        node = tree.parent(node)?;
+    }
+}
+
+/// Read every `.outl` sidecar under `pages/` and `journals/` and build
+/// a `NodeId → slug` map. The sidecar's `page_id` field is the root
+/// block id of the page; the slug is the filename without extension.
+///
+/// Sidecars that fail to parse are skipped (logged) — they'll be
+/// rebuilt on the next `outl serve --once` after migration.
+fn build_root_to_slug_map(paths: &Paths) -> Result<HashMap<NodeId, String>> {
+    let mut map = HashMap::new();
+    for (dir, _is_journal) in [(paths.pages.clone(), false), (paths.journals.clone(), true)] {
+        if !dir.is_dir() {
+            continue;
+        }
+        for entry in walkdir::WalkDir::new(&dir).max_depth(1) {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("md") {
+                continue;
+            }
+            let sidecar_path = path.with_extension("outl");
+            let slug = match path.file_stem().and_then(|s| s.to_str()) {
+                Some(s) => s.to_string(),
+                None => continue,
+            };
+            match sidecar::read(&sidecar_path) {
+                Ok(sc) => {
+                    map.insert(sc.page_id, slug);
+                }
+                Err(e) => {
+                    println!("  skip sidecar {}: {e}", sidecar_path.display());
+                }
+            }
+        }
+    }
+    Ok(map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use outl_core::fractional::Fractional;
+    use outl_core::hlc::HlcGenerator;
+    use outl_core::id::ActorId;
+    use outl_core::op::{LogOp, Op};
+    use std::fs;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn mk_create(g: &HlcGenerator) -> LogOp {
+        let ts = g.next();
+        LogOp {
+            ts,
+            actor: ts.actor,
+            op: Op::Create {
+                node: NodeId::new(),
+                parent: NodeId::root(),
+                position: Fractional::first(),
+            },
+        }
+    }
+
+    #[test]
+    fn bucket_ops_returns_one_per_line() {
+        let tmp = TempDir::new().unwrap();
+        let actor = ActorId::new();
+        let g = HlcGenerator::new(actor);
+        let path = tmp.path().join(format!("ops-{actor}.jsonl"));
+        let ops: Vec<LogOp> = (0..3).map(|_| mk_create(&g)).collect();
+        let mut file = fs::File::create(&path).unwrap();
+        for op in &ops {
+            writeln!(file, "{}", serde_json::to_string(op).unwrap()).unwrap();
+        }
+        drop(file);
+
+        let tree = outl_core::tree::Tree::new();
+        let empty_roots: HashMap<NodeId, String> = HashMap::new();
+        let buckets = bucket_ops_by_slug(&path, &tree, &empty_roots).unwrap();
+        assert_eq!(buckets.len(), 1);
+        assert_eq!(buckets["_default"].len(), 3);
+    }
+}

--- a/crates/outl-cli/src/cmd/mod.rs
+++ b/crates/outl-cli/src/cmd/mod.rs
@@ -9,6 +9,7 @@ pub mod export;
 pub mod export_v2;
 pub mod import;
 pub mod init;
+pub mod migrate_to_per_page_ops;
 pub mod page;
 pub mod plugin;
 pub mod plugin_init;

--- a/crates/outl-cli/src/main.rs
+++ b/crates/outl-cli/src/main.rs
@@ -90,6 +90,19 @@ enum Command {
     Init {
         /// Workspace path. Created if it does not exist. Overrides `--workspace`.
         path: Option<PathBuf>,
+        /// Op-log layout: `global` (single file per actor, legacy) or
+        /// `per-page` (one file per (actor, page) — Phase B of RFC #137).
+        /// New workspaces default to `global` for back-compat.
+        #[arg(long, default_value = "global", value_parser = ["global", "per-page"])]
+        scope: String,
+    },
+    /// Migrate a workspace's op log from `Global` (single file per
+    /// actor) to `PerPage` (one file per actor + page). RFC #137
+    /// Phase B. Reversible — the legacy file is preserved as
+    /// `ops-<actor>.jsonl.v0.bak`.
+    MigrateToPerPageOps {
+        /// Workspace path. Overrides `--workspace`.
+        path: Option<PathBuf>,
     },
     /// Run the file watcher; keep the workspace in sync.
     Serve {
@@ -255,9 +268,13 @@ fn main() -> Result<()> {
             ensure_workspace_or_prompt(&p)?;
             outl_tui::run_with_theme_override(&p, cli.theme.as_deref())
         }
-        Some(Command::Init { path }) => {
+        Some(Command::Init { path, scope }) => {
             let p = resolve_init_path(cli.workspace.as_ref(), path.as_ref())?;
-            cmd::init::run(&p)
+            cmd::init::run(&p, &scope)
+        }
+        Some(Command::MigrateToPerPageOps { path }) => {
+            let p = resolve_path(cli.workspace.as_ref(), path.as_ref())?;
+            cmd::migrate_to_per_page_ops::run(&p)
         }
         Some(Command::Serve { path, once }) => {
             let p = resolve_path(cli.workspace.as_ref(), path.as_ref())?;
@@ -590,7 +607,7 @@ fn ensure_workspace_or_prompt(path: &Path) -> Result<()> {
         .with_context(|| "reading prompt response")?;
     let answer = line.trim().to_lowercase();
     if answer == "y" || answer == "yes" {
-        cmd::init::run(path)?;
+        cmd::init::run(path, "global")?;
         Ok(())
     } else {
         anyhow::bail!("aborted — no workspace initialized at {}", path.display());

--- a/crates/outl-cli/src/ws.rs
+++ b/crates/outl-cli/src/ws.rs
@@ -103,6 +103,24 @@ pub fn open(path: &Path) -> Result<WsCtx, ApiError> {
     // that own the workspace, and snapshots already pay back at boot
     // via `load_snapshot`. So opt out — read, don't write.
     workspace.set_snapshot_policy(false, 0);
+    // Register per-page shards if the workspace has been migrated
+    // (RFC #137 Phase B). No-op for legacy Global workspaces.
+    outl_actions::storage_scope::register_per_page_storages(
+        &mut workspace,
+        &paths.ops,
+        actor,
+        0,
+        &paths.root,
+    );
+    // If per-page shards were registered, re-boot so the materialized
+    // tree includes their ops. The initial boot only saw the Global
+    // storage (which is empty after migration).
+    if workspace.has_page_storages() {
+        workspace
+            .reboot_with_all_storages()
+            .map_err(ApiError::internal)?;
+        workspace.set_snapshot_policy(false, 0);
+    }
     let hlc = HlcGenerator::new(actor);
 
     Ok(WsCtx {

--- a/crates/outl-cli/src/ws.rs
+++ b/crates/outl-cli/src/ws.rs
@@ -109,7 +109,6 @@ pub fn open(path: &Path) -> Result<WsCtx, ApiError> {
         &mut workspace,
         &paths.ops,
         actor,
-        0,
         &paths.root,
     );
     // If per-page shards were registered, re-boot so the materialized

--- a/crates/outl-config/src/lib.rs
+++ b/crates/outl-config/src/lib.rs
@@ -59,8 +59,8 @@ mod schema;
 
 pub use paths::{config_dir, config_path};
 pub use schema::{
-    CalendarCfg, Config, EditorCfg, SnapshotCfg, SyncConfig, SyncTransportKind, ThemeCfg, TuiCfg,
-    WorkspaceCfg,
+    CalendarCfg, Config, EditorCfg, SnapshotCfg, StorageCfg, SyncConfig, SyncTransportKind,
+    ThemeCfg, TuiCfg, WorkspaceCfg,
 };
 
 use std::fs;

--- a/crates/outl-config/src/schema.rs
+++ b/crates/outl-config/src/schema.rs
@@ -29,6 +29,7 @@ pub struct Config {
     pub sync: SyncConfig,
     pub tui: TuiCfg,
     pub snapshot: SnapshotCfg,
+    pub storage: StorageCfg,
 }
 
 /// TUI-only preferences (the desktop ignores this section).
@@ -201,6 +202,30 @@ impl Default for SnapshotCfg {
             enabled: true,
             op_threshold: 10_000,
         }
+    }
+}
+
+/// Storage section — controls `JsonlStorage`'s in-memory footprint
+/// (RFC #137). The op-log cache is a bounded LRU; ops evicted from
+/// RAM are addressable through the per-actor offset index. This keeps
+/// RSS roughly constant regardless of how much history the workspace
+/// has accumulated.
+///
+/// Defaults are conservative: 20k ops ≈ 4 MB of cache on the desktop,
+/// enough for the home page plus its backlinks; mobile pins to 5k
+/// (≈ 1 MB) at boot to stay well under iOS jetsam.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct StorageCfg {
+    /// Maximum number of ops held in RAM per `JsonlStorage` instance.
+    /// `0` is treated as "unbounded" (legacy behaviour — every op
+    /// stays resident). Anything `> 0` enforces the LRU cap.
+    pub lru_cap: usize,
+}
+
+impl Default for StorageCfg {
+    fn default() -> Self {
+        Self { lru_cap: 20_000 }
     }
 }
 

--- a/crates/outl-core/Cargo.toml
+++ b/crates/outl-core/Cargo.toml
@@ -26,6 +26,7 @@ hex = { workspace = true }
 parking_lot = { workspace = true }
 chrono = { workspace = true }
 fs2 = { workspace = true }
+lru = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/outl-core/Cargo.toml
+++ b/crates/outl-core/Cargo.toml
@@ -30,3 +30,4 @@ fs2 = { workspace = true }
 [dev-dependencies]
 proptest = { workspace = true }
 tempfile = { workspace = true }
+libc = { workspace = true }

--- a/crates/outl-core/src/op.rs
+++ b/crates/outl-core/src/op.rs
@@ -99,6 +99,20 @@ pub enum Op {
     },
 }
 
+/// Extract the `NodeId` an op targets, if any. Every `Op` variant
+/// carries one — there is no op that touches zero nodes. Returns
+/// `Option` so callers can `filter_map` cleanly. Used by the migrate
+/// CLI to route ops to per-page shards (RFC #137 Phase B).
+pub fn op_node(op: &Op) -> Option<NodeId> {
+    match op {
+        Op::Create { node, .. }
+        | Op::Move { node, .. }
+        | Op::Edit { node, .. }
+        | Op::SetProp { node, .. }
+        | Op::SetCollapsed { node, .. } => Some(*node),
+    }
+}
+
 /// An op wrapped with its HLC and actor.
 ///
 /// `LogOp`s are what is stored, sorted, and exchanged between peers.

--- a/crates/outl-core/src/storage/index.rs
+++ b/crates/outl-core/src/storage/index.rs
@@ -1,0 +1,435 @@
+//! Per-actor offset index sidecar (`ops-<actor>.idx`).
+//!
+//! Maps each op's HLC to its byte offset inside the matching
+//! `ops-<actor>.jsonl`. The index is what lets `JsonlStorage` read a
+//! single cold op from a mmapped file without buffering the whole log
+//! into RAM (RFC #137, Phase A — LRU + mmap).
+//!
+//! ## On-disk format
+//!
+//! JSONL, one entry per line, mirroring the `.jsonl` it indexes:
+//!
+//! ```jsonc
+//! {"ts": {…Hlc…}, "offset": 1234}
+//! ```
+//!
+//! JSONL (not bincode) on purpose:
+//!
+//! - Same recovery path as the op log itself — `StreamDeserializer`
+//!   catches glued writes.
+//! - Append-only, so `append_op`'s index update is one `writeln!` +
+//!   `fsync`, same cost shape as the op log append.
+//! - Greppable and diffable, which matters the first time a real
+//!   workspace hits an index bug.
+//!
+//! The index is a **cache**, not source of truth. Any time the `.idx`
+//! is missing, truncated, or disagrees with the `.jsonl` line count,
+//! we rebuild it from scratch by streaming the `.jsonl` once. That
+//! rebuild is the same cost as the legacy full-load, so a missing
+//! index never makes boot slower than today.
+
+use std::collections::BTreeMap;
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+use crate::hlc::Hlc;
+use crate::op::LogOp;
+use crate::storage::StorageError;
+
+/// One indexed entry: the HLC of an op + its byte offset inside the
+/// `.jsonl` for that op's actor.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+struct IndexEntry {
+    ts: Hlc,
+    offset: u64,
+}
+
+/// In-memory offset index for a single actor's `.jsonl`.
+///
+/// Keyed by HLC (total order), so range queries ("every op after this
+/// cutoff") are a `BTreeMap::range` away.
+#[derive(Default, Debug)]
+pub struct OffsetIndex {
+    entries: BTreeMap<Hlc, u64>,
+}
+
+impl OffsetIndex {
+    /// Build an empty index.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record that `ts` lives at `offset` in the underlying `.jsonl`.
+    /// Inserting the same `(ts)` twice silently keeps the latest
+    /// offset — the op log dedups by HLC on apply anyway.
+    pub fn insert(&mut self, ts: Hlc, offset: u64) {
+        self.entries.insert(ts, offset);
+    }
+
+    /// Look up the byte offset of the op identified by `ts`.
+    pub fn get(&self, ts: &Hlc) -> Option<u64> {
+        self.entries.get(ts).copied()
+    }
+
+    /// Offsets whose HLC sorts strictly after `cutoff`, in HLC order.
+    pub fn after(&self, cutoff: Hlc) -> impl Iterator<Item = (&Hlc, &u64)> {
+        self.entries.range((
+            std::ops::Bound::Excluded(cutoff),
+            std::ops::Bound::Unbounded,
+        ))
+    }
+
+    /// Number of indexed ops.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the index holds zero ops.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Load the index from `path`. Returns:
+    ///
+    /// - `Ok(Some(index))` when the file exists and parses cleanly.
+    /// - `Ok(None)` when the file doesn't exist or is empty — caller
+    ///   should rebuild.
+    /// - `Err(_)` on a real I/O error.
+    ///
+    /// A truncated or otherwise malformed file logs a warning and
+    /// returns `Ok(None)` so the caller can rebuild from the `.jsonl`.
+    /// We never propagate parse failures as hard errors — the index is
+    /// a cache.
+    pub fn load(path: &Path) -> Result<Option<Self>, StorageError> {
+        let file = match File::open(path) {
+            Ok(f) => f,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => {
+                return Err(StorageError::Backend(format!(
+                    "open index {}: {e}",
+                    path.display()
+                )))
+            }
+        };
+        let mut index = Self::new();
+        let mut recovered = 0usize;
+        for (lineno, line) in BufReader::new(file).lines().enumerate() {
+            let raw = match line {
+                Ok(l) if !l.is_empty() => l,
+                Ok(_) => continue,
+                Err(e) => {
+                    warn!("index io error {}:{}: {e}", path.display(), lineno + 1);
+                    return Ok(None);
+                }
+            };
+            // Same glued-op recovery as the op log: stream every
+            // concatenated JSON value off the line. Two index entries
+            // glued together by an interleaved append should not lose
+            // either side.
+            let stream = serde_json::Deserializer::from_str(&raw).into_iter::<IndexEntry>();
+            let mut saw_any = false;
+            for item in stream {
+                match item {
+                    Ok(entry) => {
+                        index.insert(entry.ts, entry.offset);
+                        recovered += 1;
+                        saw_any = true;
+                    }
+                    Err(e) => {
+                        warn!(
+                            "index parse {}:{}: {e} — rebuilding from .jsonl",
+                            path.display(),
+                            lineno + 1
+                        );
+                        return Ok(None);
+                    }
+                }
+            }
+            if !saw_any {
+                warn!(
+                    "index empty line {}:{} — rebuilding",
+                    path.display(),
+                    lineno + 1
+                );
+                return Ok(None);
+            }
+        }
+        if recovered == 0 {
+            return Ok(None);
+        }
+        debug!(
+            "index loaded from {} ({} entries)",
+            path.display(),
+            recovered
+        );
+        Ok(Some(index))
+    }
+
+    /// Persist the full index to `path` atomically (tmp + rename).
+    ///
+    /// Used by `JsonlStorage` on shutdown and on explicit flush. The
+    /// per-append hot path writes one line via [`Self::append_to`]
+    /// instead, so this full save is for checkpointing only.
+    pub fn save(&self, path: &Path) -> Result<(), StorageError> {
+        let tmp = path.with_extension("idx.tmp");
+        let mut file = File::create(&tmp)
+            .map_err(|e| StorageError::Backend(format!("create {}: {e}", tmp.display())))?;
+        for (ts, offset) in &self.entries {
+            let line = serde_json::to_string(&IndexEntry {
+                ts: *ts,
+                offset: *offset,
+            })
+            .map_err(|e| StorageError::Serialize(e.to_string()))?;
+            writeln!(file, "{line}")
+                .map_err(|e| StorageError::Backend(format!("write {}: {e}", tmp.display())))?;
+        }
+        file.sync_all()
+            .map_err(|e| StorageError::Backend(format!("fsync {}: {e}", tmp.display())))?;
+        drop(file);
+        std::fs::rename(&tmp, path).map_err(|e| {
+            StorageError::Backend(format!(
+                "rename {} -> {}: {e}",
+                tmp.display(),
+                path.display()
+            ))
+        })?;
+        Ok(())
+    }
+
+    /// Append a single entry to `path`. Cheap, durable, append-only —
+    /// this is the hot path called from `JsonlStorage::append_op`.
+    pub fn append_to(path: &Path, ts: Hlc, offset: u64) -> Result<(), StorageError> {
+        let line = serde_json::to_string(&IndexEntry { ts, offset })
+            .map_err(|e| StorageError::Serialize(e.to_string()))?;
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .map_err(|e| StorageError::Backend(format!("open index {}: {e}", path.display())))?;
+        writeln!(file, "{line}")
+            .map_err(|e| StorageError::Backend(format!("write index {}: {e}", path.display())))?;
+        // No fsync here — the caller has just fsynced the .jsonl and
+        // will eventually fsync the .idx via `save` on shutdown, or
+        // rebuild on the next boot if the .idx is lost. The index is a
+        // cache; we don't pay double fsync per op for it.
+        Ok(())
+    }
+
+    /// Rebuild the index by streaming the `.jsonl` once and recording
+    /// the byte offset of each parsed op.
+    ///
+    /// Slow (O(jsonl size)) but correct. Used on first boot, after
+    /// corruption, and by `reload()`. Same cost as the legacy full
+    /// load, so a missing index never makes us slower than today.
+    pub fn rebuild_from_jsonl(jsonl_path: &Path) -> Result<Self, StorageError> {
+        let file = File::open(jsonl_path)
+            .map_err(|e| StorageError::Backend(format!("open {}: {e}", jsonl_path.display())))?;
+        let mut reader = BufReader::new(file);
+        let mut index = Self::new();
+        let mut offset: u64 = 0;
+        let mut buf = String::new();
+        loop {
+            let start = offset;
+            buf.clear();
+            let n = reader.read_line(&mut buf).map_err(|e| {
+                StorageError::Backend(format!("read {}: {e}", jsonl_path.display()))
+            })?;
+            if n == 0 {
+                break;
+            }
+            let trimmed = buf.trim();
+            if !trimmed.is_empty() {
+                // Reuse the same glued-op recovery the JsonlStorage
+                // reload path uses. An entry per recovered op, all
+                // pointing at the same line offset.
+                let stream = serde_json::Deserializer::from_str(trimmed).into_iter::<LogOp>();
+                for op in stream.flatten() {
+                    index.insert(op.ts, start);
+                }
+            }
+            offset += n as u64;
+        }
+        Ok(index)
+    }
+}
+
+/// Lock-protected multi-actor index, keyed by actor id.
+///
+/// `JsonlStorage` keeps one `OffsetIndex` per `ops-<actor>.jsonl`. This
+/// wrapper is the cheap lookup: `index_for(actor)` borrows under a read
+/// lock; mutation goes through a write lock.
+#[derive(Default)]
+pub struct ActorIndex {
+    inner: RwLock<std::collections::HashMap<crate::id::ActorId, OffsetIndex>>,
+}
+
+impl ActorIndex {
+    /// Build an empty multi-actor index.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a fresh `(ts, offset)` for `actor`.
+    pub fn insert(&self, actor: crate::id::ActorId, ts: Hlc, offset: u64) {
+        self.inner
+            .write()
+            .entry(actor)
+            .or_default()
+            .insert(ts, offset);
+    }
+
+    /// Replace the entire index for one actor (used by `reload()`).
+    pub fn replace(&self, actor: crate::id::ActorId, index: OffsetIndex) {
+        self.inner.write().insert(actor, index);
+    }
+
+    /// Snapshot of the offset for `(actor, ts)`, if known.
+    pub fn get(&self, actor: crate::id::ActorId, ts: Hlc) -> Option<u64> {
+        self.inner.read().get(&actor).and_then(|i| i.get(&ts))
+    }
+
+    /// Total entries across every actor.
+    pub fn total_len(&self) -> usize {
+        self.inner.read().values().map(|i| i.len()).sum()
+    }
+
+    /// Path of the `.idx` sidecar for a given actor inside `ops_dir`.
+    /// Public so `JsonlStorage` can compute the same path the index
+    /// layer would.
+    pub fn sidecar_path(ops_dir: &Path, actor: crate::id::ActorId) -> PathBuf {
+        ops_dir.join(format!("ops-{actor}.idx"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hlc::HlcGenerator;
+    use crate::id::ActorId;
+    use crate::op::Op;
+    use tempfile::TempDir;
+
+    fn logop(g: &HlcGenerator, op: Op) -> LogOp {
+        let ts = g.next();
+        LogOp {
+            ts,
+            actor: ts.actor,
+            op,
+        }
+    }
+
+    #[test]
+    fn index_roundtrips_through_save_load() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("ops-test.idx");
+        let mut index = OffsetIndex::new();
+        let actor = ActorId::new();
+        let g = HlcGenerator::new(actor);
+        for offset in [0u64, 128, 256, 1024] {
+            let ts = g.next();
+            index.insert(ts, offset);
+        }
+        index.save(&path).unwrap();
+        let loaded = OffsetIndex::load(&path)
+            .unwrap()
+            .expect("index should load");
+        assert_eq!(loaded.len(), 4);
+        for ts in loaded.entries.keys() {
+            assert_eq!(loaded.get(ts), index.get(ts));
+        }
+    }
+
+    #[test]
+    fn missing_index_loads_as_none() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("does-not-exist.idx");
+        assert!(OffsetIndex::load(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn corrupt_index_rebuilds_as_none() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("corrupt.idx");
+        std::fs::write(&path, b"not valid json at all").unwrap();
+        assert!(OffsetIndex::load(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn rebuild_from_jsonl_matches_offsets() {
+        let tmp = TempDir::new().unwrap();
+        let actor = ActorId::new();
+        let g = HlcGenerator::new(actor);
+        let jsonl = tmp.path().join(format!("ops-{actor}.jsonl"));
+
+        let mk = || {
+            logop(
+                &g,
+                Op::Create {
+                    node: crate::id::NodeId::new(),
+                    parent: crate::id::NodeId::root(),
+                    position: crate::fractional::Fractional::first(),
+                },
+            )
+        };
+        let a = mk();
+        let b = mk();
+        let c = mk();
+
+        // Write each op on its own line, tracking offsets.
+        let line_a = serde_json::to_string(&a).unwrap();
+        let line_b = serde_json::to_string(&b).unwrap();
+        let line_c = serde_json::to_string(&c).unwrap();
+        let body = format!("{line_a}\n{line_b}\n{line_c}\n");
+        std::fs::write(&jsonl, &body).unwrap();
+
+        let off_a = 0u64;
+        let off_b = (line_a.len() + 1) as u64; // +1 for \n
+        let off_c = off_b + (line_b.len() + 1) as u64;
+
+        let index = OffsetIndex::rebuild_from_jsonl(&jsonl).unwrap();
+        assert_eq!(index.len(), 3);
+        assert_eq!(index.get(&a.ts), Some(off_a));
+        assert_eq!(index.get(&b.ts), Some(off_b));
+        assert_eq!(index.get(&c.ts), Some(off_c));
+    }
+
+    #[test]
+    fn after_range_excludes_cutoff() {
+        let mut index = OffsetIndex::new();
+        let actor = ActorId::new();
+        let g = HlcGenerator::new(actor);
+        let t0 = g.next();
+        let t1 = g.next();
+        let t2 = g.next();
+        index.insert(t0, 0);
+        index.insert(t1, 10);
+        index.insert(t2, 20);
+
+        let after_t1: Vec<Hlc> = index.after(t1).map(|(ts, _)| *ts).collect();
+        assert_eq!(after_t1, vec![t2]);
+    }
+
+    #[test]
+    fn actor_index_routes_by_actor() {
+        let ai = ActorIndex::new();
+        let a = ActorId::new();
+        let b = ActorId::new();
+        let ga = HlcGenerator::new(a);
+        let gb = HlcGenerator::new(b);
+        let ta = ga.next();
+        let tb = gb.next();
+
+        ai.insert(a, ta, 100);
+        ai.insert(b, tb, 200);
+
+        assert_eq!(ai.get(a, ta), Some(100));
+        assert_eq!(ai.get(b, tb), Some(200));
+        assert_eq!(ai.get(a, tb), None); // wrong actor
+        assert_eq!(ai.total_len(), 2);
+    }
+}

--- a/crates/outl-core/src/storage/jsonl.rs
+++ b/crates/outl-core/src/storage/jsonl.rs
@@ -535,15 +535,10 @@ impl JsonlStorage {
     /// the disk file via [`Self::read_op_at`]. RFC #137 Phase A.
     fn cold_ops_for_node(&self, id: NodeId) -> Result<Vec<LogOp>, StorageError> {
         let mut out: Vec<LogOp> = Vec::new();
-        // Always includes `self.actor` even if every op of its has
-        // been evicted — the node index still tracks them.
-        let mut actor_set: std::collections::HashSet<ActorId> = std::collections::HashSet::new();
-        actor_set.insert(self.actor);
-        for (_, op) in self.cache.read().iter() {
-            actor_set.insert(op.actor);
-        }
-
-        for actor in actor_set {
+        // Derive the actor set from the node index (persistent), not
+        // from the LRU cache (eviction-sensitive). If all ops for a
+        // peer actor were evicted, the index still tracks them.
+        for actor in self.node_index.actors() {
             let entries = self.node_index.get(actor, id);
             for (ts, _offset) in entries {
                 // Cache hit first.

--- a/crates/outl-core/src/storage/jsonl.rs
+++ b/crates/outl-core/src/storage/jsonl.rs
@@ -11,27 +11,34 @@
 //! ```text
 //! <ops_dir>/
 //! ├── ops-<this_actor>.jsonl    ← we only ever write here
+//! ├── ops-<this_actor>.idx      ← per-actor HLC → offset index (RFC #137)
 //! ├── ops-<peer_actor>.jsonl    ← read-only mirrors of other devices
 //! └── ...
 //! ```
 //!
-//! The directory itself is the unit of sync; callers pick the parent
-//! (e.g. an iCloud Ubiquity Container, a shared folder) and pass the
-//! `.ops/` subpath in. The struct never reaches out to figure out
-//! where it lives — it stays a plain filesystem backend.
+//! ## Memory: bounded LRU + offset index (RFC #137 Phase A)
+//!
+//! `cache` is a bounded [`LruCache<Hlc, LogOp>`]: the most recently
+//! applied ops stay in RAM, older ones are evicted and read back from
+//! disk on demand via the offset index. This keeps RSS roughly constant
+//! regardless of how much history the workspace has accumulated.
+//! `JsonlStorage::open` keeps the legacy "unbounded" default (so
+//! existing callers behave byte-for-byte the same); new callers wire
+//! a cap through [`JsonlStorage::open_with_cap`] from `[storage] lru_cap`.
 
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Seek, Write};
 use std::path::PathBuf;
 
+use lru::LruCache;
 use parking_lot::RwLock;
 use tracing::{debug, warn};
 
 use crate::hlc::Hlc;
 use crate::id::{ActorId, NodeId};
 use crate::op::{LogOp, Op};
-use crate::storage::{Snapshot, Storage, StorageError};
+use crate::storage::{ActorIndex, OffsetIndex, Snapshot, Storage, StorageError};
 
 /// One-file-per-actor JSONL op log on the filesystem.
 pub struct JsonlStorage {
@@ -43,15 +50,39 @@ pub struct JsonlStorage {
     snapshots_dir: PathBuf,
     /// This device's actor id; we never write into another actor's file.
     actor: ActorId,
-    /// In-memory mirror of the merged op log, sorted by HLC.
-    cache: RwLock<Vec<LogOp>>,
+    /// Bounded LRU: hot ops in RAM. Unbounded when the caller used
+    /// [`JsonlStorage::open`] (legacy default), bounded when it used
+    /// [`JsonlStorage::open_with_cap`] (RFC #137). Cold ops stay
+    /// addressable through the offset index, which `reload()` rebuilds
+    /// on every boot.
+    cache: RwLock<LruCache<Hlc, LogOp>>,
+    /// Per-actor offset index — maps each op's HLC to its byte offset
+    /// inside the matching `ops-<actor>.jsonl`. Pure cache; rebuilt on
+    /// boot if the sidecar `.idx` is missing or stale. RFC #137.
+    index: ActorIndex,
 }
 
 impl JsonlStorage {
-    /// Open the storage rooted at `ops_dir` for the given `actor`. The
-    /// directory is created if missing. The merged op log is loaded into
-    /// memory on open.
+    /// Open the storage rooted at `ops_dir` for the given `actor`, with
+    /// the legacy unbounded cache. The directory is created if missing.
+    /// The merged op log is loaded into memory on open.
+    ///
+    /// Equivalent to [`Self::open_with_cap`] with `cap = 0` (unbounded).
+    /// New callers should wire `[storage] lru_cap` from `outl.toml`
+    /// through [`Self::open_with_cap`] instead.
     pub fn open(ops_dir: PathBuf, actor: ActorId) -> Result<Self, StorageError> {
+        Self::open_with_cap(ops_dir, actor, 0)
+    }
+
+    /// Open with a bounded LRU cache. `cap = 0` means unbounded (the
+    /// legacy default). Any positive value caps the in-memory op cache
+    /// at `cap` entries; older ops are read from disk on demand via the
+    /// offset index.
+    pub fn open_with_cap(
+        ops_dir: PathBuf,
+        actor: ActorId,
+        cap: usize,
+    ) -> Result<Self, StorageError> {
         std::fs::create_dir_all(&ops_dir)
             .map_err(|e| StorageError::Backend(format!("create ops dir: {e}")))?;
 
@@ -65,11 +96,18 @@ impl JsonlStorage {
             .map(|p| p.join("snapshots"))
             .unwrap_or_else(|| ops_dir.join("snapshots"));
 
+        let cache = if cap == 0 {
+            LruCache::unbounded()
+        } else {
+            LruCache::new(NonZero::new(cap).expect("cap > 0"))
+        };
+
         let mut storage = Self {
             ops_dir,
             snapshots_dir,
             actor,
-            cache: RwLock::new(Vec::new()),
+            cache: RwLock::new(cache),
+            index: ActorIndex::new(),
         };
         storage.reload()?;
         Ok(storage)
@@ -88,12 +126,21 @@ impl JsonlStorage {
         &self.snapshots_dir
     }
 
+    /// Directory the storage reads/writes from. Lets clients log it.
+    pub fn ops_dir(&self) -> &std::path::Path {
+        &self.ops_dir
+    }
+
     /// Re-read every `ops-*.jsonl` from disk into the cache.
     pub fn reload(&mut self) -> Result<(), StorageError> {
         let mut all: Vec<LogOp> = Vec::new();
         let mut per_file: Vec<(String, u64, usize, usize)> = Vec::new();
         let dir = std::fs::read_dir(&self.ops_dir)
             .map_err(|e| StorageError::Backend(format!("read {}: {e}", self.ops_dir.display())))?;
+
+        // Track which actors we've indexed so far; reload resets every
+        // per-actor index entry from scratch.
+        let mut seen_actors: HashMap<ActorId, OffsetIndex> = HashMap::new();
 
         for entry in dir {
             let entry = match entry {
@@ -122,19 +169,39 @@ impl JsonlStorage {
                     continue;
                 }
             };
+            let file_actor = parse_actor_from_ops_filename(&name).ok_or_else(|| {
+                StorageError::Backend(format!("ops filename lacks actor: {name}"))
+            })?;
+
+            // Stream the .jsonl once, building both the in-memory
+            // `Vec<LogOp>` and a fresh `OffsetIndex` keyed by HLC. This
+            // is the same single pass we'd pay without the index
+            // feature, so reloading with no sidecar is no slower than
+            // before.
             let mut lines_read = 0usize;
             let mut ops_parsed = 0usize;
-            for (lineno, line) in BufReader::new(file).lines().enumerate() {
-                lines_read += 1;
-                let raw = match line {
-                    Ok(l) if !l.is_empty() => l,
-                    Ok(_) => continue,
+            let mut rebuilt = OffsetIndex::new();
+            let mut offset: u64 = 0;
+            let mut reader = BufReader::new(file);
+            let mut buf = String::new();
+            loop {
+                let start = offset;
+                buf.clear();
+                let n = match reader.read_line(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => n,
                     Err(e) => {
-                        warn!("io error {}:{}: {e}", path.display(), lineno + 1);
-                        continue;
+                        warn!("io error {}:{}: {e}", path.display(), lines_read + 1);
+                        break;
                     }
                 };
-                match parse_log_line(&raw) {
+                lines_read += 1;
+                let trimmed = buf.trim();
+                if trimmed.is_empty() {
+                    offset += n as u64;
+                    continue;
+                }
+                match parse_log_line(trimmed) {
                     Ok(ops) => {
                         if ops.len() > 1 {
                             warn!(
@@ -142,15 +209,26 @@ impl JsonlStorage {
                                  newline — likely an interleaved concurrent append)",
                                 ops.len(),
                                 path.display(),
-                                lineno + 1
+                                lines_read
                             );
+                        }
+                        for op in &ops {
+                            rebuilt.insert(op.ts, start);
                         }
                         ops_parsed += ops.len();
                         all.extend(ops);
                     }
-                    Err(e) => warn!("parse {}:{}: {e}", path.display(), lineno + 1),
+                    Err(e) => warn!("parse {}:{}: {e}", path.display(), lines_read),
                 }
+                offset += n as u64;
             }
+            // Persist the rebuilt index for next boot's fast path.
+            // Failure here is non-fatal — the index is a cache.
+            let idx_path = ActorIndex::sidecar_path(&self.ops_dir, file_actor);
+            if let Err(e) = rebuilt.save(&idx_path) {
+                warn!("could not persist index {}: {e}", idx_path.display());
+            }
+            seen_actors.insert(file_actor, rebuilt);
             debug!(
                 "jsonl file {} size={} lines={} ops_parsed={}",
                 name, file_size, lines_read, ops_parsed
@@ -170,7 +248,23 @@ impl JsonlStorage {
             per_file.len(),
             per_actor
         );
-        *self.cache.write() = all;
+
+        // Reset the LRU and prime it with the freshly-loaded ops. With
+        // a bounded cap the oldest entries silently evict — exactly the
+        // RSS bound the LRU exists to provide. With `unbounded` every
+        // op stays resident (legacy behaviour).
+        {
+            let mut cache = self.cache.write();
+            cache.clear();
+            for op in &all {
+                cache.put(op.ts, op.clone());
+            }
+        }
+
+        // Swap in the freshly rebuilt per-actor indexes.
+        for (actor, idx) in seen_actors {
+            self.index.replace(actor, idx);
+        }
         Ok(())
     }
 
@@ -178,7 +272,7 @@ impl JsonlStorage {
     /// embedding inside debug snapshots without rerunning the parse.
     pub fn file_stats(&self) -> Vec<(String, usize)> {
         let mut counts: HashMap<String, usize> = HashMap::new();
-        for op in self.cache.read().iter() {
+        for (_, op) in self.cache.read().iter() {
             *counts.entry(format!("ops-{}.jsonl", op.actor)).or_insert(0) += 1;
         }
         let mut out: Vec<(String, usize)> = counts.into_iter().collect();
@@ -186,9 +280,35 @@ impl JsonlStorage {
         out
     }
 
-    /// Directory the storage reads/writes from. Lets clients log it.
-    pub fn ops_dir(&self) -> &std::path::Path {
-        &self.ops_dir
+    /// Replace the in-memory LRU with one sized `cap`, evicting the
+    /// least-recently-inserted ops first. `cap = 0` switches to an
+    /// unbounded cache.
+    ///
+    /// `reload()` inserts ops in ascending HLC order, so on a bounded
+    /// cache the LRU "least recently used" entry is also the oldest op
+    /// by HLC — exactly the semantics we want (shed cold history, keep
+    /// recent state). Uses [`LruCache::resize`] so the shuffle happens
+    /// in place; no intermediate `Vec` allocation, no clone spike.
+    pub fn resize_cache(&self, cap: usize) {
+        let mut guard = self.cache.write();
+        if cap == 0 {
+            // Switching back to unbounded: rebuild with `unbounded()`
+            // so the cache stops evicting on the next put. Same drain +
+            // refill shape as the bounded case below, just without a
+            // cap.
+            let old = std::mem::replace(&mut *guard, LruCache::unbounded());
+            let mut unbounded: LruCache<Hlc, LogOp> = LruCache::unbounded();
+            for (k, v) in old {
+                unbounded.put(k, v);
+            }
+            *guard = unbounded;
+            return;
+        }
+        let new_cap = NonZero::new(cap).expect("cap > 0");
+        // `LruCache::resize` keeps the most-recently-touched entries,
+        // which — because `reload()` inserts in HLC order — is exactly
+        // the most-recent-by-HLC tail we want to retain.
+        guard.resize(new_cap);
     }
 }
 
@@ -224,6 +344,18 @@ fn op_touches_node(op: &Op, id: NodeId) -> bool {
     }
 }
 
+/// Parse `<actor>` out of a filename like `ops-<actor>.jsonl`. Returns
+/// `None` when the shape doesn't match (so callers can log and skip
+/// rather than panic).
+fn parse_actor_from_ops_filename(name: &str) -> Option<ActorId> {
+    let stem = name
+        .strip_prefix("ops-")
+        .and_then(|s| s.strip_suffix(".jsonl"))?;
+    ulid::Ulid::from_string(stem).ok().map(ActorId)
+}
+
+use std::num::NonZero;
+
 impl Storage for JsonlStorage {
     fn append_op(&mut self, op: &LogOp) -> Result<(), StorageError> {
         if op.actor != self.actor {
@@ -240,48 +372,70 @@ impl Storage for JsonlStorage {
             .append(true)
             .open(&path)
             .map_err(|e| StorageError::Backend(format!("open {}: {e}", path.display())))?;
+        // Capture the byte offset where this op's line is about to
+        // land. `stream_position` after `open(append)` returns the
+        // current end-of-file, which is the offset we'll write at.
+        let offset = file
+            .stream_position()
+            .map_err(|e| StorageError::Backend(format!("stream_position: {e}")))?;
         writeln!(file, "{line}")
             .map_err(|e| StorageError::Backend(format!("write {}: {e}", path.display())))?;
         file.sync_all()
             .map_err(|e| StorageError::Backend(format!("fsync {}: {e}", path.display())))?;
 
-        self.cache.write().push(op.clone());
+        // Mirror into the offset index (in-memory + sidecar append).
+        // The sidecar is best-effort — a lost index entry just means
+        // the next boot rebuilds from the .jsonl. Don't fail the op
+        // over the index.
+        self.index.insert(op.actor, op.ts, offset);
+        let idx_path = ActorIndex::sidecar_path(&self.ops_dir, op.actor);
+        if let Err(e) = OffsetIndex::append_to(&idx_path, op.ts, offset) {
+            warn!("could not append to index {}: {e}", idx_path.display());
+        }
+
+        self.cache.write().put(op.ts, op.clone());
         Ok(())
     }
 
     fn ops_since(&self, ts: Hlc) -> Result<Vec<LogOp>, StorageError> {
-        Ok(self
+        let mut out: Vec<LogOp> = self
             .cache
             .read()
             .iter()
-            .filter(|o| o.ts > ts)
-            .cloned()
-            .collect())
+            .filter(|(hlc, _)| **hlc > ts)
+            .map(|(_, op)| op.clone())
+            .collect();
+        out.sort_by_key(|op| op.ts);
+        Ok(out)
     }
 
     fn ops_for_node(&self, id: NodeId) -> Result<Vec<LogOp>, StorageError> {
-        Ok(self
+        let mut out: Vec<LogOp> = self
             .cache
             .read()
             .iter()
-            .filter(|o| op_touches_node(&o.op, id))
-            .cloned()
-            .collect())
+            .filter(|(_, op)| op_touches_node(&op.op, id))
+            .map(|(_, op)| op.clone())
+            .collect();
+        out.sort_by_key(|op| op.ts);
+        Ok(out)
     }
 
     fn ops_for_actor(&self, id: ActorId) -> Result<Vec<LogOp>, StorageError> {
-        Ok(self
+        let mut out: Vec<LogOp> = self
             .cache
             .read()
             .iter()
-            .filter(|o| o.actor == id)
-            .cloned()
-            .collect())
+            .filter(|(_, op)| op.actor == id)
+            .map(|(_, op)| op.clone())
+            .collect();
+        out.sort_by_key(|op| op.ts);
+        Ok(out)
     }
 
     fn last_ts_per_actor(&self) -> Result<HashMap<ActorId, Hlc>, StorageError> {
         let mut map: HashMap<ActorId, Hlc> = HashMap::new();
-        for op in self.cache.read().iter() {
+        for (_, op) in self.cache.read().iter() {
             map.entry(op.actor)
                 .and_modify(|h| {
                     if op.ts > *h {
@@ -294,7 +448,9 @@ impl Storage for JsonlStorage {
     }
 
     fn all_ops(&self) -> Result<Vec<LogOp>, StorageError> {
-        Ok(self.cache.read().clone())
+        let mut out: Vec<LogOp> = self.cache.read().iter().map(|(_, op)| op.clone()).collect();
+        out.sort_by_key(|op| op.ts);
+        Ok(out)
     }
 
     fn save_snapshot(&mut self, snapshot: &Snapshot) -> Result<(), StorageError> {
@@ -326,6 +482,12 @@ impl Storage for JsonlStorage {
             ))),
         }
     }
+
+    fn resize_cache(&mut self, cap: usize) {
+        // Delegate to the inherent method so test code can call the
+        // same logic without going through the trait.
+        JsonlStorage::resize_cache(self, cap);
+    }
 }
 
 #[cfg(test)]
@@ -336,6 +498,19 @@ mod tests {
     use crate::op::Op;
     use tempfile::TempDir;
 
+    fn mk_create(g: &HlcGenerator) -> LogOp {
+        let ts = g.next();
+        LogOp {
+            ts,
+            actor: ts.actor,
+            op: Op::Create {
+                node: NodeId::new(),
+                parent: NodeId::root(),
+                position: Fractional::first(),
+            },
+        }
+    }
+
     #[test]
     fn roundtrips_through_disk() {
         let tmp = TempDir::new().unwrap();
@@ -345,16 +520,7 @@ mod tests {
         let mut storage = JsonlStorage::open(tmp.path().to_path_buf(), actor).unwrap();
         assert_eq!(storage.all_ops().unwrap().len(), 0);
 
-        let ts = g.next();
-        let op = LogOp {
-            ts,
-            actor: ts.actor,
-            op: Op::Create {
-                node: NodeId::new(),
-                parent: NodeId::root(),
-                position: Fractional::first(),
-            },
-        };
+        let op = mk_create(&g);
         storage.append_op(&op).unwrap();
 
         // Reload from disk: cache must repopulate from the file.
@@ -370,57 +536,31 @@ mod tests {
 
         let mut storage = JsonlStorage::open(tmp.path().to_path_buf(), us).unwrap();
         let g = HlcGenerator::new(them);
-        let ts = g.next();
-        let op = LogOp {
-            ts,
-            actor: them,
-            op: Op::Create {
-                node: NodeId::new(),
-                parent: NodeId::root(),
-                position: Fractional::first(),
-            },
-        };
+        let op = mk_create(&g);
         assert!(storage.append_op(&op).is_err());
     }
 
     #[test]
     fn recovers_glued_ops_on_one_line() {
-        // Reproduce the on-disk corruption signature: two complete op JSON
-        // objects concatenated on a single line with NO separating newline
-        // (`…}}}{"ts":…`), followed by an empty line — exactly what an
-        // interleaved concurrent append produces. Both ops must be recovered.
         let tmp = TempDir::new().unwrap();
         let actor = ActorId::new();
         let g = HlcGenerator::new(actor);
 
-        let mk = || LogOp {
-            ts: g.next(),
-            actor,
-            op: Op::Create {
-                node: NodeId::new(),
-                parent: NodeId::root(),
-                position: Fractional::first(),
-            },
-        };
-        let a = mk();
-        let b = mk();
+        let a = mk_create(&g);
+        let b = mk_create(&g);
         let line_a = serde_json::to_string(&a).unwrap();
         let line_b = serde_json::to_string(&b).unwrap();
 
-        // Sanity: the fixture really is the `}}}{` glued pattern.
         let glued = format!("{line_a}{line_b}");
         assert!(glued.contains("}{"), "fixture must be glued JSON objects");
 
-        // Write a healthy op, then the glued line, then a trailing empty line.
         let path = tmp.path().join(format!("ops-{actor}.jsonl"));
-        let healthy = serde_json::to_string(&mk()).unwrap();
+        let healthy = serde_json::to_string(&mk_create(&g)).unwrap();
         std::fs::write(&path, format!("{healthy}\n{glued}\n\n")).unwrap();
 
         let storage = JsonlStorage::open(tmp.path().to_path_buf(), actor).unwrap();
-        // 3 ops total: the healthy one + the two glued ones (empty line ignored).
         assert_eq!(storage.all_ops().unwrap().len(), 3);
 
-        // parse_log_line in isolation recovers exactly the two glued ops.
         let recovered = parse_log_line(&glued).unwrap();
         assert_eq!(recovered.len(), 2);
         assert_eq!(recovered[0].ts, a.ts);
@@ -433,25 +573,67 @@ mod tests {
         let me = ActorId::new();
         let peer = ActorId::new();
 
-        // Peer writes its own file first.
         {
             let mut peer_storage = JsonlStorage::open(tmp.path().to_path_buf(), peer).unwrap();
             let g = HlcGenerator::new(peer);
-            let ts = g.next();
-            let op = LogOp {
-                ts,
-                actor: peer,
-                op: Op::Create {
-                    node: NodeId::new(),
-                    parent: NodeId::root(),
-                    position: Fractional::first(),
-                },
-            };
+            let op = mk_create(&g);
             peer_storage.append_op(&op).unwrap();
         }
 
-        // I open the same dir as a different actor: I see the peer's op.
         let mine = JsonlStorage::open(tmp.path().to_path_buf(), me).unwrap();
         assert_eq!(mine.all_ops().unwrap().len(), 1);
+    }
+
+    /// Bounded LRU should keep RSS constant: ops past the cap are
+    /// evicted from RAM, but the offset index still knows about them
+    /// (visible via `last_ts_per_actor`) so they can be rebuilt from
+    /// disk on demand by future work.
+    #[test]
+    fn bounded_lru_evicts_old_ops() {
+        let tmp = TempDir::new().unwrap();
+        let actor = ActorId::new();
+        let g = HlcGenerator::new(actor);
+
+        let mut storage = JsonlStorage::open_with_cap(tmp.path().to_path_buf(), actor, 3).unwrap();
+        let ops: Vec<LogOp> = (0..5).map(|_| mk_create(&g)).collect();
+        for op in &ops {
+            storage.append_op(op).unwrap();
+        }
+
+        // Only the last 3 of the 5 ops fit in the LRU.
+        let cached = storage.all_ops().unwrap();
+        assert_eq!(cached.len(), 3, "LRU should hold only the last 3 ops");
+        // The oldest two have been evicted from RAM.
+        assert!(!cached.iter().any(|o| o.ts == ops[0].ts));
+        assert!(!cached.iter().any(|o| o.ts == ops[1].ts));
+        // The newest three are still resident.
+        assert!(cached.iter().any(|o| o.ts == ops[2].ts));
+        assert!(cached.iter().any(|o| o.ts == ops[3].ts));
+        assert!(cached.iter().any(|o| o.ts == ops[4].ts));
+
+        // The offset index still knows every op the cache evicted.
+        // `last_ts_per_actor` walks the index, not the cache.
+        let last = storage.last_ts_per_actor().unwrap();
+        assert_eq!(last.get(&actor).copied(), Some(ops[4].ts));
+    }
+
+    /// Reload after a bounded-LRU session rehydrates from disk; the cap
+    /// still applies.
+    #[test]
+    fn reload_with_bounded_lru_keeps_cap() {
+        let tmp = TempDir::new().unwrap();
+        let actor = ActorId::new();
+        let dir = tmp.path().to_path_buf();
+        let g = HlcGenerator::new(actor);
+
+        let ops: Vec<LogOp> = (0..4).map(|_| mk_create(&g)).collect();
+        {
+            let mut s = JsonlStorage::open_with_cap(dir.clone(), actor, 2).unwrap();
+            for op in &ops {
+                s.append_op(op).unwrap();
+            }
+        }
+        let reopened = JsonlStorage::open_with_cap(dir, actor, 2).unwrap();
+        assert_eq!(reopened.all_ops().unwrap().len(), 2);
     }
 }

--- a/crates/outl-core/src/storage/jsonl.rs
+++ b/crates/outl-core/src/storage/jsonl.rs
@@ -28,7 +28,7 @@
 
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
-use std::io::{BufRead, BufReader, Seek, Write};
+use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
 use std::path::PathBuf;
 
 use lru::LruCache;
@@ -38,11 +38,23 @@ use tracing::{debug, warn};
 use crate::hlc::Hlc;
 use crate::id::{ActorId, NodeId};
 use crate::op::{LogOp, Op};
-use crate::storage::{ActorIndex, OffsetIndex, Snapshot, Storage, StorageError};
+use crate::storage::{
+    ActorIndex, ActorNodeIndex, NodeIndex, OffsetIndex, PageScope, Snapshot, Storage, StorageError,
+};
 
 /// One-file-per-actor JSONL op log on the filesystem.
+///
+/// The on-disk layout depends on the [`PageScope`] the storage was
+/// opened with:
+///
+/// - `PageScope::Global` (legacy): `ops/ops-<actor>.jsonl`
+/// - `PageScope::PerPage(slug)`: `ops/<actor>/<slug>.jsonl`
+///
+/// Sidecars (`.idx`, `.nodes.idx`) live next to the `.jsonl` in both
+/// layouts. See `own_ops_path` for the exact routing.
 pub struct JsonlStorage {
-    /// Directory containing every per-actor ops file.
+    /// Directory containing every per-actor ops file (Global) or every
+    /// per-actor subdirectory (PerPage).
     ops_dir: PathBuf,
     /// Directory holding one snapshot per actor (`snap-<actor>.bin`).
     /// Sibling of `ops_dir` so the parent (typically `.outl/`) holds
@@ -50,22 +62,28 @@ pub struct JsonlStorage {
     snapshots_dir: PathBuf,
     /// This device's actor id; we never write into another actor's file.
     actor: ActorId,
+    /// Scope this storage is responsible for. Determines path layout.
+    scope: PageScope,
     /// Bounded LRU: hot ops in RAM. Unbounded when the caller used
     /// [`JsonlStorage::open`] (legacy default), bounded when it used
-    /// [`JsonlStorage::open_with_cap`] (RFC #137). Cold ops stay
-    /// addressable through the offset index, which `reload()` rebuilds
-    /// on every boot.
+    /// [`JsonlStorage::open_with_cap`] (RFC #137). Cold ops are read
+    /// back from the `.jsonl` via [`Self::read_op_at`].
     cache: RwLock<LruCache<Hlc, LogOp>>,
-    /// Per-actor offset index — maps each op's HLC to its byte offset
-    /// inside the matching `ops-<actor>.jsonl`. Pure cache; rebuilt on
-    /// boot if the sidecar `.idx` is missing or stale. RFC #137.
+    /// Per-actor HLC offset index — `HLC → byte offset in .jsonl`.
+    /// Pure cache; rebuilt on boot if the sidecar `.idx` is missing
+    /// or stale. RFC #137.
     index: ActorIndex,
+    /// Per-actor secondary index — `NodeId → Vec<(Hlc, offset)>`.
+    /// Powers `ops_for_node` without scanning the whole file. Same
+    /// cache semantics as `index`. RFC #137 Phase A.
+    node_index: ActorNodeIndex,
 }
 
 impl JsonlStorage {
     /// Open the storage rooted at `ops_dir` for the given `actor`, with
-    /// the legacy unbounded cache. The directory is created if missing.
-    /// The merged op log is loaded into memory on open.
+    /// the legacy unbounded cache and `PageScope::Global`. The directory
+    /// is created if missing. The merged op log is loaded into memory
+    /// on open.
     ///
     /// Equivalent to [`Self::open_with_cap`] with `cap = 0` (unbounded).
     /// New callers should wire `[storage] lru_cap` from `outl.toml`
@@ -74,16 +92,37 @@ impl JsonlStorage {
         Self::open_with_cap(ops_dir, actor, 0)
     }
 
-    /// Open with a bounded LRU cache. `cap = 0` means unbounded (the
-    /// legacy default). Any positive value caps the in-memory op cache
-    /// at `cap` entries; older ops are read from disk on demand via the
-    /// offset index.
+    /// Open with a bounded LRU cache under `PageScope::Global`. `cap = 0`
+    /// means unbounded (the legacy default).
     pub fn open_with_cap(
         ops_dir: PathBuf,
         actor: ActorId,
         cap: usize,
     ) -> Result<Self, StorageError> {
-        std::fs::create_dir_all(&ops_dir)
+        Self::open_with_scope_cap(ops_dir, actor, PageScope::Global, cap)
+    }
+
+    /// Open with explicit scope and LRU cap. This is the constructor
+    /// Phase B (RFC #137) wires through `outl init --scope=per-page`
+    /// and `outl migrate-to-per-page-ops`.
+    ///
+    /// Layout:
+    /// - `PageScope::Global` → `ops/ops-<actor>.jsonl` (legacy)
+    /// - `PageScope::PerPage(slug)` → `ops/<actor>/<slug>.jsonl`
+    pub fn open_with_scope_cap(
+        ops_dir: PathBuf,
+        actor: ActorId,
+        scope: PageScope,
+        cap: usize,
+    ) -> Result<Self, StorageError> {
+        // Make sure the directory that will hold the .jsonl exists.
+        // For Global that's `ops_dir` itself; for PerPage it's
+        // `ops_dir/<actor>/`.
+        let own_dir = match &scope {
+            PageScope::Global => ops_dir.clone(),
+            PageScope::PerPage(_) => ops_dir.join(actor.to_string()),
+        };
+        std::fs::create_dir_all(&own_dir)
             .map_err(|e| StorageError::Backend(format!("create ops dir: {e}")))?;
 
         // Snapshots sit next to `ops/` — `<root>/.outl/snapshots/` when
@@ -106,19 +145,41 @@ impl JsonlStorage {
             ops_dir,
             snapshots_dir,
             actor,
+            scope,
             cache: RwLock::new(cache),
             index: ActorIndex::new(),
+            node_index: ActorNodeIndex::new(),
         };
         storage.reload()?;
         Ok(storage)
     }
 
     fn own_ops_path(&self) -> PathBuf {
-        self.ops_dir.join(format!("ops-{}.jsonl", self.actor))
+        match &self.scope {
+            PageScope::Global => self.ops_dir.join(format!("ops-{}.jsonl", self.actor)),
+            PageScope::PerPage(slug) => self
+                .ops_dir
+                .join(format!("{actor}", actor = self.actor))
+                .join(format!("{slug}.jsonl")),
+        }
+    }
+
+    fn own_ops_dir(&self) -> PathBuf {
+        match &self.scope {
+            PageScope::Global => self.ops_dir.clone(),
+            PageScope::PerPage(_) => self.ops_dir.join(self.actor.to_string()),
+        }
     }
 
     fn snapshot_path(&self) -> PathBuf {
-        self.snapshots_dir.join(format!("snap-{}.bin", self.actor))
+        // Per-page snapshots are namespaced by slug so multiple pages
+        // don't clobber each other under `snapshots/`.
+        match &self.scope {
+            PageScope::Global => self.snapshots_dir.join(format!("snap-{}.bin", self.actor)),
+            PageScope::PerPage(slug) => self
+                .snapshots_dir
+                .join(format!("snap-{}-{slug}.bin", self.actor)),
+        }
     }
 
     /// Snapshot directory; useful for diagnostics and tests.
@@ -131,16 +192,87 @@ impl JsonlStorage {
         &self.ops_dir
     }
 
+    /// Scope this storage was opened with.
+    pub fn scope(&self) -> &PageScope {
+        &self.scope
+    }
+
+    /// Read a single op from disk by `(actor, ts)`. Returns `None`
+    /// when the HLC isn't in the offset index or the read fails.
+    ///
+    /// Cold path: only used when an op has been evicted from the LRU.
+    /// Hot ops come straight out of `cache`. Uses seek + line read
+    /// (no mmap) so the `unsafe`-free invariant of the crate holds.
+    ///
+    /// Under `PageScope::PerPage`, the offset index only knows about
+    /// `self.actor`'s ops for this page (peer ops under PerPage come
+    /// from their own `<peer-actor>/<slug>.jsonl` file). Cross-actor
+    /// cold reads walk the per-actor file directory.
+    fn read_op_at(&self, actor: ActorId, ts: Hlc) -> Option<LogOp> {
+        let offset = self.index.get(actor, ts)?;
+        let path = self.ops_path_for_actor(actor)?;
+        let mut file = File::open(&path).ok()?;
+        file.seek(SeekFrom::Start(offset)).ok()?;
+        let mut line = String::new();
+        BufReader::new(file).read_line(&mut line).ok()?;
+        if line.is_empty() {
+            return None;
+        }
+        // A glued line yields multiple ops; pick the one whose HLC
+        // matches (same recovery semantics as the boot path).
+        let ops = parse_log_line(line.trim()).ok()?;
+        ops.into_iter().find(|o| o.ts == ts)
+    }
+
+    /// Path of the `.jsonl` for `actor` under this storage's scope.
+    /// Under Global that's `ops/ops-<actor>.jsonl`; under PerPage it's
+    /// `ops/<actor>/<slug>.jsonl` (and only `self.actor` is expected).
+    fn ops_path_for_actor(&self, actor: ActorId) -> Option<PathBuf> {
+        match &self.scope {
+            PageScope::Global => Some(self.ops_dir.join(format!("ops-{actor}.jsonl"))),
+            PageScope::PerPage(slug) => {
+                if actor == self.actor {
+                    Some(
+                        self.ops_dir
+                            .join(self.actor.to_string())
+                            .join(format!("{slug}.jsonl")),
+                    )
+                } else {
+                    // PerPage doesn't currently merge peer files; the
+                    // caller (cold_ops_for_node) iterates this actor
+                    // only. Returning None makes the cold read a no-op
+                    // for peers, which is correct under Phase B's
+                    // single-page-per-storage model.
+                    None
+                }
+            }
+        }
+    }
+
     /// Re-read every `ops-*.jsonl` from disk into the cache.
+    ///
+    /// Under `PageScope::Global` this scans every `ops-<actor>.jsonl`
+    /// in `ops_dir` (legacy multi-actor merge). Under
+    /// `PageScope::PerPage(slug)` it only opens the single file for
+    /// `(this actor, this slug)` — that's the whole point of Phase B:
+    /// boot is proportional to one page, not the whole workspace.
     pub fn reload(&mut self) -> Result<(), StorageError> {
+        let scope = self.scope.clone();
+        match scope {
+            PageScope::Global => self.reload_global(),
+            PageScope::PerPage(slug) => self.reload_per_page(&slug),
+        }
+    }
+
+    fn reload_global(&mut self) -> Result<(), StorageError> {
         let mut all: Vec<LogOp> = Vec::new();
         let mut per_file: Vec<(String, u64, usize, usize)> = Vec::new();
         let dir = std::fs::read_dir(&self.ops_dir)
             .map_err(|e| StorageError::Backend(format!("read {}: {e}", self.ops_dir.display())))?;
 
-        // Track which actors we've indexed so far; reload resets every
-        // per-actor index entry from scratch.
-        let mut seen_actors: HashMap<ActorId, OffsetIndex> = HashMap::new();
+        // Reset every per-actor index — reload rebuilds from scratch.
+        let mut seen_hlc: HashMap<ActorId, OffsetIndex> = HashMap::new();
+        let mut seen_node: HashMap<ActorId, NodeIndex> = HashMap::new();
 
         for entry in dir {
             let entry = match entry {
@@ -173,14 +305,10 @@ impl JsonlStorage {
                 StorageError::Backend(format!("ops filename lacks actor: {name}"))
             })?;
 
-            // Stream the .jsonl once, building both the in-memory
-            // `Vec<LogOp>` and a fresh `OffsetIndex` keyed by HLC. This
-            // is the same single pass we'd pay without the index
-            // feature, so reloading with no sidecar is no slower than
-            // before.
             let mut lines_read = 0usize;
             let mut ops_parsed = 0usize;
-            let mut rebuilt = OffsetIndex::new();
+            let mut rebuilt_hlc = OffsetIndex::new();
+            let mut rebuilt_node = NodeIndex::new();
             let mut offset: u64 = 0;
             let mut reader = BufReader::new(file);
             let mut buf = String::new();
@@ -213,7 +341,10 @@ impl JsonlStorage {
                             );
                         }
                         for op in &ops {
-                            rebuilt.insert(op.ts, start);
+                            rebuilt_hlc.insert(op.ts, start);
+                            if let Some(node) = op_node(&op.op) {
+                                rebuilt_node.insert(node, op.ts, start);
+                            }
                         }
                         ops_parsed += ops.len();
                         all.extend(ops);
@@ -222,13 +353,17 @@ impl JsonlStorage {
                 }
                 offset += n as u64;
             }
-            // Persist the rebuilt index for next boot's fast path.
-            // Failure here is non-fatal — the index is a cache.
-            let idx_path = ActorIndex::sidecar_path(&self.ops_dir, file_actor);
-            if let Err(e) = rebuilt.save(&idx_path) {
-                warn!("could not persist index {}: {e}", idx_path.display());
+            // Persist both sidecars next to the .jsonl.
+            let hlc_path = ActorIndex::sidecar_path(&self.ops_dir, file_actor);
+            if let Err(e) = rebuilt_hlc.save(&hlc_path) {
+                warn!("could not persist index {}: {e}", hlc_path.display());
             }
-            seen_actors.insert(file_actor, rebuilt);
+            let node_path = ActorNodeIndex::sidecar_path(&self.ops_dir, file_actor);
+            if let Err(e) = rebuilt_node.save(&node_path) {
+                warn!("could not persist node index {}: {e}", node_path.display());
+            }
+            seen_hlc.insert(file_actor, rebuilt_hlc);
+            seen_node.insert(file_actor, rebuilt_node);
             debug!(
                 "jsonl file {} size={} lines={} ops_parsed={}",
                 name, file_size, lines_read, ops_parsed
@@ -237,22 +372,13 @@ impl JsonlStorage {
         }
 
         all.sort_by_key(|op| op.ts);
-        let mut per_actor: HashMap<ActorId, usize> = HashMap::new();
-        for op in &all {
-            *per_actor.entry(op.actor).or_insert(0) += 1;
-        }
         debug!(
-            "jsonl storage loaded {} ops from {} ({} files); per_actor={:?}",
+            "jsonl storage (global) loaded {} ops from {} ({} files)",
             all.len(),
             self.ops_dir.display(),
-            per_file.len(),
-            per_actor
+            per_file.len()
         );
 
-        // Reset the LRU and prime it with the freshly-loaded ops. With
-        // a bounded cap the oldest entries silently evict — exactly the
-        // RSS bound the LRU exists to provide. With `unbounded` every
-        // op stays resident (legacy behaviour).
         {
             let mut cache = self.cache.write();
             cache.clear();
@@ -260,11 +386,104 @@ impl JsonlStorage {
                 cache.put(op.ts, op.clone());
             }
         }
-
-        // Swap in the freshly rebuilt per-actor indexes.
-        for (actor, idx) in seen_actors {
+        for (actor, idx) in seen_hlc {
             self.index.replace(actor, idx);
         }
+        for (actor, idx) in seen_node {
+            self.node_index.replace(actor, idx);
+        }
+        Ok(())
+    }
+
+    /// Reload under `PageScope::PerPage(slug)`. Opens exactly one file:
+    /// `ops/<actor>/<slug>.jsonl`. Boot cost is O(this page's history),
+    /// not O(workspace history).
+    fn reload_per_page(&mut self, slug: &str) -> Result<(), StorageError> {
+        let path = self.own_ops_path();
+        let mut all: Vec<LogOp> = Vec::new();
+        let mut rebuilt_hlc = OffsetIndex::new();
+        let mut rebuilt_node = NodeIndex::new();
+
+        let file = match File::open(&path) {
+            Ok(f) => f,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // Page has no ops yet — fresh workspace, nothing to load.
+                self.cache.write().clear();
+                self.index.replace(self.actor, OffsetIndex::new());
+                self.node_index.replace(self.actor, NodeIndex::new());
+                return Ok(());
+            }
+            Err(e) => {
+                return Err(StorageError::Backend(format!(
+                    "open {}: {e}",
+                    path.display()
+                )))
+            }
+        };
+
+        let mut offset: u64 = 0;
+        let mut reader = BufReader::new(file);
+        let mut buf = String::new();
+        let mut lines_read = 0usize;
+        loop {
+            let start = offset;
+            buf.clear();
+            let n = match reader.read_line(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => n,
+                Err(e) => {
+                    warn!("io error {}:{}: {e}", path.display(), lines_read + 1);
+                    break;
+                }
+            };
+            lines_read += 1;
+            let trimmed = buf.trim();
+            if trimmed.is_empty() {
+                offset += n as u64;
+                continue;
+            }
+            match parse_log_line(trimmed) {
+                Ok(ops) => {
+                    for op in &ops {
+                        rebuilt_hlc.insert(op.ts, start);
+                        if let Some(node) = op_node(&op.op) {
+                            rebuilt_node.insert(node, op.ts, start);
+                        }
+                    }
+                    all.extend(ops);
+                }
+                Err(e) => warn!("parse {}:{}: {e}", path.display(), lines_read),
+            }
+            offset += n as u64;
+        }
+
+        let own_dir = self.own_ops_dir();
+        let hlc_path = ActorIndex::sidecar_path(&own_dir, self.actor);
+        if let Err(e) = rebuilt_hlc.save(&hlc_path) {
+            warn!("could not persist index {}: {e}", hlc_path.display());
+        }
+        let node_path = ActorNodeIndex::sidecar_path(&own_dir, self.actor);
+        if let Err(e) = rebuilt_node.save(&node_path) {
+            warn!("could not persist node index {}: {e}", node_path.display());
+        }
+
+        debug!(
+            "jsonl storage (per-page {}) loaded {} ops from {} ({} lines)",
+            slug,
+            all.len(),
+            path.display(),
+            lines_read
+        );
+
+        {
+            let mut cache = self.cache.write();
+            cache.clear();
+            for op in &all {
+                cache.put(op.ts, op.clone());
+            }
+        }
+        self.index.replace(self.actor, rebuilt_hlc);
+        self.node_index.replace(self.actor, rebuilt_node);
         Ok(())
     }
 
@@ -310,6 +529,37 @@ impl JsonlStorage {
         // the most-recent-by-HLC tail we want to retain.
         guard.resize(new_cap);
     }
+    /// Cold-path `ops_for_node` when the LRU has no warm entry for the
+    /// node. Walks the per-node secondary index across every known
+    /// actor and pulls each op from the cache (if still resident) or
+    /// the disk file via [`Self::read_op_at`]. RFC #137 Phase A.
+    fn cold_ops_for_node(&self, id: NodeId) -> Result<Vec<LogOp>, StorageError> {
+        let mut out: Vec<LogOp> = Vec::new();
+        // Always includes `self.actor` even if every op of its has
+        // been evicted — the node index still tracks them.
+        let mut actor_set: std::collections::HashSet<ActorId> = std::collections::HashSet::new();
+        actor_set.insert(self.actor);
+        for (_, op) in self.cache.read().iter() {
+            actor_set.insert(op.actor);
+        }
+
+        for actor in actor_set {
+            let entries = self.node_index.get(actor, id);
+            for (ts, _offset) in entries {
+                // Cache hit first.
+                if let Some(op) = self.cache.read().peek(&ts).cloned() {
+                    out.push(op);
+                    continue;
+                }
+                // Cold: read from disk via the offset index.
+                if let Some(op) = self.read_op_at(actor, ts) {
+                    out.push(op);
+                }
+            }
+        }
+        out.sort_by_key(|op| op.ts);
+        Ok(out)
+    }
 }
 
 /// Parse one JSONL line into one-or-more [`LogOp`]s.
@@ -344,6 +594,19 @@ fn op_touches_node(op: &Op, id: NodeId) -> bool {
     }
 }
 
+/// Extract the `NodeId` an op targets, if any. Every `Op` variant
+/// carries one — there is no op that touches zero nodes. Returns
+/// `Option` so callers can `filter_map` cleanly.
+fn op_node(op: &Op) -> Option<NodeId> {
+    match op {
+        Op::Create { node, .. }
+        | Op::Move { node, .. }
+        | Op::Edit { node, .. }
+        | Op::SetProp { node, .. }
+        | Op::SetCollapsed { node, .. } => Some(*node),
+    }
+}
+
 /// Parse `<actor>` out of a filename like `ops-<actor>.jsonl`. Returns
 /// `None` when the shape doesn't match (so callers can log and skip
 /// rather than panic).
@@ -367,30 +630,42 @@ impl Storage for JsonlStorage {
 
         let line = serde_json::to_string(op).map_err(|e| StorageError::Serialize(e.to_string()))?;
         let path = self.own_ops_path();
+        // Capture the byte offset where this op's line will land BEFORE
+        // opening the file in append mode. POSIX `O_APPEND` (set by
+        // `OpenOptions::append(true)`) does not update the file offset
+        // for `stream_position()` until after the next write, so reading
+        // `stream_position()` post-open would return 0 every time.
+        // `metadata.len()` is the current end-of-file, which is the
+        // offset we are about to write at.
+        let offset = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
         let mut file = OpenOptions::new()
             .create(true)
             .append(true)
             .open(&path)
             .map_err(|e| StorageError::Backend(format!("open {}: {e}", path.display())))?;
-        // Capture the byte offset where this op's line is about to
-        // land. `stream_position` after `open(append)` returns the
-        // current end-of-file, which is the offset we'll write at.
-        let offset = file
-            .stream_position()
-            .map_err(|e| StorageError::Backend(format!("stream_position: {e}")))?;
         writeln!(file, "{line}")
             .map_err(|e| StorageError::Backend(format!("write {}: {e}", path.display())))?;
         file.sync_all()
             .map_err(|e| StorageError::Backend(format!("fsync {}: {e}", path.display())))?;
 
-        // Mirror into the offset index (in-memory + sidecar append).
-        // The sidecar is best-effort — a lost index entry just means
-        // the next boot rebuilds from the .jsonl. Don't fail the op
-        // over the index.
+        // Mirror into both indexes (in-memory + sidecar append). Sidecar
+        // failures are best-effort — the index is a cache, a missing
+        // entry just means the next boot rebuilds from the .jsonl.
+        let own_dir = self.own_ops_dir();
         self.index.insert(op.actor, op.ts, offset);
-        let idx_path = ActorIndex::sidecar_path(&self.ops_dir, op.actor);
-        if let Err(e) = OffsetIndex::append_to(&idx_path, op.ts, offset) {
-            warn!("could not append to index {}: {e}", idx_path.display());
+        let hlc_idx_path = ActorIndex::sidecar_path(&own_dir, op.actor);
+        if let Err(e) = OffsetIndex::append_to(&hlc_idx_path, op.ts, offset) {
+            warn!("could not append to index {}: {e}", hlc_idx_path.display());
+        }
+        if let Some(node) = op_node(&op.op) {
+            self.node_index.insert(op.actor, node, op.ts, offset);
+            let node_idx_path = ActorNodeIndex::sidecar_path(&own_dir, op.actor);
+            if let Err(e) = NodeIndex::append_to(&node_idx_path, node, op.ts, offset) {
+                warn!(
+                    "could not append to node index {}: {e}",
+                    node_idx_path.display()
+                );
+            }
         }
 
         self.cache.write().put(op.ts, op.clone());
@@ -408,17 +683,21 @@ impl Storage for JsonlStorage {
         out.sort_by_key(|op| op.ts);
         Ok(out)
     }
-
     fn ops_for_node(&self, id: NodeId) -> Result<Vec<LogOp>, StorageError> {
-        let mut out: Vec<LogOp> = self
-            .cache
-            .read()
+        // Hot path: cache hits cover recent ops.
+        let cache = self.cache.read();
+        let mut warm: Vec<LogOp> = cache
             .iter()
             .filter(|(_, op)| op_touches_node(&op.op, id))
             .map(|(_, op)| op.clone())
             .collect();
-        out.sort_by_key(|op| op.ts);
-        Ok(out)
+        drop(cache);
+        if warm.is_empty() {
+            // No warm hits at all; fall back to the per-node index.
+            return self.cold_ops_for_node(id);
+        }
+        warm.sort_by_key(|op| op.ts);
+        Ok(warm)
     }
 
     fn ops_for_actor(&self, id: ActorId) -> Result<Vec<LogOp>, StorageError> {
@@ -617,6 +896,83 @@ mod tests {
         assert_eq!(last.get(&actor).copied(), Some(ops[4].ts));
     }
 
+    /// After LRU eviction, `ops_for_node` must still return every op
+    /// that touched the node — pulled back from disk via the per-node
+    /// secondary index. This is the correctness guarantee RFC #137
+    /// Phase A needs: shedding cold history can't lose data.
+    #[test]
+    fn ops_for_node_survives_lru_eviction() {
+        let tmp = TempDir::new().unwrap();
+        let actor = ActorId::new();
+        let g = HlcGenerator::new(actor);
+
+        // Use the legacy unbounded API so we can append without LRU
+        // eviction interfering, then explicitly shrink afterwards.
+        let mut storage = JsonlStorage::open(tmp.path().to_path_buf(), actor).unwrap();
+        let target = NodeId::new();
+        // 5 edits on `target`, 1 edit on filler nodes between each so
+        // they push `target` ops out of a small LRU.
+        let mut target_ts: Vec<Hlc> = Vec::new();
+        for _ in 0..5 {
+            let ts = g.next();
+            target_ts.push(ts);
+            storage
+                .append_op(&LogOp {
+                    ts,
+                    actor,
+                    op: Op::Edit {
+                        node: target,
+                        text_op: vec![1, 2, 3, 4],
+                    },
+                })
+                .unwrap();
+            // Filler edit on a different node — 5 of these between
+            // each target edit means a cap of 5 leaves all target ops
+            // evicted.
+            let _ = g.next();
+            storage
+                .append_op(&LogOp {
+                    ts: g.next(),
+                    actor,
+                    op: Op::Edit {
+                        node: NodeId::new(),
+                        text_op: vec![5, 6],
+                    },
+                })
+                .unwrap();
+        }
+
+        // Sanity: pre-shrink, ops_for_node returns every target op.
+        let pre = storage.ops_for_node(target).unwrap();
+        assert_eq!(pre.len(), 5);
+
+        // Shrink the LRU so all target ops get evicted. cap=1 keeps
+        // only the very last put (a filler), so every target op
+        // becomes a cold read.
+        storage.resize_cache(1);
+        // Cache no longer holds any target op.
+        let cached = storage.all_ops().unwrap();
+        assert!(
+            !cached.iter().any(|o| op_touches_node(&o.op, target)),
+            "target ops should be evicted by resize_cache(1)"
+        );
+
+        // Cold path must still find every target op via the per-node
+        // index + offset index.
+        let post = storage.ops_for_node(target).unwrap();
+        assert_eq!(
+            post.len(),
+            5,
+            "ops_for_node must return every op even when the LRU has evicted them all"
+        );
+        // Same HLCs as we appended.
+        let mut post_ts: Vec<Hlc> = post.iter().map(|o| o.ts).collect();
+        post_ts.sort();
+        let mut expected = target_ts.clone();
+        expected.sort();
+        assert_eq!(post_ts, expected);
+    }
+
     /// Reload after a bounded-LRU session rehydrates from disk; the cap
     /// still applies.
     #[test]
@@ -635,5 +991,109 @@ mod tests {
         }
         let reopened = JsonlStorage::open_with_cap(dir, actor, 2).unwrap();
         assert_eq!(reopened.all_ops().unwrap().len(), 2);
+    }
+
+    /// `PageScope::PerPage` writes ops to `ops/<actor>/<slug>.jsonl`,
+    /// not the legacy `ops-<actor>.jsonl`. Boot reads them back from
+    /// the same path. RFC #137 Phase B.
+    #[test]
+    fn per_page_scope_routes_to_actor_subdir() {
+        let tmp = TempDir::new().unwrap();
+        let actor = ActorId::new();
+        let g = HlcGenerator::new(actor);
+
+        let mut storage = JsonlStorage::open_with_scope_cap(
+            tmp.path().to_path_buf(),
+            actor,
+            PageScope::PerPage("project-x".into()),
+            0,
+        )
+        .unwrap();
+        let op = mk_create(&g);
+        storage.append_op(&op).unwrap();
+
+        // File landed under `ops/<actor>/project-x.jsonl`, not
+        // `ops-<actor>.jsonl`.
+        let expected = tmp.path().join(format!("{actor}")).join("project-x.jsonl");
+        assert!(
+            expected.exists(),
+            "expected per-page file at {}",
+            expected.display()
+        );
+        let legacy = tmp.path().join(format!("ops-{actor}.jsonl"));
+        assert!(
+            !legacy.exists(),
+            "legacy global file should not exist under PerPage scope"
+        );
+
+        // Reload reads from the per-page path.
+        let reopened = JsonlStorage::open_with_scope_cap(
+            tmp.path().to_path_buf(),
+            actor,
+            PageScope::PerPage("project-x".into()),
+            0,
+        )
+        .unwrap();
+        let ops = reopened.all_ops().unwrap();
+        assert_eq!(ops.len(), 1);
+        assert_eq!(ops[0].ts, op.ts);
+
+        // Scope is reported back.
+        assert_eq!(reopened.scope(), &PageScope::PerPage("project-x".into()));
+    }
+
+    /// PerPage storage with no ops on disk boots cleanly (fresh page).
+    #[test]
+    fn per_page_scope_with_missing_file_boots_clean() {
+        let tmp = TempDir::new().unwrap();
+        let actor = ActorId::new();
+        let storage = JsonlStorage::open_with_scope_cap(
+            tmp.path().to_path_buf(),
+            actor,
+            PageScope::PerPage("never-existed".into()),
+            0,
+        )
+        .unwrap();
+        assert_eq!(storage.all_ops().unwrap().len(), 0);
+    }
+
+    /// Global and PerPage storages coexist in the same `ops/` dir
+    /// without clobbering each other.
+    #[test]
+    fn global_and_per_page_coexist() {
+        let tmp = TempDir::new().unwrap();
+        let actor = ActorId::new();
+        let g = HlcGenerator::new(actor);
+
+        // Write one op under Global.
+        let mut global = JsonlStorage::open(tmp.path().to_path_buf(), actor).unwrap();
+        let global_op = mk_create(&g);
+        global.append_op(&global_op).unwrap();
+        drop(global);
+
+        // Write one op under PerPage("home").
+        let mut per_page = JsonlStorage::open_with_scope_cap(
+            tmp.path().to_path_buf(),
+            actor,
+            PageScope::PerPage("home".into()),
+            0,
+        )
+        .unwrap();
+        let page_op = mk_create(&g);
+        per_page.append_op(&page_op).unwrap();
+        drop(per_page);
+
+        // Both reload independently and see only their own ops.
+        let g2 = JsonlStorage::open(tmp.path().to_path_buf(), actor).unwrap();
+        let p2 = JsonlStorage::open_with_scope_cap(
+            tmp.path().to_path_buf(),
+            actor,
+            PageScope::PerPage("home".into()),
+            0,
+        )
+        .unwrap();
+        assert_eq!(g2.all_ops().unwrap().len(), 1);
+        assert_eq!(p2.all_ops().unwrap().len(), 1);
+        assert_ne!(g2.all_ops().unwrap()[0].ts, p2.all_ops().unwrap()[0].ts);
     }
 }

--- a/crates/outl-core/src/storage/mod.rs
+++ b/crates/outl-core/src/storage/mod.rs
@@ -13,10 +13,45 @@ use thiserror::Error;
 pub mod index;
 pub mod jsonl;
 pub mod memory;
+pub mod node_index;
 
 pub use index::{ActorIndex, OffsetIndex};
 pub use jsonl::JsonlStorage;
 pub use memory::MemoryStorage;
+pub use node_index::{ActorNodeIndex, NodeIndex};
+
+/// Which page a storage backend is responsible for.
+///
+/// `Global` is the legacy single-file-per-actor layout every workspace
+/// shipped with before RFC #137 Phase B. `PerPage(slug)` is the
+/// sharded layout — one `ops/<actor>/<slug>.jsonl` per (actor, page)
+/// pair — that lets boot and sync be proportional to the active page
+/// rather than the whole workspace.
+///
+/// Layouts on disk:
+///
+/// - `Global` → `ops/ops-<actor>.jsonl` (+ `.idx`, `.nodes.idx` sidecars)
+/// - `PerPage(slug)` → `ops/<actor>/<slug>.jsonl` (+ sidecars)
+///
+/// `Global` stays the default for back-compat. New workspaces opt into
+/// `PerPage` via `outl init --scope=per-page`; existing ones migrate
+/// via `outl migrate-to-per-page-ops`.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub enum PageScope {
+    /// Single op log per actor — every page shares one file.
+    #[default]
+    Global,
+    /// Op log scoped to one page. The slug is the page's URL-safe name
+    /// (same one used for the `.md` filename under `pages/`).
+    PerPage(String),
+}
+
+impl PageScope {
+    /// `true` for the legacy single-file layout.
+    pub fn is_global(&self) -> bool {
+        matches!(self, PageScope::Global)
+    }
+}
 
 /// Errors a `Storage` implementation may produce.
 #[derive(Debug, Error)]

--- a/crates/outl-core/src/storage/mod.rs
+++ b/crates/outl-core/src/storage/mod.rs
@@ -10,9 +10,11 @@ use crate::op::LogOp;
 use std::collections::HashMap;
 use thiserror::Error;
 
+pub mod index;
 pub mod jsonl;
 pub mod memory;
 
+pub use index::{ActorIndex, OffsetIndex};
 pub use jsonl::JsonlStorage;
 pub use memory::MemoryStorage;
 
@@ -89,4 +91,18 @@ pub trait Storage: Send + Sync {
     fn snapshot_cutoff(&self) -> Result<Option<Hlc>, StorageError> {
         Ok(None)
     }
+
+    /// Shrink (or grow) the in-memory op cache to hold at most `cap`
+    /// ops. `cap = 0` means "unbounded" — keep every op resident (the
+    /// legacy default). Default no-op; [`JsonlStorage`] implements it
+    /// for real.
+    ///
+    /// Called by `Workspace` after boot completes (see
+    /// `Workspace::apply_lru_cap`). Boot needs every op in RAM to
+    /// re-materialise Yrs `Doc`s via `ops_for_node`; once that's done,
+    /// the long-running client can shed the cold history.
+    ///
+    /// Implementations must be idempotent and safe to call from any
+    /// point in the lifecycle.
+    fn resize_cache(&mut self, _cap: usize) {}
 }

--- a/crates/outl-core/src/storage/node_index.rs
+++ b/crates/outl-core/src/storage/node_index.rs
@@ -256,6 +256,13 @@ impl ActorNodeIndex {
     pub fn sidecar_path(ops_dir: &Path, actor: ActorId) -> PathBuf {
         ops_dir.join(format!("ops-{actor}.nodes.idx"))
     }
+
+    /// Snapshot of every actor known to the index. Used by
+    /// `cold_ops_for_node` to enumerate peer actors without depending
+    /// on which ops happen to be warm in the LRU cache.
+    pub fn actors(&self) -> Vec<ActorId> {
+        self.inner.read().keys().copied().collect()
+    }
 }
 
 #[cfg(test)]

--- a/crates/outl-core/src/storage/node_index.rs
+++ b/crates/outl-core/src/storage/node_index.rs
@@ -1,0 +1,362 @@
+//! Per-actor secondary index: `NodeId → Vec<(Hlc, offset)>`.
+//!
+//! The HLC index in [`super::index::OffsetIndex`] answers "where does
+//! this op live?" by timestamp. This one answers "which ops ever
+//! touched this block?" — the query `ops_for_node` needs.
+//!
+//! Without it, `ops_for_node` would scan every op in the file. With
+//! it (plus the mmapped file), a cold rebuild of a heavily-edited Yrs
+//! `Doc` is O(ops-on-that-node), not O(total).
+//!
+//! Same on-disk shape as `ops-<actor>.idx`: JSONL, one entry per line,
+//! append-only. Pure cache; rebuilt from the `.jsonl` when missing.
+
+use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+use crate::hlc::Hlc;
+use crate::id::{ActorId, NodeId};
+use crate::op::LogOp;
+use crate::storage::StorageError;
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+struct NodeEntry {
+    node: NodeId,
+    ts: Hlc,
+    offset: u64,
+}
+
+/// Secondary index mapping each `NodeId` to every `(Hlc, offset)` that
+/// ever touched it. Powers `JsonlStorage::ops_for_node` without
+/// scanning the whole `.jsonl`.
+#[derive(Default, Debug)]
+pub struct NodeIndex {
+    entries: HashMap<NodeId, Vec<(Hlc, u64)>>,
+}
+
+impl NodeIndex {
+    /// Build an empty index.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record that the op at `(ts, offset)` touched `node`. Order
+    /// matters: callers should insert in HLC order so the per-node
+    /// vector stays sorted (recovery code relies on this).
+    pub fn insert(&mut self, node: NodeId, ts: Hlc, offset: u64) {
+        self.entries.entry(node).or_default().push((ts, offset));
+    }
+
+    /// Offsets of every op that touched `node`, in insertion order.
+    pub fn get(&self, node: &NodeId) -> &[(Hlc, u64)] {
+        self.entries
+            .get(node)
+            .map(|v| v.as_slice())
+            .unwrap_or_default()
+    }
+
+    /// Number of nodes tracked.
+    pub fn node_count(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Total entries across every node.
+    pub fn total_len(&self) -> usize {
+        self.entries.values().map(|v| v.len()).sum()
+    }
+
+    /// Load from a `ops-<actor>.nodes.idx` sidecar. Returns:
+    /// - `Ok(Some)` when the file exists and parses.
+    /// - `Ok(None)` when missing, empty, or corrupt (caller rebuilds).
+    /// - `Err` only on real I/O failure.
+    pub fn load(path: &Path) -> Result<Option<Self>, StorageError> {
+        let file = match File::open(path) {
+            Ok(f) => f,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => {
+                return Err(StorageError::Backend(format!(
+                    "open node index {}: {e}",
+                    path.display()
+                )))
+            }
+        };
+        let mut index = Self::new();
+        let mut recovered = 0usize;
+        for (lineno, line) in BufReader::new(file).lines().enumerate() {
+            let raw = match line {
+                Ok(l) if !l.is_empty() => l,
+                Ok(_) => continue,
+                Err(e) => {
+                    warn!("node index io error {}:{}: {e}", path.display(), lineno + 1);
+                    return Ok(None);
+                }
+            };
+            let stream = serde_json::Deserializer::from_str(&raw).into_iter::<NodeEntry>();
+            let mut saw_any = false;
+            for item in stream {
+                match item {
+                    Ok(entry) => {
+                        index.insert(entry.node, entry.ts, entry.offset);
+                        recovered += 1;
+                        saw_any = true;
+                    }
+                    Err(e) => {
+                        warn!(
+                            "node index parse {}:{}: {e} — rebuilding from .jsonl",
+                            path.display(),
+                            lineno + 1
+                        );
+                        return Ok(None);
+                    }
+                }
+            }
+            if !saw_any {
+                return Ok(None);
+            }
+        }
+        if recovered == 0 {
+            return Ok(None);
+        }
+        debug!(
+            "node index loaded from {} ({} entries across {} nodes)",
+            path.display(),
+            recovered,
+            index.node_count()
+        );
+        Ok(Some(index))
+    }
+
+    /// Persist the full index to `path` atomically.
+    pub fn save(&self, path: &Path) -> Result<(), StorageError> {
+        let tmp = path.with_extension("idx.tmp");
+        let mut file = File::create(&tmp)
+            .map_err(|e| StorageError::Backend(format!("create {}: {e}", tmp.display())))?;
+        for (node, entries) in &self.entries {
+            for (ts, offset) in entries {
+                let line = serde_json::to_string(&NodeEntry {
+                    node: *node,
+                    ts: *ts,
+                    offset: *offset,
+                })
+                .map_err(|e| StorageError::Serialize(e.to_string()))?;
+                writeln!(file, "{line}")
+                    .map_err(|e| StorageError::Backend(format!("write {}: {e}", tmp.display())))?;
+            }
+        }
+        file.sync_all()
+            .map_err(|e| StorageError::Backend(format!("fsync {}: {e}", tmp.display())))?;
+        drop(file);
+        std::fs::rename(&tmp, path).map_err(|e| {
+            StorageError::Backend(format!(
+                "rename {} -> {}: {e}",
+                tmp.display(),
+                path.display()
+            ))
+        })?;
+        Ok(())
+    }
+
+    /// Append one entry to `path` (hot path from `append_op`).
+    pub fn append_to(path: &Path, node: NodeId, ts: Hlc, offset: u64) -> Result<(), StorageError> {
+        let line = serde_json::to_string(&NodeEntry { node, ts, offset })
+            .map_err(|e| StorageError::Serialize(e.to_string()))?;
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .map_err(|e| {
+                StorageError::Backend(format!("open node index {}: {e}", path.display()))
+            })?;
+        writeln!(file, "{line}").map_err(|e| {
+            StorageError::Backend(format!("write node index {}: {e}", path.display()))
+        })?;
+        Ok(())
+    }
+
+    /// Rebuild by streaming the `.jsonl` once and recording every op
+    /// that touches a node (every `Op` variant does — see
+    /// `op_touches_node` in `super::jsonl`).
+    pub fn rebuild_from_jsonl(
+        jsonl_path: &Path,
+        op_touches_node: impl Fn(&crate::op::Op) -> Option<NodeId>,
+    ) -> Result<Self, StorageError> {
+        let file = File::open(jsonl_path)
+            .map_err(|e| StorageError::Backend(format!("open {}: {e}", jsonl_path.display())))?;
+        let mut reader = BufReader::new(file);
+        let mut index = Self::new();
+        let mut offset: u64 = 0;
+        let mut buf = String::new();
+        loop {
+            let start = offset;
+            buf.clear();
+            let n = reader.read_line(&mut buf).map_err(|e| {
+                StorageError::Backend(format!("read {}: {e}", jsonl_path.display()))
+            })?;
+            if n == 0 {
+                break;
+            }
+            let trimmed = buf.trim();
+            if !trimmed.is_empty() {
+                let stream = serde_json::Deserializer::from_str(trimmed).into_iter::<LogOp>();
+                for op in stream.flatten() {
+                    if let Some(node) = op_touches_node(&op.op) {
+                        index.insert(node, op.ts, start);
+                    }
+                }
+            }
+            offset += n as u64;
+        }
+        Ok(index)
+    }
+}
+
+/// Lock-protected multi-actor secondary index, keyed by actor id.
+#[derive(Default)]
+pub struct ActorNodeIndex {
+    inner: RwLock<HashMap<ActorId, NodeIndex>>,
+}
+
+impl ActorNodeIndex {
+    /// Build an empty multi-actor index.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a fresh `(node, ts, offset)` triple for `actor`.
+    pub fn insert(&self, actor: ActorId, node: NodeId, ts: Hlc, offset: u64) {
+        self.inner
+            .write()
+            .entry(actor)
+            .or_default()
+            .insert(node, ts, offset);
+    }
+
+    /// Replace the entire index for one actor (used by `reload()`).
+    pub fn replace(&self, actor: ActorId, index: NodeIndex) {
+        self.inner.write().insert(actor, index);
+    }
+
+    /// Snapshot of the offsets of every op that touched `node` under
+    /// `actor`, in insertion order.
+    pub fn get(&self, actor: ActorId, node: NodeId) -> Vec<(Hlc, u64)> {
+        self.inner
+            .read()
+            .get(&actor)
+            .map(|i| i.get(&node).to_vec())
+            .unwrap_or_default()
+    }
+
+    /// Path of the `.nodes.idx` sidecar for `actor` inside `ops_dir`.
+    pub fn sidecar_path(ops_dir: &Path, actor: ActorId) -> PathBuf {
+        ops_dir.join(format!("ops-{actor}.nodes.idx"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fractional::Fractional;
+    use crate::hlc::HlcGenerator;
+    use crate::op::Op;
+    use tempfile::TempDir;
+
+    fn logop(g: &HlcGenerator, node: NodeId) -> LogOp {
+        let ts = g.next();
+        LogOp {
+            ts,
+            actor: ts.actor,
+            op: Op::Create {
+                node,
+                parent: NodeId::root(),
+                position: Fractional::first(),
+            },
+        }
+    }
+
+    fn touches(op: &crate::op::Op) -> Option<NodeId> {
+        match op {
+            Op::Create { node, .. }
+            | Op::Move { node, .. }
+            | Op::Edit { node, .. }
+            | Op::SetProp { node, .. }
+            | Op::SetCollapsed { node, .. } => Some(*node),
+        }
+    }
+
+    #[test]
+    fn node_index_roundtrips() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("ops-x.nodes.idx");
+        let actor = ActorId::new();
+        let g = HlcGenerator::new(actor);
+        let n1 = NodeId::new();
+        let n2 = NodeId::new();
+
+        let mut index = NodeIndex::new();
+        index.insert(n1, g.next(), 0);
+        index.insert(n1, g.next(), 100);
+        index.insert(n2, g.next(), 200);
+        index.save(&path).unwrap();
+
+        let loaded = NodeIndex::load(&path).unwrap().expect("should load");
+        assert_eq!(loaded.node_count(), 2);
+        assert_eq!(loaded.get(&n1).len(), 2);
+        assert_eq!(loaded.get(&n2).len(), 1);
+        assert_eq!(loaded.total_len(), 3);
+    }
+
+    #[test]
+    fn missing_index_loads_as_none() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("nope.nodes.idx");
+        assert!(NodeIndex::load(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn rebuild_from_jsonl_finds_all_node_ops() {
+        let tmp = TempDir::new().unwrap();
+        let actor = ActorId::new();
+        let g = HlcGenerator::new(actor);
+        let n1 = NodeId::new();
+        let n2 = NodeId::new();
+        let a = logop(&g, n1);
+        let b = logop(&g, n2);
+        let c = logop(&g, n1); // n1 again
+
+        let jsonl = tmp.path().join(format!("ops-{actor}.jsonl"));
+        let body = format!(
+            "{}\n{}\n{}\n",
+            serde_json::to_string(&a).unwrap(),
+            serde_json::to_string(&b).unwrap(),
+            serde_json::to_string(&c).unwrap(),
+        );
+        std::fs::write(&jsonl, &body).unwrap();
+
+        let index = NodeIndex::rebuild_from_jsonl(&jsonl, touches).unwrap();
+        assert_eq!(index.node_count(), 2);
+        assert_eq!(index.get(&n1).len(), 2);
+        assert_eq!(index.get(&n2).len(), 1);
+    }
+
+    #[test]
+    fn actor_node_index_routes_by_actor() {
+        let ai = ActorNodeIndex::new();
+        let a = ActorId::new();
+        let b = ActorId::new();
+        let ga = HlcGenerator::new(a);
+        let gb = HlcGenerator::new(b);
+        let n = NodeId::new();
+        ai.insert(a, n, ga.next(), 10);
+        ai.insert(b, n, gb.next(), 20);
+        assert_eq!(ai.get(a, n).len(), 1);
+        assert_eq!(ai.get(b, n).len(), 1);
+        assert_eq!(ai.get(a, n)[0].1, 10);
+        assert_eq!(ai.get(b, n)[0].1, 20);
+    }
+}

--- a/crates/outl-core/src/workspace.rs
+++ b/crates/outl-core/src/workspace.rs
@@ -512,6 +512,23 @@ impl Workspace {
         self.ensure_doc_for_edit(node);
         self.content.replace_text(node, &self.log, new_text)
     }
+
+    /// Apply the LRU cap configured by the client, after boot has
+    /// finished re-materialising Yrs `Doc`s.
+    ///
+    /// Boot needs every op in RAM so `ops_for_node` (used to rebuild
+    /// `Doc`s for nodes edited after the snapshot cutoff) sees the full
+    /// `Edit` history. Once boot is done, the long-running client can
+    /// shed cold history: `cap = 50_000` keeps the most-recent ops
+    /// resident; older ones come back from disk via the offset index.
+    /// RFC #137 Phase A.
+    ///
+    /// `cap = 0` means "unbounded" — keep every op resident (legacy
+    /// default). Idempotent and safe to call at any point in the
+    /// lifecycle (clients may resize on config change).
+    pub fn apply_lru_cap(&mut self, cap: usize) {
+        self.storage.resize_cache(cap);
+    }
 }
 
 #[cfg(test)]

--- a/crates/outl-core/src/workspace.rs
+++ b/crates/outl-core/src/workspace.rs
@@ -17,7 +17,7 @@
 use crate::content::ContentStore;
 use crate::id::{ActorId, NodeId};
 use crate::log::OpLog;
-use crate::op::{LogOp, Op};
+use crate::op::{op_node, LogOp, Op};
 use crate::snapshot::{self, SnapshotBody};
 use crate::storage::{Storage, StorageError};
 use crate::tree::Tree;
@@ -49,8 +49,21 @@ pub struct Workspace {
     log: OpLog,
     /// Block text content (Yrs docs).
     content: ContentStore,
-    /// Pluggable storage backend.
+    /// Pluggable storage backend (Global scope — the legacy
+    /// single-file-per-actor layout). Per-page shards live in
+    /// `page_storages`.
     storage: Box<dyn Storage>,
+    /// Per-page storage backends (Phase B of RFC #137). Keyed by page
+    /// slug. Empty for workspaces that haven't migrated to per-page
+    /// shards. When non-empty, `apply` routes each op to the storage
+    /// that owns the op's node.
+    page_storages: HashMap<String, Box<dyn Storage>>,
+    /// `NodeId → slug` map for page roots. Populated by the client
+    /// (which reads sidecars via `outl-md`) via
+    /// [`Self::register_page_root`]. `apply` walks the parent chain
+    /// from an op's node up to a page root, then uses this map to
+    /// find the slug and route to the right `page_storages` entry.
+    page_root_to_slug: HashMap<NodeId, String>,
     /// `<root>/.outl/snapshots` when `root` is set, `None` for
     /// in-memory workspaces. Background snapshot writes go straight
     /// here — they don't go through `storage` (the snapshot is a local
@@ -109,6 +122,8 @@ impl Workspace {
             log: OpLog::new(),
             content: ContentStore::default(),
             storage,
+            page_storages: HashMap::new(),
+            page_root_to_slug: HashMap::new(),
             snapshots_dir,
             snapshot_workers: Vec::new(),
             ops_since_snapshot: 0,
@@ -172,7 +187,7 @@ impl Workspace {
         // Replay only the ops the snapshot hasn't seen yet. `Edit` ops
         // in this delta will be re-materialized in the loop below; the
         // rest of the snapshot's text is still authoritative.
-        let delta = self.storage.ops_since(body.hlc_cutoff)?;
+        let delta = self.ops_since_combined(body.hlc_cutoff)?;
         let mut edited_in_delta: HashSet<NodeId> = HashSet::new();
         for op in delta {
             if let Op::Edit { node, .. } = &op.op {
@@ -189,7 +204,7 @@ impl Workspace {
         // resulting text match the full-replay path (#129).
         let rematerialized_count = edited_in_delta.len();
         for node in &edited_in_delta {
-            let mut ops = match self.storage.ops_for_node(*node) {
+            let mut ops = match self.ops_for_node_combined(*node) {
                 Ok(o) => o,
                 Err(e) => {
                     warn!("skipping re-materialize for {node}: {e}");
@@ -232,7 +247,7 @@ impl Workspace {
         // no-op there) and the log. Text is materialized in pass 2 so the
         // open-time memory peak stays at a single live `Doc` instead of
         // one per block — that peak is what jetsam was killing on iOS.
-        let ops = self.storage.all_ops()?;
+        let ops = self.all_ops_combined()?;
         for op in ops {
             self.tree.apply_op(&mut self.log, op);
         }
@@ -285,7 +300,7 @@ impl Workspace {
         if self.log_complete {
             return; // ContentStore::ensure_doc rebuilds from the full log.
         }
-        let mut ops = match self.storage.ops_for_node(node) {
+        let mut ops = match self.ops_for_node_combined(node) {
             Ok(o) => o,
             Err(e) => {
                 warn!("could not load ops for {node} from storage: {e}");
@@ -324,7 +339,21 @@ impl Workspace {
             self.content.merge_update(*node, &self.log, text_op);
         }
         self.tree.apply_op(&mut self.log, op.clone());
-        self.storage.append_op(&op)?;
+
+        // Route to the right storage. If the op's node belongs to a
+        // registered page, write to that page's shard; otherwise write
+        // to the global storage (legacy behaviour).
+        let slug = op_node(&op.op).and_then(|node| self.slug_for_node(node));
+        match slug {
+            Some(ref slug) if self.page_storages.contains_key(slug) => {
+                if let Some(s) = self.page_storages.get_mut(slug) {
+                    s.append_op(&op)?;
+                }
+            }
+            _ => {
+                self.storage.append_op(&op)?;
+            }
+        }
 
         // Background snapshot trigger. `snapshot_threshold = 0` is the
         // opt-out (CLI). When the threshold is crossed we build the
@@ -513,6 +542,110 @@ impl Workspace {
         self.content.replace_text(node, &self.log, new_text)
     }
 
+    /// Re-boot the workspace from all registered storages (Global +
+    /// PerPage). Called by clients after registering per-page shards
+    /// via [`Self::register_page_storage`] — the initial boot only
+    /// sees the Global storage, so a re-boot is needed to load the
+    /// per-page ops into the materialized tree. RFC #137 Phase B.
+    pub fn reboot_with_all_storages(&mut self) -> Result<(), WorkspaceError> {
+        self.tree = Tree::new();
+        self.log = OpLog::new();
+        self.content = ContentStore::default();
+        self.log_complete = true;
+        self.boot_from_full_replay()?;
+        Ok(())
+    }
+
+    /// Whether any per-page storage shards have been registered.
+    pub fn has_page_storages(&self) -> bool {
+        !self.page_storages.is_empty()
+    }
+
+    /// Register a per-page storage backend. The client (CLI / TUI /
+    /// desktop / mobile) calls this after opening the workspace if the
+    /// workspace uses the per-page shard layout (RFC #137 Phase B).
+    /// Ops whose node belongs to `slug` will be routed to this storage
+    /// instead of the global one.
+    pub fn register_page_storage(&mut self, slug: &str, storage: Box<dyn Storage>) {
+        self.page_storages.insert(slug.to_string(), storage);
+    }
+
+    /// Register a page root → slug mapping. The client calls this for
+    /// every page/journal it knows about (read from sidecars via
+    /// `outl-md`). `apply` uses this to resolve which page an op
+    /// belongs to by walking the parent chain up to a page root.
+    pub fn register_page_root(&mut self, root_id: NodeId, slug: &str) {
+        self.page_root_to_slug.insert(root_id, slug.to_string());
+    }
+
+    /// Walk `tree.parent(node)` up until we hit a registered page root.
+    /// Returns the slug of that page, or `None` if the chain dead-ends
+    /// at the workspace root without finding one.
+    fn slug_for_node(&self, node: NodeId) -> Option<String> {
+        let mut current = node;
+        loop {
+            if let Some(slug) = self.page_root_to_slug.get(&current) {
+                return Some(slug.clone());
+            }
+            current = self.tree.parent(current)?;
+        }
+    }
+
+    /// Merge ops from the global storage and every registered
+    /// per-page storage, sorted by HLC. Used by boot and read-side
+    /// accessors (`all_ops`, `ops_since`, `ops_for_node`, etc.).
+    fn all_ops_combined(&self) -> Result<Vec<LogOp>, StorageError> {
+        let mut all = self.storage.all_ops()?;
+        for s in self.page_storages.values() {
+            all.extend(s.all_ops()?);
+        }
+        all.sort_by_key(|op| op.ts);
+        all.dedup_by_key(|op| op.ts);
+        Ok(all)
+    }
+
+    /// Merge ops with HLC > `ts` from every storage.
+    fn ops_since_combined(&self, ts: crate::hlc::Hlc) -> Result<Vec<LogOp>, StorageError> {
+        let mut all = self.storage.ops_since(ts)?;
+        for s in self.page_storages.values() {
+            all.extend(s.ops_since(ts)?);
+        }
+        all.sort_by_key(|op| op.ts);
+        all.dedup_by_key(|op| op.ts);
+        Ok(all)
+    }
+
+    /// Merge ops for `node` from every storage.
+    fn ops_for_node_combined(&self, node: NodeId) -> Result<Vec<LogOp>, StorageError> {
+        let mut all = self.storage.ops_for_node(node)?;
+        for s in self.page_storages.values() {
+            all.extend(s.ops_for_node(node)?);
+        }
+        all.sort_by_key(|op| op.ts);
+        all.dedup_by_key(|op| op.ts);
+        Ok(all)
+    }
+
+    /// Merge `last_ts_per_actor` from every storage.
+    #[allow(dead_code)]
+    fn last_ts_per_actor_combined(
+        &self,
+    ) -> Result<HashMap<ActorId, crate::hlc::Hlc>, StorageError> {
+        let mut map = self.storage.last_ts_per_actor()?;
+        for s in self.page_storages.values() {
+            for (actor, ts) in s.last_ts_per_actor()? {
+                map.entry(actor)
+                    .and_modify(|existing| {
+                        if ts > *existing {
+                            *existing = ts;
+                        }
+                    })
+                    .or_insert(ts);
+            }
+        }
+        Ok(map)
+    }
+
     /// Apply the LRU cap configured by the client, after boot has
     /// finished re-materialising Yrs `Doc`s.
     ///
@@ -528,6 +661,9 @@ impl Workspace {
     /// lifecycle (clients may resize on config change).
     pub fn apply_lru_cap(&mut self, cap: usize) {
         self.storage.resize_cache(cap);
+        for s in self.page_storages.values_mut() {
+            s.resize_cache(cap);
+        }
     }
 }
 

--- a/crates/outl-core/src/workspace.rs
+++ b/crates/outl-core/src/workspace.rs
@@ -331,6 +331,7 @@ impl Workspace {
     /// storage fails, the in-memory state is still mutated — the caller
     /// is responsible for surfacing the error and/or invoking `outl doctor`.
     pub fn apply(&mut self, op: LogOp) -> Result<(), WorkspaceError> {
+        let is_new = !self.log.contains_ts(&op.ts);
         if let Op::Edit { node, text_op } = &op.op {
             // Merge the update into the block's text. The Doc is rebuilt
             // from the log here, before this op is appended below, so the
@@ -339,6 +340,14 @@ impl Workspace {
             self.content.merge_update(*node, &self.log, text_op);
         }
         self.tree.apply_op(&mut self.log, op.clone());
+
+        // Only persist ops the tree didn't already have. `apply_op`
+        // deduplicates via `contains_ts`, but the storage append below
+        // is unconditional without this guard — a re-delivered op
+        // (sync replay, plugin pull) would write a duplicate line.
+        if !is_new {
+            return Ok(());
+        }
 
         // Route to the right storage. If the op's node belongs to a
         // registered page, write to that page's shard; otherwise write

--- a/crates/outl-core/tests/boot_scale_bench.rs
+++ b/crates/outl-core/tests/boot_scale_bench.rs
@@ -109,7 +109,7 @@ fn peak_rss_bytes() -> u64 {
     }
 }
 
-/// Run one scale row: generate, snapshot, boot both ways, print the row.
+/// Run one scale row: generate, snapshot, boot two ways, print the row.
 ///
 /// Shared by the per-scale tests below so each can run in isolation —
 /// generation is the slow step (~4 ms/op fsync-bound on an SSD), and a
@@ -141,15 +141,8 @@ fn run_scale(scale: Scale) {
         Some(root.to_path_buf()),
     )
     .unwrap();
-    // Disable in-band trigger so the snapshot we measure is the one
-    // we write explicitly at the end (otherwise it fires partway
-    // through generation and confuses the measurement).
     ws.set_snapshot_policy(false, 0);
 
-    // Generation: 1 Create + N Edits per node. The `Edit` carries a
-    // tiny placeholder update — the boot-path cost we're measuring
-    // is structural replay + cache load, which doesn't depend on
-    // real text content. fsync-per-op dominates wall time.
     let start_gen = Instant::now();
     for _ in 0..scale.nodes {
         let n = NodeId::new();
@@ -175,8 +168,6 @@ fn run_scale(scale: Scale) {
     }
     let gen_time = start_gen.elapsed();
 
-    // Save snapshot synchronously (the path TUI / desktop / mobile
-    // take on shutdown).
     ws.save_snapshot().unwrap();
     let snap_size = std::fs::metadata(snapshots_dir.join(format!("snap-{actor}.bin")))
         .map(|m| m.len())
@@ -184,7 +175,7 @@ fn run_scale(scale: Scale) {
     let node_count = ws.tree().node_count();
     drop(ws);
 
-    // Boot path 1: with snapshot present.
+    // Boot path 1: snapshot present, LRU unbounded.
     let start = Instant::now();
     let ws1 = Workspace::open_with_storage(
         actor,
@@ -211,18 +202,8 @@ fn run_scale(scale: Scale) {
     let nodes_full = ws2.tree().node_count();
     drop(ws2);
 
-    // Sanity: every path must land on the same node count, otherwise
-    // the bench is comparing different states.
-    assert_eq!(
-        nodes_snap, nodes_full,
-        "node count diverged between snapshot and full-replay boot at {}",
-        scale.label
-    );
-    assert_eq!(
-        nodes_snap, node_count,
-        "node count drifted between generation and boot at {}",
-        scale.label
-    );
+    assert_eq!(nodes_snap, nodes_full);
+    assert_eq!(nodes_snap, node_count);
 
     eprintln!(
         "{:>6} | {:>9} | {:>6.1?} | {:>10.2?} | {:>10.2?} | {:>6} MB | {:>6} MB | {:>6} KB",
@@ -234,16 +215,6 @@ fn run_scale(scale: Scale) {
         rss_snap / 1024 / 1024,
         rss_full / 1024 / 1024,
         snap_size / 1024,
-    );
-    eprintln!(
-        "  rss_snap = {} MB, rss_full = {} MB (peak RSS of this process after boot)",
-        rss_snap / 1024 / 1024,
-        rss_full / 1024 / 1024
-    );
-    eprintln!(
-        "  speedup: {:.2}x (saved {:?} per boot)",
-        boot_full.as_secs_f64() / boot_snap.as_secs_f64().max(0.000_001),
-        boot_full.checked_sub(boot_snap).unwrap_or_default()
     );
 }
 

--- a/crates/outl-core/tests/boot_scale_bench.rs
+++ b/crates/outl-core/tests/boot_scale_bench.rs
@@ -1,0 +1,272 @@
+//! Boot-path scale benchmark (#37 driver).
+//!
+//! Measures `Workspace::open_with_storage` time AND peak resident
+//! memory at four op-log scales, with and without a Phase 1 snapshot.
+//!
+//! Run all rows (slow — generation is fsync-bound, ~4 ms/op):
+//!
+//! ```sh
+//! cargo test -p outl-core --release --test boot_scale_bench -- --ignored --nocapture
+//! ```
+//!
+//! Run one scale in isolation (preferred for partial data):
+//!
+//! ```sh
+//! cargo test -p outl-core --release --test boot_scale_bench boot_scale_100k -- --ignored --nocapture
+//! ```
+//!
+//! ## Why this exists
+//!
+//! Phase 1 snapshot (#128) speeds up boot but **does not reduce RSS** —
+//! the resident `OpLog` still holds every `Op::Edit`'s `text_op` bytes,
+//! and `JsonlStorage` mirrors them in its own cache. This bench
+//! quantifies where the cost lands as the op log grows, so we can
+//! decide whether per-page shards (#37) are urgent or can wait, and
+//! pick the right layer to fix.
+//!
+//! Output is plain text on stderr so `--nocapture` shows the numbers
+//! inline. Not run in CI — slow and the `snapshot_equivalence` property
+//! test is the load-bearing correctness guard.
+
+use outl_core::fractional::Fractional;
+use outl_core::hlc::HlcGenerator;
+use outl_core::id::{ActorId, NodeId};
+use outl_core::op::{LogOp, Op};
+use outl_core::storage::JsonlStorage;
+use outl_core::Workspace;
+use std::time::Instant;
+use tempfile::TempDir;
+
+#[derive(Clone, Copy)]
+struct Scale {
+    label: &'static str,
+    nodes: usize,
+    edits_per_node: usize,
+}
+
+impl Scale {
+    fn total_ops(&self) -> usize {
+        // 1 Create + N Edits per node.
+        self.nodes * (1 + self.edits_per_node)
+    }
+}
+
+// 50k ≈ 1k pages × 50 ops (the "sync.md:520" soft ceiling).
+// 100k/250k/500k trace the curve past it.
+// 1M omitted — generation cost crosses ~10 min on an SSD and the
+// curve is already legible at 500k. Add it back when shards land.
+const SCALES: &[Scale] = &[
+    Scale {
+        label: "50k",
+        nodes: 1_000,
+        edits_per_node: 49,
+    },
+    Scale {
+        label: "100k",
+        nodes: 1_000,
+        edits_per_node: 99,
+    },
+    Scale {
+        label: "250k",
+        nodes: 2_000,
+        edits_per_node: 124,
+    },
+    Scale {
+        label: "500k",
+        nodes: 2_000,
+        edits_per_node: 249,
+    },
+];
+
+fn logop(g: &HlcGenerator, op: Op) -> LogOp {
+    let ts = g.next();
+    LogOp {
+        ts,
+        actor: ts.actor,
+        op,
+    }
+}
+
+/// Peak resident set size of this process, in bytes.
+///
+/// `getrusage(RUSAGE_SELF).ru_maxrss` reports bytes on macOS and KB on
+/// Linux — the cfg below normalises both to bytes. Returns 0 on any
+/// syscall failure (the boot-time measurement is still meaningful).
+fn peak_rss_bytes() -> u64 {
+    let mut ru: libc::rusage = unsafe { std::mem::zeroed() };
+    let rc = unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut ru) };
+    if rc != 0 {
+        return 0;
+    }
+    let raw = ru.ru_maxrss.max(0) as u64;
+    #[cfg(target_os = "linux")]
+    {
+        raw * 1024
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        raw
+    }
+}
+
+/// Run one scale row: generate, snapshot, boot both ways, print the row.
+///
+/// Shared by the per-scale tests below so each can run in isolation —
+/// generation is the slow step (~4 ms/op fsync-bound on an SSD), and a
+/// single all-scales test used to time out before reaching the bigger
+/// rows. Per-scale tests give partial data when the runner is killed.
+fn run_scale(scale: Scale) {
+    eprintln!();
+    eprintln!(
+        "boot_scale {} — {} ops, {} nodes. Phase 1 snapshot speeds boot but does NOT reduce RSS.",
+        scale.label,
+        scale.total_ops(),
+        scale.nodes
+    );
+    eprintln!(
+        "{:>6} | {:>9} | {:>9} | {:>10} | {:>10} | {:>10} | {:>10} | {:>9}",
+        "scale", "ops", "gen", "boot_snap", "boot_full", "rss_snap", "rss_full", "snap_size"
+    );
+
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    let ops_dir = root.join(".outl").join("ops");
+    let snapshots_dir = root.join(".outl").join("snapshots");
+    let actor = ActorId::new();
+    let g = HlcGenerator::new(actor);
+
+    let mut ws = Workspace::open_with_storage(
+        actor,
+        Box::new(JsonlStorage::open(ops_dir.clone(), actor).unwrap()),
+        Some(root.to_path_buf()),
+    )
+    .unwrap();
+    // Disable in-band trigger so the snapshot we measure is the one
+    // we write explicitly at the end (otherwise it fires partway
+    // through generation and confuses the measurement).
+    ws.set_snapshot_policy(false, 0);
+
+    // Generation: 1 Create + N Edits per node. The `Edit` carries a
+    // tiny placeholder update — the boot-path cost we're measuring
+    // is structural replay + cache load, which doesn't depend on
+    // real text content. fsync-per-op dominates wall time.
+    let start_gen = Instant::now();
+    for _ in 0..scale.nodes {
+        let n = NodeId::new();
+        ws.apply(logop(
+            &g,
+            Op::Create {
+                node: n,
+                parent: NodeId::root(),
+                position: Fractional::first(),
+            },
+        ))
+        .unwrap();
+        for _ in 0..scale.edits_per_node {
+            ws.apply(logop(
+                &g,
+                Op::Edit {
+                    node: n,
+                    text_op: vec![1, 2, 3, 4],
+                },
+            ))
+            .unwrap();
+        }
+    }
+    let gen_time = start_gen.elapsed();
+
+    // Save snapshot synchronously (the path TUI / desktop / mobile
+    // take on shutdown).
+    ws.save_snapshot().unwrap();
+    let snap_size = std::fs::metadata(snapshots_dir.join(format!("snap-{actor}.bin")))
+        .map(|m| m.len())
+        .unwrap_or(0);
+    let node_count = ws.tree().node_count();
+    drop(ws);
+
+    // Boot path 1: with snapshot present.
+    let start = Instant::now();
+    let ws1 = Workspace::open_with_storage(
+        actor,
+        Box::new(JsonlStorage::open(ops_dir.clone(), actor).unwrap()),
+        Some(root.to_path_buf()),
+    )
+    .unwrap();
+    let boot_snap = start.elapsed();
+    let rss_snap = peak_rss_bytes();
+    let nodes_snap = ws1.tree().node_count();
+    drop(ws1);
+
+    // Boot path 2: snapshot removed, full replay fallback.
+    let _ = std::fs::remove_dir_all(&snapshots_dir);
+    let start = Instant::now();
+    let ws2 = Workspace::open_with_storage(
+        actor,
+        Box::new(JsonlStorage::open(ops_dir.clone(), actor).unwrap()),
+        Some(root.to_path_buf()),
+    )
+    .unwrap();
+    let boot_full = start.elapsed();
+    let rss_full = peak_rss_bytes();
+    let nodes_full = ws2.tree().node_count();
+    drop(ws2);
+
+    // Sanity: every path must land on the same node count, otherwise
+    // the bench is comparing different states.
+    assert_eq!(
+        nodes_snap, nodes_full,
+        "node count diverged between snapshot and full-replay boot at {}",
+        scale.label
+    );
+    assert_eq!(
+        nodes_snap, node_count,
+        "node count drifted between generation and boot at {}",
+        scale.label
+    );
+
+    eprintln!(
+        "{:>6} | {:>9} | {:>6.1?} | {:>10.2?} | {:>10.2?} | {:>6} MB | {:>6} MB | {:>6} KB",
+        scale.label,
+        scale.total_ops(),
+        gen_time,
+        boot_snap,
+        boot_full,
+        rss_snap / 1024 / 1024,
+        rss_full / 1024 / 1024,
+        snap_size / 1024,
+    );
+    eprintln!(
+        "  rss_snap = {} MB, rss_full = {} MB (peak RSS of this process after boot)",
+        rss_snap / 1024 / 1024,
+        rss_full / 1024 / 1024
+    );
+    eprintln!(
+        "  speedup: {:.2}x (saved {:?} per boot)",
+        boot_full.as_secs_f64() / boot_snap.as_secs_f64().max(0.000_001),
+        boot_full.checked_sub(boot_snap).unwrap_or_default()
+    );
+}
+
+#[test]
+#[ignore]
+fn boot_scale_50k() {
+    run_scale(SCALES[0]);
+}
+
+#[test]
+#[ignore]
+fn boot_scale_100k() {
+    run_scale(SCALES[1]);
+}
+
+#[test]
+#[ignore]
+fn boot_scale_250k() {
+    run_scale(SCALES[2]);
+}
+
+#[test]
+#[ignore]
+fn boot_scale_500k() {
+    run_scale(SCALES[3]);
+}

--- a/crates/outl-desktop/src-tauri/src/commands/workspace.rs
+++ b/crates/outl-desktop/src-tauri/src/commands/workspace.rs
@@ -29,7 +29,8 @@ pub(crate) fn set_workspace(
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     let path = PathBuf::from(&path);
-    let workspace = open_workspace_at(state.hlc.actor(), &state.hlc, &path)
+    let lru_cap = outl_config::load().storage.lru_cap;
+    let workspace = open_workspace_at(state.hlc.actor(), &state.hlc, &path, lru_cap)
         .map_err(|e| format!("open workspace at {}: {e}", path.display()))?;
 
     *state.workspace.lock() = Some(workspace);

--- a/crates/outl-desktop/src-tauri/src/settings.rs
+++ b/crates/outl-desktop/src-tauri/src/settings.rs
@@ -99,9 +99,6 @@ impl From<Settings> for Config {
             // `[snapshot]` is core-managed; the desktop doesn't model it.
             // `save` restores it from disk so a hand-set policy survives a
             // settings write (same pattern as `[calendar]` / `[tui]`).
-            // `[snapshot]` is core-managed; the desktop doesn't model it.
-            // `save` restores it from disk so a hand-set policy survives
-            // a settings write (same pattern as `[calendar]` / `[tui]`).
             snapshot: outl_config::SnapshotCfg::default(),
             // `[storage]` is core-managed (LRU cap for JsonlStorage);
             // same restore-on-save pattern as the other core sections.

--- a/crates/outl-desktop/src-tauri/src/settings.rs
+++ b/crates/outl-desktop/src-tauri/src/settings.rs
@@ -99,7 +99,13 @@ impl From<Settings> for Config {
             // `[snapshot]` is core-managed; the desktop doesn't model it.
             // `save` restores it from disk so a hand-set policy survives a
             // settings write (same pattern as `[calendar]` / `[tui]`).
+            // `[snapshot]` is core-managed; the desktop doesn't model it.
+            // `save` restores it from disk so a hand-set policy survives
+            // a settings write (same pattern as `[calendar]` / `[tui]`).
             snapshot: outl_config::SnapshotCfg::default(),
+            // `[storage]` is core-managed (LRU cap for JsonlStorage);
+            // same restore-on-save pattern as the other core sections.
+            storage: outl_config::StorageCfg::default(),
         }
     }
 }

--- a/crates/outl-desktop/src-tauri/src/workspace_open.rs
+++ b/crates/outl-desktop/src-tauri/src/workspace_open.rs
@@ -101,6 +101,7 @@ pub(crate) fn spawn_workspace_opener(
     app: tauri::AppHandle,
 ) {
     let actor = hlc.actor();
+    let lru_cap = outl_config::load().storage.lru_cap;
     thread::spawn(move || {
         if !last_workspace.exists() {
             warn!(
@@ -113,7 +114,7 @@ pub(crate) fn spawn_workspace_opener(
         // resolved; legacy blocks moved under it. **No orphan
         // reconcile here** — that runs after we publish the workspace
         // so the user sees today's journal immediately.
-        let workspace = match open_workspace_at(actor, &hlc, &last_workspace) {
+        let workspace = match open_workspace_at(actor, &hlc, &last_workspace, lru_cap) {
             Ok(w) => w,
             Err(e) => {
                 warn!(

--- a/crates/outl-mobile/src-tauri/src/workspace_open.rs
+++ b/crates/outl-mobile/src-tauri/src/workspace_open.rs
@@ -127,8 +127,13 @@ pub(crate) fn spawn_workspace_opener(
     app: tauri::AppHandle,
 ) {
     let actor = hlc.actor();
+    // Mobile pins the LRU cap to 5k ops (≈ 1 MB of cache) regardless of
+    // what `outl.toml` says. The home page + its backlink set fit
+    // comfortably in 5k ops; the rest is rebuildable from the offset
+    // index. Keeps the long-lived client well under iOS jetsam.
+    let lru_cap = outl_config::load().storage.lru_cap.min(5_000);
     thread::spawn(move || {
-        let mut workspace = match open_workspace_at(actor, &hlc, &storage_root) {
+        let mut workspace = match open_workspace_at(actor, &hlc, &storage_root, lru_cap) {
             Ok(w) => w,
             Err(e) => {
                 warn!("background open failed for {}: {e}", storage_root.display());

--- a/crates/outl-tauri-shared/Cargo.toml
+++ b/crates/outl-tauri-shared/Cargo.toml
@@ -30,6 +30,7 @@ ulid = { workspace = true }
 chrono = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
+walkdir = "2"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/outl-tauri-shared/src/workspace_open.rs
+++ b/crates/outl-tauri-shared/src/workspace_open.rs
@@ -25,10 +25,16 @@ use tracing::{info, warn};
 /// the number of pages; each client decides whether to run
 /// [`reconcile_orphan_md`] inline (mobile) or on a background thread
 /// (desktop).
+///
+/// `lru_cap` is the in-memory op cache bound (RFC #137). `0` keeps the
+/// legacy unbounded behaviour; any positive value sheds cold history
+/// after boot completes (so RSS stays constant regardless of workspace
+/// age).
 pub fn open_workspace_at(
     actor: ActorId,
     hlc: &HlcGenerator,
     path: &Path,
+    lru_cap: usize,
 ) -> anyhow::Result<Workspace> {
     std::fs::create_dir_all(path.join("ops"))?;
     std::fs::create_dir_all(path.join("journals"))?;
@@ -44,6 +50,12 @@ pub fn open_workspace_at(
     if let Err(e) = open_today(&mut workspace, hlc) {
         warn!("could not pre-open today: {e}");
     }
+
+    // Apply the LRU cap AFTER boot so `ops_for_node` (used to rebuild
+    // Yrs `Doc`s) had the full history in RAM. After this point cold
+    // ops are read back from disk on demand via the offset index.
+    workspace.apply_lru_cap(lru_cap);
+
     Ok(workspace)
 }
 

--- a/crates/outl-tauri-shared/src/workspace_open.rs
+++ b/crates/outl-tauri-shared/src/workspace_open.rs
@@ -44,6 +44,19 @@ pub fn open_workspace_at(
     let mut workspace =
         Workspace::open_with_storage(actor, Box::new(storage), Some(path.to_path_buf()))?;
 
+    // Register per-page shards + reboot BEFORE running boot helpers so
+    // the materialized tree is complete (migrated workspaces have an
+    // empty global log — the initial boot sees nothing without shards).
+    outl_actions::storage_scope::register_per_page_storages(
+        &mut workspace,
+        &path.join("ops"),
+        actor,
+        path,
+    );
+    if workspace.has_page_storages() {
+        workspace.reboot_with_all_storages()?;
+    }
+
     if let Err(e) = migrate_legacy_into_today(&mut workspace, hlc) {
         warn!("legacy migration: {e}");
     }
@@ -51,22 +64,10 @@ pub fn open_workspace_at(
         warn!("could not pre-open today: {e}");
     }
 
-    // Apply the LRU cap AFTER boot so `ops_for_node` (used to rebuild
-    // Yrs `Doc`s) had the full history in RAM. After this point cold
-    // ops are read back from disk on demand via the offset index.
+    // Shed cold history AFTER boot + helpers finish. Boot needs every
+    // op in RAM to rebuild Yrs `Doc`s; afterwards cold ops come back
+    // from disk via the offset index.
     workspace.apply_lru_cap(lru_cap);
-
-    outl_actions::storage_scope::register_per_page_storages(
-        &mut workspace,
-        &path.join("ops"),
-        actor,
-        lru_cap,
-        path,
-    );
-    if workspace.has_page_storages() {
-        workspace.reboot_with_all_storages()?;
-        workspace.apply_lru_cap(lru_cap);
-    }
 
     Ok(workspace)
 }

--- a/crates/outl-tauri-shared/src/workspace_open.rs
+++ b/crates/outl-tauri-shared/src/workspace_open.rs
@@ -56,6 +56,18 @@ pub fn open_workspace_at(
     // ops are read back from disk on demand via the offset index.
     workspace.apply_lru_cap(lru_cap);
 
+    outl_actions::storage_scope::register_per_page_storages(
+        &mut workspace,
+        &path.join("ops"),
+        actor,
+        lru_cap,
+        path,
+    );
+    if workspace.has_page_storages() {
+        workspace.reboot_with_all_storages()?;
+        workspace.apply_lru_cap(lru_cap);
+    }
+
     Ok(workspace)
 }
 

--- a/crates/outl-tui/src/runtime.rs
+++ b/crates/outl-tui/src/runtime.rs
@@ -350,11 +350,15 @@ fn open_workspace(
             .with_context(|| format!("opening jsonl storage at {}", ops_dir.display()))?,
     );
     let mut ws = Workspace::open_with_storage(actor, storage, Some(root.to_path_buf()))?;
-    // Apply the LRU cap AFTER boot finishes re-materialising Yrs
-    // `Doc`s via `ops_for_node`. Boot needs every op in RAM; the
-    // long-running TUI then sheds cold history to keep RSS constant
-    // regardless of how much the workspace has accumulated. RFC #137.
-    ws.apply_lru_cap(outl_config::load().storage.lru_cap);
+    let lru_cap = outl_config::load().storage.lru_cap;
+    ws.apply_lru_cap(lru_cap);
+    outl_actions::storage_scope::register_per_page_storages(
+        &mut ws, &ops_dir, actor, lru_cap, root,
+    );
+    if ws.has_page_storages() {
+        ws.reboot_with_all_storages()?;
+        ws.apply_lru_cap(lru_cap);
+    }
     Ok((ws, actor, cfg, lock, actor_lock))
 }
 

--- a/crates/outl-tui/src/runtime.rs
+++ b/crates/outl-tui/src/runtime.rs
@@ -349,7 +349,12 @@ fn open_workspace(
         JsonlStorage::open(ops_dir.clone(), actor)
             .with_context(|| format!("opening jsonl storage at {}", ops_dir.display()))?,
     );
-    let ws = Workspace::open_with_storage(actor, storage, Some(root.to_path_buf()))?;
+    let mut ws = Workspace::open_with_storage(actor, storage, Some(root.to_path_buf()))?;
+    // Apply the LRU cap AFTER boot finishes re-materialising Yrs
+    // `Doc`s via `ops_for_node`. Boot needs every op in RAM; the
+    // long-running TUI then sheds cold history to keep RSS constant
+    // regardless of how much the workspace has accumulated. RFC #137.
+    ws.apply_lru_cap(outl_config::load().storage.lru_cap);
     Ok((ws, actor, cfg, lock, actor_lock))
 }
 

--- a/crates/outl-tui/src/runtime.rs
+++ b/crates/outl-tui/src/runtime.rs
@@ -351,14 +351,14 @@ fn open_workspace(
     );
     let mut ws = Workspace::open_with_storage(actor, storage, Some(root.to_path_buf()))?;
     let lru_cap = outl_config::load().storage.lru_cap;
-    ws.apply_lru_cap(lru_cap);
-    outl_actions::storage_scope::register_per_page_storages(
-        &mut ws, &ops_dir, actor, lru_cap, root,
-    );
+    // Register per-page shards BEFORE applying the LRU cap. Shards
+    // open unbounded (cap = 0) so the reboot replays the full history.
+    outl_actions::storage_scope::register_per_page_storages(&mut ws, &ops_dir, actor, root);
     if ws.has_page_storages() {
         ws.reboot_with_all_storages()?;
-        ws.apply_lru_cap(lru_cap);
     }
+    // Shed cold history AFTER the materialized tree is complete.
+    ws.apply_lru_cap(lru_cap);
     Ok((ws, actor, cfg, lock, actor_lock))
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -96,6 +96,19 @@ See [theming.md](theming.md) for the look of each.
 | `transport` | `"iroh"` \| `"file"` | `"iroh"` | every client (TUI / desktop / mobile / MCP) | Which transport ships each device's `ops-<actor>.jsonl` to the others. `"iroh"` opens direct P2P QUIC connections to paired peers; `"file"` is the opt-out that relies on iCloud Drive / a shared filesystem. Missing `[sync]` defaults to iroh (P2P is the primary sync). |
 | `relay_url` | string (URL) | _empty_ | TUI peer-sync wiring | iroh relay used for NAT traversal + fallback. Empty means iroh's n0 public relays. Ignored when `transport = "file"`. See [relay.md](relay.md). |
 
+#### `[snapshot]`
+
+| Field | Type | Default | Read by | Effect |
+|---|---|---|---|---|
+| `enabled` | bool | `true` | TUI / desktop / mobile | Master switch for materialised-state snapshots on disk. The CLI ignores this (always off — its work is ephemeral). When `true`, `Workspace::apply` writes a snapshot every `op_threshold` ops so the next boot skips the full op-log replay. |
+| `op_threshold` | integer (ops) | `10_000` | TUI / desktop / mobile | How many ops between snapshot writes. Lower = faster boot, more disk churn; higher = less churn, slower boot. |
+
+#### `[storage]`
+
+| Field | Type | Default | Read by | Effect |
+|---|---|---|---|---|
+| `lru_cap` | integer (ops) | `20_000` | TUI / desktop / mobile | Maximum number of ops held in `JsonlStorage`'s in-memory cache. `0` keeps the legacy unbounded behaviour (every op resident forever). Any positive value caps the cache so RSS stays roughly constant regardless of workspace history; cold ops stay addressable through the per-actor offset index (`ops-<actor>.idx`). Mobile pins this to `min(lru_cap, 5_000)` to stay well under iOS jetsam. See [RFC #137](https://github.com/avelino/outl/issues/137). |
+
 #### `[tui]`
 
 | Field | Type | Default | Read by | Effect |

--- a/docs/rfcs/0137-storage-scale.md
+++ b/docs/rfcs/0137-storage-scale.md
@@ -53,12 +53,16 @@ Mobile hits the wall first (iOS jetsam kills above ~500 MB).
 
 Replace `Vec<LogOp>` with a bounded LRU (cap configurable in
 `outl.toml` via `[storage] lru_cap`, default 20k ops desktop, 5k on
-mobile). Add a per-actor offset index `(actor, hlc) → file offset` so
-cold ops stay addressable without buffering the whole log.
+mobile). Add a per-actor offset index `(actor, hlc) → file offset` and
+a per-node secondary index `NodeId → Vec<(Hlc, offset)>` so cold ops
+stay addressable without buffering the whole log.
 `Workspace::apply_lru_cap(cap)` is called by every long-lived client
 AFTER boot finishes re-materialising Yrs `Doc`s via `ops_for_node` —
 boot needs every op in RAM, the long-running client sheds cold history
 afterwards.
+
+Cold reads use `File + seek + read_line` (not mmap — see
+"Decision: mmap deferred" below).
 
 Result: RSS ≈ constant (LRU cap + index + mmap window), regardless of
 history. No `.jsonl` format change. No migration. No client breaks.
@@ -70,16 +74,71 @@ history. No `.jsonl` format change. No migration. No client breaks.
 | 1 | `perf(core): per-actor offset index sidecar` | shipped — `crates/outl-core/src/storage/index.rs` (new), `JsonlStorage::reload` populates + persists `ops-<actor>.idx` |
 | 2 | `perf(core): replace Vec<LogOp> cache with bounded LRU` | shipped — `cache: RwLock<LruCache<Hlc, LogOp>>`, `JsonlStorage::open_with_cap`, `[storage] lru_cap` in `outl-config` |
 | 3 | `perf(core): Workspace::apply_lru_cap shrinks cache post-boot` | shipped — `Storage::resize_cache` (default no-op), `Workspace::apply_lru_cap`, wired in TUI + desktop + mobile |
+| 3.5 | `perf(core): per-node secondary index + cold ops_for_node` | shipped — `crates/outl-core/src/storage/node_index.rs` (new), `ops_for_node` falls through to per-node index + disk read when LRU is empty, regression test `ops_for_node_survives_lru_eviction` |
 
 **Milestone verification**:
 - `cargo test -p outl-core` passes (CRDT invariants intact, 100%
   coverage on the four critical functions preserved).
 - New unit tests cover the LRU cap (`bounded_lru_evicts_old_ops`,
-  `reload_with_bounded_lru_keeps_cap`) and the offset index
-  (roundtrip, missing/corrupt file, rebuild from jsonl).
+  `reload_with_bounded_lru_keeps_cap`, `ops_for_node_survives_lru_eviction`)
+  and both indexes (HLC roundtrip, missing/corrupt file, rebuild from
+  jsonl; per-node roundtrip, rebuild, actor routing).
 - `boot_scale_bench.rs` is the long-running scale measurement
   (`cargo test -p outl-core --release --test boot_scale_bench
   boot_scale_100k -- --ignored --nocapture`).
+
+## Decision: mmap deferred
+
+The original Phase A sketch mentioned mmap (`memmap2`) for the cold
+read path. After analysis we kept `File + seek + read_line` instead.
+This section records why so the next person doesn't re-litigate it
+without new evidence.
+
+**Why mmap was tempting**
+
+- Cold `ops_for_node` would be zero-syscall (pointer dereference into
+  the kernel page cache) instead of one `lseek` + one `read` per op.
+- Mature tool — lmdb, sled, sqlite, redis all use it. Yrs (which we
+  already ship) uses it internally.
+- Phase B per-page shards would multiply file handles; mmap would let
+  the kernel manage the working set instead of us holding N `File`s.
+
+**Why we declined**
+
+- `outl-core` is `#![forbid(unsafe_code)]` (`src/lib.rs:12`).
+  `Mmap::map` is `unsafe`. Lifting `forbid` to `deny` + a local
+  `#[allow]` was the only path, and `forbid` is a project value, not a
+  style choice. Changing it is a philosophical decision, not a
+  technical one.
+- **SIGBUS.** A file that disappears under a mmap (iCloud lazy
+  download, manual truncation, FS corruption) takes the process down.
+  Recovery needs a signal handler (more unsafe) or pre-read validation.
+  `File::open` returns `Err` cleanly.
+- **Mmap counts toward RSS.** On iOS, mapped pages show up in the
+  jetsam accounting. We'd be undoing the very RSS bound Phase A
+  delivers.
+- **Concurrent appender race.** Two processes sharing `ops/` (TUI +
+  desktop on the same Mac) can grow the file while another holds a
+  stale mmap. Reading past the old end is undefined.
+- **Windows divergence.** `CreateFileMapping` + `MapViewOfFile` differ
+  from POSIX mmap in locking and resize semantics. Tauri 2 doesn't
+  abstract this at our layer.
+- **Marginal gain at current scale.** Cold `ops_for_node` is O(K)
+  where K = Edit ops on one block (typically < 100). 100 syscalls ×
+  ~10 µs ≈ 1 ms. Imperceptible. The offset bug (every entry returning
+  offset 0 because `O_APPEND` doesn't update `stream_position`) was
+  the real correctness issue and is fixed.
+- **Phase B kills the root cause.** Per-page shards make every jsonl
+  small by construction. mmap becomes overkill the moment #37 lands.
+
+**When to re-open**
+
+- Real-world workspaces pass 500k ops AND Phase B hasn't landed in
+  six months.
+- A real flamegraph (not a synthetic bench) shows `ops_for_node` in
+  the top 5 hot paths.
+- Someone proposes ChronDB (#1) — a new format warrants rethinking
+  the whole storage layer, not just the read path.
 
 ## Phase B — constant boot/sync (#37 / Part 2 of `sync.md`) — PENDING
 
@@ -113,6 +172,9 @@ paired device. Tracked separately.
 - **LRU cap default for mobile** — resolved: 5k (mobile pins
   `min(cfg.lru_cap, 5_000)` in `outl-mobile/src-tauri/src/workspace_open.rs`);
   desktop default 20k.
+- **mmap cold-read path** — resolved for Phase A: declined (see
+  "Decision: mmap deferred"). Reopen only if real-world flamegraphs
+  show `ops_for_node` in the hot path AND Phase B hasn't landed.
 - **Index persistence** — resolved: sidecar `ops-<actor>.idx` (Phase A).
 - **mmap strategy** — deferred to follow-up; Phase A reads cold ops via
   `File + seek + parse`, which is correct but slower than mmap. Land

--- a/docs/rfcs/0137-storage-scale.md
+++ b/docs/rfcs/0137-storage-scale.md
@@ -1,0 +1,153 @@
+# RFC 0137 — Storage scale: constant RSS, then constant boot/sync
+
+**Status**: Phase A shipped; Phase B pending
+**Issue**: [#137](https://github.com/avelino/outl/issues/137)
+**Branch**: `feat/storage-scale-rfc-137`
+**Tracking**: 11 PRs across two phases (A done, B pending)
+
+## Why
+
+`JsonlStorage` keeps every op ever written in resident memory. The cache
+field was `RwLock<Vec<LogOp>>` at [`storage/jsonl.rs:42`][src-cache];
+`reload()` reads every `ops-<actor>.jsonl` line-by-line into that `Vec`
+([`storage/jsonl.rs:92-130`][src-reload]); `boot_from_full_replay`
+([`workspace.rs:230-269`][src-full]) loads all of them through `OpLog`
+on top. Phase 1 snapshot (#128) speeds up boot but doesn't reduce RSS —
+the storage cache still mirrors everything.
+
+Measured on M-series Mac, release build, via `boot_scale_bench.rs`:
+
+| ops    | boot_snap | boot_full | rss_snap | rss_full | source      |
+|--------|-----------|-----------|----------|----------|-------------|
+| 50k    | 27 ms     | 31 ms     | 37 MB    | 54 MB    | measured    |
+| 100k   | 55 ms     | 64 ms     | 66 MB    | 98 MB    | measured    |
+| 250k   | ~140 ms   | ~160 ms   | ~160 MB  | ~230 MB  | extrapolated |
+| 500k   | ~280 ms   | ~320 ms   | ~300 MB  | ~470 MB  | extrapolated |
+| 1M     | ~550 ms   | ~640 ms   | ~600 MB  | ~900 MB  | extrapolated |
+
+Per-op cost: ~0.55 µs boot, ~590 bytes RSS. Both linear.
+
+**Boot is not the wall.** Even at 1M ops, 550 ms is acceptable.
+**RSS is the wall.** Each `Op::Edit` costs ~590 bytes of resident memory
+forever — even after a snapshot, even after the block was deleted.
+Mobile hits the wall first (iOS jetsam kills above ~500 MB).
+
+## Decisions (locked)
+
+1. **LRU + mmap first (Phase A), per-page shards second (Phase B).**
+   Phase A bounds RSS at the storage layer without a format break.
+   Phase B bounds boot and sync at the workspace layer. Both are needed
+   because a single page (10-year journal) can still grow without bound.
+
+2. **`PageScope` default = `PerPage` in new workspaces** (Phase B).
+   Existing workspaces stay on `Global` until migrated. Migration CLI
+   is opt-in.
+
+3. **Include iroh-blobs snapshot transfer** as PR #9 in Phase B
+   (closes Phase 2 of #128). Reduces wire bytes for fresh peer pairing.
+
+4. **Single long-running branch** `feat/storage-scale-rfc-137`, merged
+   to `main` as one PR (squash). Each sub-PR is a logical commit.
+
+## Phase A — constant RSS (SHIPPED)
+
+Replace `Vec<LogOp>` with a bounded LRU (cap configurable in
+`outl.toml` via `[storage] lru_cap`, default 20k ops desktop, 5k on
+mobile). Add a per-actor offset index `(actor, hlc) → file offset` so
+cold ops stay addressable without buffering the whole log.
+`Workspace::apply_lru_cap(cap)` is called by every long-lived client
+AFTER boot finishes re-materialising Yrs `Doc`s via `ops_for_node` —
+boot needs every op in RAM, the long-running client sheds cold history
+afterwards.
+
+Result: RSS ≈ constant (LRU cap + index + mmap window), regardless of
+history. No `.jsonl` format change. No migration. No client breaks.
+
+### Phase A PRs (DONE)
+
+| # | Title | Status |
+|---|-------|--------|
+| 1 | `perf(core): per-actor offset index sidecar` | shipped — `crates/outl-core/src/storage/index.rs` (new), `JsonlStorage::reload` populates + persists `ops-<actor>.idx` |
+| 2 | `perf(core): replace Vec<LogOp> cache with bounded LRU` | shipped — `cache: RwLock<LruCache<Hlc, LogOp>>`, `JsonlStorage::open_with_cap`, `[storage] lru_cap` in `outl-config` |
+| 3 | `perf(core): Workspace::apply_lru_cap shrinks cache post-boot` | shipped — `Storage::resize_cache` (default no-op), `Workspace::apply_lru_cap`, wired in TUI + desktop + mobile |
+
+**Milestone verification**:
+- `cargo test -p outl-core` passes (CRDT invariants intact, 100%
+  coverage on the four critical functions preserved).
+- New unit tests cover the LRU cap (`bounded_lru_evicts_old_ops`,
+  `reload_with_bounded_lru_keeps_cap`) and the offset index
+  (roundtrip, missing/corrupt file, rebuild from jsonl).
+- `boot_scale_bench.rs` is the long-running scale measurement
+  (`cargo test -p outl-core --release --test boot_scale_bench
+  boot_scale_100k -- --ignored --nocapture`).
+
+## Phase B — constant boot/sync (#37 / Part 2 of `sync.md`) — PENDING
+
+`PageScope`, per-page op log shards, `migrate-to-per-page-ops`, four
+clients update. Builds on Phase A — each page-scope reuses the LRU +
+mmap storage layer.
+
+This is a 1-2 month refactor with a format break and migration CLI.
+It cannot be done blind in a single session — the op log format is
+the sync correctness invariant, and a bad migration corrupts every
+paired device. Tracked separately.
+
+### Phase B PRs (PENDING)
+
+| # | Title | Touches |
+|---|-------|---------|
+| 5 | `refactor(core): PageScope on Storage trait (default Global)` | `storage/mod.rs`, `storage/jsonl.rs`, `workspace.rs` (back-compat: `Global` matches current behaviour byte-for-byte) |
+| 6 | `feat(core): per-page op log shards for new workspaces` | `storage/jsonl.rs` (write path), `outl-cli init` (default scope = `PerPage`) |
+| 7 | `feat(cli): migrate-to-per-page-ops command` | `outl-cli/src/cmd/migrate_to_per_page_ops.rs`, idempotent + `.v0.bak` backup |
+| 8 | `refactor: clients use page scopes` | TUI, mobile, desktop, CLI — `open_or_create` dispatches by scope, boot loads page lazily on navigation |
+| 9 | `feat(sync): iroh-blobs snapshot transfer (closes #128 phase 2)` | `outl-sync-iroh` — ship snapshot binary then delta ops on fresh pair |
+
+**Phase B prerequisites before landing**:
+1. Workspace backup to test the migration against (a real 3-year vault).
+2. Wire-format review — per-page shards change what iroh ships.
+3. `crdt-invariant-checker` agent pass on any change to `apply_op`.
+4. `markdown-roundtrip-tester` agent pass on the migration output.
+
+## Open questions (Phase B)
+
+- **LRU cap default for mobile** — resolved: 5k (mobile pins
+  `min(cfg.lru_cap, 5_000)` in `outl-mobile/src-tauri/src/workspace_open.rs`);
+  desktop default 20k.
+- **Index persistence** — resolved: sidecar `ops-<actor>.idx` (Phase A).
+- **mmap strategy** — deferred to follow-up; Phase A reads cold ops via
+  `File + seek + parse`, which is correct but slower than mmap. Land
+  mmap when a profile shows the cold-read path is hot.
+- **Snapshot interaction** — resolved: `apply_lru_cap` runs AFTER
+  `ops_for_node` finishes re-materialising Yrs `Doc`s at boot (see
+  `Workspace::apply_lru_cap`).
+- **Throughput cost of cold reads** — pending; needs a micro-bench
+  before mmap lands. Today `ops_for_node` returns only the resident
+  tail, which is what boot-from-snapshot needs (delta-edited nodes
+  are still warm).
+
+## Non-goals (explicit)
+
+- **Op log compaction** (#110). Orthogonal. The LRU doesn't delete ops
+  from disk; compaction is a separate horizon (`Undo horizon`).
+- **Block text CRDT replacement**. Yrs stays. The two-tier `Doc` cache
+  (#108's fix) stays.
+- **ChronDB backend** (#1). Out of scope. The `Storage` trait changes
+  planned for Phase B (PageScope) are forward-compatible with ChronDB.
+
+## References
+
+- Issue: <https://github.com/avelino/outl/issues/137>
+- Companion: `docs/sync.md` Part 2 (the design Phase B implements)
+- Related issues: #37, #128, #110, #109, #108
+- Bench: `crates/outl-core/tests/boot_scale_bench.rs`
+- Phase A code:
+  - `crates/outl-core/src/storage/index.rs` (offset index sidecar)
+  - `crates/outl-core/src/storage/jsonl.rs` (LRU + cap + index wiring)
+  - `crates/outl-core/src/storage/mod.rs` (`Storage::resize_cache`)
+  - `crates/outl-core/src/workspace.rs` (`Workspace::apply_lru_cap`)
+  - `crates/outl-config/src/schema.rs` (`[storage] lru_cap`)
+
+[src-cache]: https://github.com/avelino/outl/blob/main/crates/outl-core/src/storage/jsonl.rs#L42
+[src-reload]: https://github.com/avelino/outl/blob/main/crates/outl-core/src/storage/jsonl.rs#L92
+[src-full]: https://github.com/avelino/outl/blob/main/crates/outl-core/src/workspace.rs#L230
+

--- a/docs/rfcs/0137-storage-scale.md
+++ b/docs/rfcs/0137-storage-scale.md
@@ -64,7 +64,7 @@ afterwards.
 Cold reads use `File + seek + read_line` (not mmap — see
 "Decision: mmap deferred" below).
 
-Result: RSS ≈ constant (LRU cap + index + mmap window), regardless of
+Result: RSS ≈ constant (LRU cap + index), regardless of
 history. No `.jsonl` format change. No migration. No client breaks.
 
 ### Phase A PRs (DONE)

--- a/docs/shared-primitives.md
+++ b/docs/shared-primitives.md
@@ -24,6 +24,7 @@ For the reuse-first rule (why this matters, past drift incidents, what to do whe
 | Build a Yrs text-replace update payload for an op | `outl_core::Workspace::build_text_replace_update` | `crates/outl-core/src/workspace.rs` |
 | Generate HLC timestamps with actor tiebreak (required for every op) | `outl_core::HlcGenerator::new` / `next` / `observe` | `crates/outl-core/src/hlc.rs` |
 | Wrap an `Op` into a `LogOp` (timestamp + actor) for `apply` | `outl_core::Op` + `outl_core::LogOp` | `crates/outl-core/src/op.rs` |
+| Extract the `NodeId` an op targets | `outl_core::op::op_node(&Op) -> Option<NodeId>` | `crates/outl-core/src/op.rs` |
 | Sentinel node ids (`root`, `trash`) | `outl_core::NodeId::root()` / `trash()` | `crates/outl-core/src/id.rs` |
 | Per-device identity for ops | `outl_core::ActorId` | `crates/outl-core/src/id.rs` |
 | Stable, shared workspace identity (read/generate, persist, pairing-adoption) — the gossip-topic key, NOT the path | `outl_core::WorkspaceId::read_or_create` / `write` / `from_raw` (errors: `outl_core::WorkspaceIdError`) | `crates/outl-core/src/workspace_id.rs` |


### PR DESCRIPTION
Measures `Workspace::open_with_storage` time AND peak resident memory at
four op-log scales, with and without a Phase 1 snapshot.
Validates the diagnosis behind RFC #137: snapshot Phase 1 (#128) speeds
up boot but does not reduce RSS, `JsonlStorage.cache` holds every op
ever written.

Phase A (constant RSS) and Phase B scaffolding (per-page sharding) are
both included in this branch.
The LRU + per-actor offset index + per-node secondary index bound RAM
regardless of history size.
Per-page storage layout (`PageScope::PerPage`, `init --scope=per-page`,
`migrate-to-per-page-ops`) lets boot/sync be proportional to the active
page rather than the whole workspace.

Run the bench with:

```bash
cargo test -p outl-core --release --test boot_scale_bench   boot_scale_50k -- --ignored --nocapture
```

One test per scale so partial runs are usable.
Generation is the slow step (fsync per op), so 250k/500k rows can be
run individually.

Initial measurements (M-series Mac, release):

| scale | ops    | boot_snap | boot_full | rss_snap | rss_full |
|-------|--------|-----------|-----------|----------|----------|
| 50k   | 50000  | 27 ms     | 31 ms     | 37 MB    | 54 MB    |
| 100k  | 100000 | 55 ms     | 64 ms     | 66 MB    | 98 MB    |

Per-op cost: ~0.55 µs boot, ~590 bytes RSS.
Both linear.

Also fixes a duplicate-op bug found during review: `Workspace::apply`
called `storage.append_op` unconditionally even when `tree.apply_op`
had already deduped the op via `contains_ts`.
Re-delivered ops from sync replay wrote duplicate lines to the `.jsonl`.

fixed: #137
refs: #128
refs: #37
refs: #110