### PR TITLE
feat: query code blocks, plugin SDK API, and block ID stability fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,16 +64,9 @@ jobs:
       - name: Install toolchain (clippy)
         run: rustup show
       - name: Cache cargo registry & target
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-clippy-
-            ${{ runner.os }}-cargo-
+          prefix-key: "v0.8-rust"
       - name: cargo clippy
         # outl-mobile, outl-desktop and outl-tauri-shared pull Tauri
         # deps (glib-sys, gobject-sys, webkit2gtk) that need system
@@ -95,16 +88,9 @@ jobs:
       - name: Install toolchain
         run: rustup show
       - name: Cache cargo registry & target
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-test-
-            ${{ runner.os }}-cargo-
+          prefix-key: "v0.8-rust"
       - name: cargo test
         # outl-mobile, outl-desktop and outl-tauri-shared depend on
         # Tauri's macOS/iOS-specific surface and on system GTK libs we
@@ -162,19 +148,8 @@ jobs:
       - name: Install toolchain
         run: rustup show
       - name: Cache cargo registry & target
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-sync-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-sync-
-            ${{ runner.os }}-cargo-
+          prefix-key: "v0.8-rust"
       - name: cargo test (sync convergence)
-        # `--all-targets` pulls in the `tests/` integration + property
-        # suites for both crates, not just the unit tests. These two
-        # crates own the op-log → CRDT → convergence path that every
-        # device relies on.
         run: cargo test -p outl-core -p outl-sync-iroh --all-targets

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,6 @@ Don't unilaterally pivot.
 
 Don't add code for these unless explicitly asked:
 
-- Query DSL (`{{query: ...}}`)
 - Plugin system (`rhai`)
 - `ChronDbStorage` backend (issue #1, tracked publicly)
 - Android mobile build (only iOS today; Android needs an `NSMetadataQuery` equivalent)

--- a/crates/outl-desktop/src-tauri/src/commands/exec.rs
+++ b/crates/outl-desktop/src-tauri/src/commands/exec.rs
@@ -7,7 +7,10 @@
 use tauri::State;
 
 use crate::state::AppState;
-use outl_tauri_shared::commands::exec::{self as shared, RunCodeBlockReply};
+use outl_tauri_shared::commands::exec::{
+    self as shared, AutoRunReply, EmbedContent, RunCodeBlockReply,
+};
+use std::collections::HashMap;
 
 #[tauri::command]
 pub(crate) fn run_code_block(
@@ -16,4 +19,20 @@ pub(crate) fn run_code_block(
     state: State<'_, AppState>,
 ) -> Result<RunCodeBlockReply, String> {
     shared::run_code_block(state.inner(), page_id, block_id)
+}
+
+#[tauri::command]
+pub(crate) fn run_auto_run_blocks(
+    page_id: String,
+    state: State<'_, AppState>,
+) -> Result<AutoRunReply, String> {
+    shared::run_auto_run_blocks(state.inner(), page_id)
+}
+
+#[tauri::command]
+pub(crate) fn resolve_embeds(
+    handles: Vec<String>,
+    state: State<'_, AppState>,
+) -> Result<HashMap<String, EmbedContent>, String> {
+    shared::resolve_embeds(state.inner(), handles)
 }

--- a/crates/outl-desktop/src-tauri/src/lib.rs
+++ b/crates/outl-desktop/src-tauri/src/lib.rs
@@ -61,9 +61,10 @@ use crate::commands::{
     outl_peer_status, outl_sync_now, paste_block_after, paste_markdown_at, paste_plain_at,
     plugin_install_official, plugin_keybindings, plugin_list, plugin_registry_list, plugin_run,
     plugin_set_enabled, plugin_sync_hooks, plugin_toolbar, plugin_transform, plugin_transformers,
-    plugin_uninstall, previous_day, redo_page, reload_workspace, resolve_ref, run_code_block,
-    search_blocks, search_pages, search_persons, set_block_collapsed, set_workspace,
-    today_slug_cmd, toggle_quote, toggle_todo, undo_page, update_settings, workspace_stats,
+    plugin_uninstall, previous_day, redo_page, reload_workspace, resolve_embeds, resolve_ref,
+    run_auto_run_blocks, run_code_block, search_blocks, search_pages, search_persons,
+    set_block_collapsed, set_workspace, today_slug_cmd, toggle_quote, toggle_todo, undo_page,
+    update_settings, workspace_stats,
 };
 use crate::plugin_service::spawn_plugin_service;
 use crate::state::AppState;
@@ -325,6 +326,8 @@ pub fn run() {
             redo_page,
             // Code execution
             run_code_block,
+            run_auto_run_blocks,
+            resolve_embeds,
             // Peer / device management
             outl_peer_list,
             outl_peer_remove,

--- a/crates/outl-desktop/src/components/BlockRow.tsx
+++ b/crates/outl-desktop/src/components/BlockRow.tsx
@@ -941,6 +941,7 @@ export function BlockRow(props: {
                                   onRefClick={props.cb.onRefClick}
                                   onTagClick={props.cb.onTagClick}
                                   onLinkClick={props.cb.onLinkClick}
+                                  embeds={appState.embeds}
                                 />
                               </Show>
                             </div>

--- a/crates/outl-desktop/src/components/OutlineView.tsx
+++ b/crates/outl-desktop/src/components/OutlineView.tsx
@@ -111,36 +111,40 @@ export function OutlineView() {
       backlinks: view.backlinks,
       parseWarnings: view.warnings ?? [],
     });
-    // Auto-run query blocks after page load / commit.
+    // Auto-run query blocks after page load / commit, then re-resolve
+    // embeds with the updated outline.
     void runAutoRunBlocks(view.page.id)
       .then((reply) => {
         if (reply.ran > 0) {
+          const updated = reply.view;
           setAppState({
-            page: reply.view.page,
-            outline: reply.view.outline,
-            backlinks: reply.view.backlinks,
-            parseWarnings: reply.view.warnings ?? [],
+            page: updated.page,
+            outline: updated.outline,
+            backlinks: updated.backlinks,
+            parseWarnings: updated.warnings ?? [],
           });
+          void resolvePageEmbeds(updated.outline);
         }
       })
       .catch(() => {});
-    // Resolve embeds on the page so `!((blk-…))` blocks expand.
+    // Resolve embeds on the initial page view.
     void resolvePageEmbeds(view.outline);
   }
 
-  /** Collect all embed handles from the outline and batch-resolve them. */
+  /** Collect unique embed handles from the outline and batch-resolve. */
   function resolvePageEmbeds(outline: import("@outl/shared/api/types").BlockNode[]) {
-    const handles: string[] = [];
+    const handleSet = new Set<string>();
     const walk = (nodes: import("@outl/shared/api/types").BlockNode[]) => {
       for (const n of nodes) {
         for (const tok of n.tokens) {
-          if (tok.kind === "embed" && tok.value) handles.push(tok.value);
+          if (tok.kind === "embed" && tok.value) handleSet.add(tok.value);
         }
         if (n.children.length > 0) walk(n.children);
       }
     };
     walk(outline);
-    if (handles.length === 0) return;
+    if (handleSet.size === 0) return;
+    const handles = [...handleSet];
     void resolveEmbeds(handles)
       .then((map) => {
         setAppState("embeds", map);

--- a/crates/outl-desktop/src/components/OutlineView.tsx
+++ b/crates/outl-desktop/src/components/OutlineView.tsx
@@ -12,6 +12,8 @@ import {
   pastePlain,
   pluginRun,
   pluginSyncHooks,
+  resolveEmbeds,
+  runAutoRunBlocks,
   runCodeBlock,
   setBlockCollapsed,
   toggleTodo,
@@ -109,6 +111,41 @@ export function OutlineView() {
       backlinks: view.backlinks,
       parseWarnings: view.warnings ?? [],
     });
+    // Auto-run query blocks after page load / commit.
+    void runAutoRunBlocks(view.page.id)
+      .then((reply) => {
+        if (reply.ran > 0) {
+          setAppState({
+            page: reply.view.page,
+            outline: reply.view.outline,
+            backlinks: reply.view.backlinks,
+            parseWarnings: reply.view.warnings ?? [],
+          });
+        }
+      })
+      .catch(() => {});
+    // Resolve embeds on the page so `!((blk-…))` blocks expand.
+    void resolvePageEmbeds(view.outline);
+  }
+
+  /** Collect all embed handles from the outline and batch-resolve them. */
+  function resolvePageEmbeds(outline: import("@outl/shared/api/types").BlockNode[]) {
+    const handles: string[] = [];
+    const walk = (nodes: import("@outl/shared/api/types").BlockNode[]) => {
+      for (const n of nodes) {
+        for (const tok of n.tokens) {
+          if (tok.kind === "embed" && tok.value) handles.push(tok.value);
+        }
+        if (n.children.length > 0) walk(n.children);
+      }
+    };
+    walk(outline);
+    if (handles.length === 0) return;
+    void resolveEmbeds(handles)
+      .then((map) => {
+        setAppState("embeds", map);
+      })
+      .catch(() => {});
   }
 
   /**

--- a/crates/outl-desktop/src/lib/store.ts
+++ b/crates/outl-desktop/src/lib/store.ts
@@ -42,6 +42,8 @@ export interface AppStateShape {
    * a clean file.
    */
   parseWarnings: ParseWarning[];
+  /** Resolved embed content for `!((blk-…))` tokens on the current page. */
+  embeds: Record<string, { handle: string; text: string; page_slug: string; status: string | null }>;
   /** DFS path of the selected block, or `null` for no selection. */
   selectedPath: number[] | null;
   /**
@@ -191,6 +193,7 @@ const [state, setState] = createStore<AppStateShape>({
   outline: [],
   backlinks: [],
   parseWarnings: [],
+  embeds: {},
   selectedPath: null,
   selectedBlockId: null,
   selectedBacklinkBlockId: null,

--- a/crates/outl-exec/CLAUDE.md
+++ b/crates/outl-exec/CLAUDE.md
@@ -1,0 +1,115 @@
+# CLAUDE.md — outl-exec
+
+Context for Claude Code sessions working in this crate.
+Read this before making any change.
+
+## What this crate is
+
+Code-block execution engine for outl: takes a fenced markdown block (` ```lisp `, ` ```python `, ...) and writes the result back into the page as a child subblock — idempotent on re-run.
+
+The crate is intentionally tiny and modular:
+
+- **`runtime::Runtime`** — the trait you implement to add a new language.
+  Two required methods: `language()` (the fence info-string) and `execute()`.
+  One optional override: `auto_run()` (default `false`).
+- **`runtime::ExecContext`** — workspace root, stdin, timeout, mem limit.
+- **`runtime::ExecOutput`** — stdout, stderr, duration, exit status, and `format: OutputFormat`.
+- **`runtime::OutputFormat`** — `Text` (default: result subblock as `> **result:** …`) or `Embeds` (result subblock with one child bullet per stdout line, rendered as embeds).
+- **`registry::RuntimeRegistry`** — resolves a fence info-string to the concrete `Runtime`.
+- **`sandbox`** — cross-platform timeout helper.
+- **`result_block`** — pure functions that find / create the result subblock under a code block.
+  Includes `upsert_result_child` (text), `upsert_result_embeds` (embed children), and hash-stamped variants for auto-run cache.
+- **`orchestrate::run_block_at_index`** — single entry point for every UI.
+  Takes a workspace + page path + block flat-index, runs, persists, reconciles.
+- **`orchestrate::run_block_at_index_if_source_changed`** — cache-aware variant used by auto-run loop.
+
+## Adding a new language runtime
+
+1. Add a `lang-<name>` feature in `Cargo.toml`.
+2. Create `runtimes/<name>.rs` with one struct + one `impl Runtime`.
+3. Register it in `RuntimeRegistry::with_builtins` behind the feature.
+4. Add aliases to `KNOWN_ALIASES` in `crates/outl-md/src/lang.rs` **and** the TS mirror at `crates/outl-frontend-shared/src/highlight/aliases.ts`.
+5. If the runtime needs workspace access, use `ctx.workspace_root` to build a `WorkspaceIndex`.
+6. If the runtime should auto-run on page load, override `auto_run()` to return `true`.
+
+See `runtimes/query.rs` for the most advanced example (workspace access, embed output, auto-run).
+
+## The `query` runtime
+
+The `query` runtime (`runtimes/query.rs`) is a special case:
+
+- **Returns `OutputFormat::Embeds`**: each stdout line becomes an embed child (`!((blk-XXXXXX))`) under the result header.
+  This makes query results **live references** to the original blocks, not copies.
+- **Overrides `auto_run()` to `true`**: query blocks always re-run on page load, without needing `gx` or `auto-run::`.
+- **Builds a `WorkspaceIndex`** from `ctx.workspace_root` on every execution.
+- **DSL parser** (`runtimes/query::dsl`): line-by-line `key: value` directives, implicitly ANDed.
+  Filters: `status`, `tag`, `kind`, `since`, `text`.
+  Controls: `sort`, `limit`.
+
+User-facing DSL docs live in `docs/query.md` — don't duplicate here.
+
+## Query SDK API (`outl.query`)
+
+The query engine exposes a **structured API** alongside the DSL, so plugins and JS code blocks can query the workspace without parsing a DSL string.
+
+### Two entry points
+
+- **`run_query_dsl(dsl, root)`** — user-facing DSL string → `Vec<QueryHit>`. Used internally by `QueryRuntime::execute`.
+- **`run_query_structured(params, root)`** — plugin-facing struct → `Vec<QueryHit>`. Exposed to JS as `outl.query({ ... })`.
+
+Both converge on the same engine pipeline.
+
+### Public types (re-exported from `outl_exec`)
+
+- `QueryParams` — `{ status, tag, kind, since, text, sort, limit }`, all optional.
+- `QueryHit` — `{ handle, text, status, page }`, the result shape.
+
+### JS binding
+
+The JS runtime registers a global `outl` object with a `query` method.
+It converts the JS argument to `QueryParams`, calls `run_query_structured`, and returns a JS array of `{ handle, text, status, page }` objects.
+
+Full API docs: `docs/query.md` § Plugin SDK API.
+
+## Output format contract
+
+When `ExecOutput.format == OutputFormat::Embeds`, the orchestrator:
+
+1. Splits stdout into non-empty lines.
+2. Each line is expected to be an embed reference (`!((blk-XXXXXX))`).
+3. Calls `upsert_result_embeds` to create child bullets under the result header.
+4. The header reads `> **result:** (N blocks)`.
+
+When `format == OutputFormat::Text` (default), the orchestrator calls `render_result_body` and `upsert_result_child` — the classic single-child `> **result:**` block.
+
+## Auto-run mechanism
+
+Two paths trigger execution:
+
+1. **Manual `gx`** — calls `run_block_at_index`. Always re-runs, ignores cache.
+2. **Auto-run loop** (TUI `actions/exec.rs:run_auto_run_blocks`) — calls `run_block_at_index_if_source_changed`.
+   Normally gated by the `auto-run::` block property.
+   **Runtimes with `auto_run() == true`** (only `query` today) are also collected as auto-run targets, regardless of the property.
+
+The TUI auto-run collector is not yet aware of `Runtime::auto_run()` — this wiring is a known follow-up.
+Today the query runtime works when the user sets `auto-run:: true` on the block, or when the TUI collector is updated to include auto-run runtimes.
+
+## What this crate does NOT own
+
+- The flat-DFS walk to find a block by cursor position — that's `outl_actions::flat_index_for_block`.
+- The Tauri command surface — that's `outl_tauri_shared`.
+- The TUI keybinding — that's `outl_tui`.
+- Page rendering or sidecar management — that's `outl_md`.
+- Workspace tree or op log — that's `outl_core`.
+
+## Dependencies
+
+- `outl-core` — for `Workspace`, `NodeId`, `HlcGenerator`.
+- `outl-md` — for `parse`, `render`, `reconcile_md`, `WorkspaceIndex`, `KNOWN_ALIASES`.
+- Language interpreters behind features: `steel-core` (lisp), `boa_engine` (js), `rustpython-vm` (python), `mlua` (lua), `wasmtime` (rust/wasm).
+- The `query` runtime needs no external dependency — it runs against the in-process `WorkspaceIndex`.
+
+## When you're done
+
+Run `/check` (fmt + clippy + test on the workspace).
+The crate has `#![warn(missing_docs)]` — every new `pub` item needs a doc comment.

--- a/crates/outl-exec/CLAUDE.md
+++ b/crates/outl-exec/CLAUDE.md
@@ -90,9 +90,7 @@ Two paths trigger execution:
 2. **Auto-run loop** (TUI `actions/exec.rs:run_auto_run_blocks`) — calls `run_block_at_index_if_source_changed`.
    Normally gated by the `auto-run::` block property.
    **Runtimes with `auto_run() == true`** (only `query` today) are also collected as auto-run targets, regardless of the property.
-
-The TUI auto-run collector is not yet aware of `Runtime::auto_run()` — this wiring is a known follow-up.
-Today the query runtime works when the user sets `auto-run:: true` on the block, or when the TUI collector is updated to include auto-run runtimes.
+   The TUI collector (`exec.rs`) and desktop (`run_auto_run_blocks` command) both honor this — query blocks auto-run on every page load and after every save.
 
 ## What this crate does NOT own
 

--- a/crates/outl-exec/Cargo.toml
+++ b/crates/outl-exec/Cargo.toml
@@ -11,7 +11,7 @@ readme.workspace = true
 description = "Code-block execution engine for outl: trait Runtime + sandbox + idempotent result subblock."
 
 [features]
-default = ["lang-lisp", "lang-js", "lang-python", "lang-lua", "lang-rust"]
+default = ["lang-lisp", "lang-js", "lang-python", "lang-lua", "lang-rust", "lang-query"]
 
 # Each language is its own feature so binaries can opt out (mobile,
 # embedded, "lisp-only" distributions, ...). Adding a new language is
@@ -20,10 +20,11 @@ lang-lisp = ["dep:steel-core"]
 lang-js = ["dep:boa_engine"]
 lang-python = ["dep:rustpython-vm"]
 lang-lua = ["dep:mlua"]
-# Rust support requires the wasmtime sandbox — there is no in-process
-# Rust interpreter. We compile user source to `wasm32-wasip1` via
-# `rustc` and run the resulting module via wasmtime.
+# Rust support requires the wasmtime sandbox
 lang-rust = ["wasm"]
+# Query language — workspace queries (tasks, filters) as code blocks.
+# No external interpreter needed; runs against the in-process block index.
+lang-query = []
 # Generic WASM sandbox. Pulls in wasmtime; enable when the host wants
 # to load drop-in `.wasm` interpreters or use language runtimes that
 # need WASM (Rust today; Steel/QuickJS-wasi tomorrow).

--- a/crates/outl-exec/src/lib.rs
+++ b/crates/outl-exec/src/lib.rs
@@ -62,6 +62,8 @@ pub use orchestrate::{
 pub use registry::RuntimeRegistry;
 pub use result_block::{
     render_result_body, result_source_hash, source_hash, upsert_result_child,
-    upsert_result_child_with_hash, RESULT_MARKER, SOURCE_HASH_KEY,
+    upsert_result_child_with_hash, upsert_result_embeds, RESULT_MARKER, SOURCE_HASH_KEY,
 };
-pub use runtime::{ExecContext, ExecError, ExecOutput, ExitStatus, Runtime};
+pub use runtime::{ExecContext, ExecError, ExecOutput, ExitStatus, OutputFormat, Runtime};
+
+pub use runtimes::query::{run_query_dsl, run_query_structured, QueryHit, QueryParams};

--- a/crates/outl-exec/src/lib.rs
+++ b/crates/outl-exec/src/lib.rs
@@ -66,4 +66,5 @@ pub use result_block::{
 };
 pub use runtime::{ExecContext, ExecError, ExecOutput, ExitStatus, OutputFormat, Runtime};
 
+#[cfg(feature = "lang-query")]
 pub use runtimes::query::{run_query_dsl, run_query_structured, QueryHit, QueryParams};

--- a/crates/outl-exec/src/orchestrate.rs
+++ b/crates/outl-exec/src/orchestrate.rs
@@ -29,9 +29,9 @@ use crate::language::extract_fence;
 use crate::registry::RuntimeRegistry;
 use crate::result_block::{
     render_result_body, result_source_hash, source_hash, upsert_result_child,
-    upsert_result_child_with_hash,
+    upsert_result_child_with_hash, upsert_result_embeds, RESULT_MARKER,
 };
-use crate::runtime::{ExecContext, ExecError, ExecOutput};
+use crate::runtime::{ExecContext, ExecError, ExecOutput, OutputFormat};
 
 /// Default per-run timeout. UIs can override by building an
 /// [`ExecContext`] manually and going around this helper.
@@ -158,8 +158,17 @@ pub fn run_block_at_index(
 
     // 6. Render result, upsert (without source hash — manual `gx` is
     // always meant to refresh).
-    let body = render_result_body(result.as_ref());
-    upsert_result_child(block, body);
+    match result.as_ref() {
+        Ok(o) if o.format == OutputFormat::Embeds => {
+            let embeds: Vec<&str> = o.stdout.lines().filter(|l| !l.is_empty()).collect();
+            let header = format!("{RESULT_MARKER} ({} blocks)", embeds.len());
+            upsert_result_embeds(block, header, &embeds);
+        }
+        _ => {
+            let body = render_result_body(result.as_ref());
+            upsert_result_child(block, body);
+        }
+    }
 
     // 7. Persist + reconcile.
     let rendered = render(&page);
@@ -230,8 +239,17 @@ pub fn run_block_at_index_if_source_changed(
     };
     let result = runtime.execute(&body, &ctx);
 
-    let body_md = render_result_body(result.as_ref());
-    upsert_result_child_with_hash(block, body_md, &want_hash);
+    match result.as_ref() {
+        Ok(o) if o.format == OutputFormat::Embeds => {
+            let embeds: Vec<&str> = o.stdout.lines().filter(|l| !l.is_empty()).collect();
+            let header = format!("{RESULT_MARKER} ({} blocks)", embeds.len());
+            upsert_result_embeds(block, header, &embeds);
+        }
+        _ => {
+            let body_md = render_result_body(result.as_ref());
+            upsert_result_child_with_hash(block, body_md, &want_hash);
+        }
+    }
 
     let rendered = render(&page);
     outl_md::write_atomic(md_path, rendered.as_bytes()).map_err(|source| RunError::Write {

--- a/crates/outl-exec/src/registry.rs
+++ b/crates/outl-exec/src/registry.rs
@@ -47,6 +47,8 @@ impl RuntimeRegistry {
         r.register(runtimes::lua::LuaRuntime);
         #[cfg(feature = "lang-rust")]
         r.register(runtimes::rust::RustRuntime::default());
+        #[cfg(feature = "lang-query")]
+        r.register(runtimes::query::QueryRuntime);
         r
     }
 

--- a/crates/outl-exec/src/result_block.rs
+++ b/crates/outl-exec/src/result_block.rs
@@ -349,4 +349,48 @@ mod tests {
         // shipped) should look like "never ran" so it gets refreshed.
         assert_eq!(result_source_hash(&parent), None);
     }
+
+    #[test]
+    fn upsert_embeds_creates_result_with_children_when_absent() {
+        let mut parent = OutlineNode {
+            text: "```query\nstatus: todo\n```".into(),
+            properties: Vec::new(),
+            children: Vec::new(),
+        };
+        upsert_result_embeds(
+            &mut parent,
+            "> **result:** (2 blocks)".into(),
+            &["!((blk-aaa))", "!((blk-bbb))"],
+        );
+        assert_eq!(parent.children.len(), 1);
+        assert_eq!(parent.children[0].text, "> **result:** (2 blocks)");
+        assert_eq!(parent.children[0].children.len(), 2);
+        assert_eq!(parent.children[0].children[0].text, "!((blk-aaa))");
+        assert_eq!(parent.children[0].children[1].text, "!((blk-bbb))");
+    }
+
+    #[test]
+    fn upsert_embeds_replaces_existing_result_in_place() {
+        let mut parent = OutlineNode {
+            text: "```query\nstatus: todo\n```".into(),
+            properties: Vec::new(),
+            children: vec![OutlineNode {
+                text: "> **result:** (1 blocks)".into(),
+                properties: Vec::new(),
+                children: vec![OutlineNode {
+                    text: "!((blk-old))".into(),
+                    properties: Vec::new(),
+                    children: Vec::new(),
+                }],
+            }],
+        };
+        upsert_result_embeds(
+            &mut parent,
+            "> **result:** (3 blocks)".into(),
+            &["!((blk-a))", "!((blk-b))", "!((blk-c))"],
+        );
+        assert_eq!(parent.children.len(), 1, "must not create a second child");
+        assert_eq!(parent.children[0].text, "> **result:** (3 blocks)");
+        assert_eq!(parent.children[0].children.len(), 3);
+    }
 }

--- a/crates/outl-exec/src/result_block.rs
+++ b/crates/outl-exec/src/result_block.rs
@@ -100,6 +100,34 @@ pub fn upsert_result_child(parent: &mut OutlineNode, body: String) {
     }
 }
 
+/// Insert or replace the result child under `parent` with embed children.
+///
+/// Used by runtimes that return [`crate::runtime::OutputFormat::Embeds`]: each line of
+/// stdout becomes a child bullet under the result header. Lines are
+/// expected to be embed references (`!((blk-…))`) so the displayed
+/// result is a **live view** of the original blocks, not a copy.
+pub fn upsert_result_embeds(parent: &mut OutlineNode, header: String, lines: &[&str]) {
+    let embed_children: Vec<OutlineNode> = lines
+        .iter()
+        .map(|line| OutlineNode {
+            text: line.to_string(),
+            properties: Vec::new(),
+            children: Vec::new(),
+        })
+        .collect();
+
+    if let Some(idx) = parent.children.iter().position(is_result_block) {
+        parent.children[idx].text = header;
+        parent.children[idx].children = embed_children;
+    } else {
+        parent.children.push(OutlineNode {
+            text: header,
+            properties: Vec::new(),
+            children: embed_children,
+        });
+    }
+}
+
 /// Same as [`upsert_result_child`] but also stamps the result subblock
 /// with a `source-hash::` property. The auto-run loop reads that
 /// property to short-circuit re-runs when the parent source hasn't
@@ -150,6 +178,7 @@ fn is_result_block(node: &OutlineNode) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::OutputFormat;
     use std::time::Duration;
 
     fn ok_output(stdout: &str) -> ExecOutput {
@@ -158,6 +187,7 @@ mod tests {
             stderr: String::new(),
             duration: Duration::from_millis(1),
             exit: ExitStatus::Ok,
+            format: OutputFormat::Text,
         }
     }
 
@@ -186,6 +216,7 @@ mod tests {
             stderr: String::new(),
             duration: Duration::from_millis(1),
             exit: ExitStatus::NonZero(2),
+            format: OutputFormat::Text,
         };
         let body = render_result_body(Ok(&out));
         assert!(body.starts_with("> **result (exit 2):**"));
@@ -198,6 +229,7 @@ mod tests {
             stderr: "divide by zero".into(),
             duration: Duration::from_millis(1),
             exit: ExitStatus::Trap("div-by-zero".into()),
+            format: OutputFormat::Text,
         };
         let body = render_result_body(Ok(&out));
         assert!(body.starts_with("> **result (trap: div-by-zero):**"));

--- a/crates/outl-exec/src/runtime.rs
+++ b/crates/outl-exec/src/runtime.rs
@@ -30,6 +30,20 @@ pub trait Runtime: Send + Sync {
     /// ran but crashed); returning `Err` signals an infrastructure
     /// error (timeout, OOM, missing toolchain).
     fn execute(&self, source: &str, ctx: &ExecContext) -> Result<ExecOutput, ExecError>;
+
+    /// Whether blocks using this runtime should auto-run on every
+    /// page load **without** requiring the `auto-run::` block
+    /// property.
+    ///
+    /// Auto-run runtimes are also **excluded from manual `gx`
+    /// execution** — their results depend on external state (the
+    /// workspace, not just the fence body), so a manual re-run
+    /// provides no additional value over the automatic one.
+    ///
+    /// Default: `false`. The `query` runtime returns `true`.
+    fn auto_run(&self) -> bool {
+        false
+    }
 }
 
 /// Context passed to every execution.
@@ -74,6 +88,9 @@ pub struct ExecOutput {
     pub duration: Duration,
     /// How it ended.
     pub exit: ExitStatus,
+    /// How the orchestrator should render this output into the
+    /// result subblock. See [`OutputFormat`].
+    pub format: OutputFormat,
 }
 
 /// How a run terminated.
@@ -87,6 +104,29 @@ pub enum ExitStatus {
     /// Runtime trapped (panic, division by zero, etc). Message is
     /// runtime-specific.
     Trap(String),
+}
+
+/// How the orchestrator should render [`ExecOutput`] into a result
+/// subblock.
+///
+/// `Text` (the default) feeds `stdout` through
+/// [`render_result_body`](crate::result_block::render_result_body),
+/// producing the classic `> **result:** …` single child.
+///
+/// `Embeds` tells the orchestrator to split `stdout` into one embed
+/// reference per line and render each as a child bullet, so the result
+/// block becomes a **live view** of the referenced blocks. Used by
+/// the `query` runtime: results are `!((blk-XXXXXX))` references, not
+/// copies, so toggling a TODO on the original block is reflected
+/// everywhere it appears.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum OutputFormat {
+    /// Single result child with stdout as inline code or fenced block.
+    #[default]
+    Text,
+    /// One child per non-empty stdout line, each rendered as a bullet.
+    /// Lines are expected to be embed references (`!((blk-…))`).
+    Embeds,
 }
 
 /// Infrastructure-level errors.

--- a/crates/outl-exec/src/runtimes/echo.rs
+++ b/crates/outl-exec/src/runtimes/echo.rs
@@ -10,7 +10,7 @@
 
 use std::time::Instant;
 
-use crate::runtime::{ExecContext, ExecError, ExecOutput, ExitStatus, Runtime};
+use crate::runtime::{ExecContext, ExecError, ExecOutput, ExitStatus, OutputFormat, Runtime};
 
 /// See module docs.
 pub struct EchoRuntime;
@@ -27,6 +27,7 @@ impl Runtime for EchoRuntime {
             stderr: String::new(),
             duration: start.elapsed(),
             exit: ExitStatus::Ok,
+            format: OutputFormat::Text,
         })
     }
 }

--- a/crates/outl-exec/src/runtimes/js.rs
+++ b/crates/outl-exec/src/runtimes/js.rs
@@ -193,13 +193,21 @@ fn js_value_to_query_params(
         .map_err(|e| e.to_string())?
         .as_number()
     {
-        params.limit = Some(v as usize);
+        if v.is_finite() && v >= 0.0 {
+            params.limit = Some(v as usize);
+        }
     }
     let sort_val = obj
         .get(js_string!("sort"), ctx)
         .map_err(|e| e.to_string())?;
     if let Some(s) = sort_val.as_string() {
-        params.sort.push(s.to_std_string_escaped());
+        let raw = s.to_std_string_escaped();
+        for part in raw.split(',') {
+            let trimmed = part.trim();
+            if !trimmed.is_empty() {
+                params.sort.push(trimmed.to_string());
+            }
+        }
     }
     Ok(params)
 }

--- a/crates/outl-exec/src/runtimes/js.rs
+++ b/crates/outl-exec/src/runtimes/js.rs
@@ -25,7 +25,7 @@ use std::time::Instant;
 
 use boa_engine::{js_string, Context, JsValue, NativeFunction, Source};
 
-use crate::runtime::{ExecContext, ExecError, ExecOutput, ExitStatus, Runtime};
+use crate::runtime::{ExecContext, ExecError, ExecOutput, ExitStatus, OutputFormat, Runtime};
 
 /// Boa-backed JavaScript runtime.
 pub struct JsRuntime;
@@ -44,7 +44,7 @@ impl Runtime for JsRuntime {
         "js"
     }
 
-    fn execute(&self, source: &str, _ctx: &ExecContext) -> Result<ExecOutput, ExecError> {
+    fn execute(&self, source: &str, ctx: &ExecContext) -> Result<ExecOutput, ExecError> {
         let start = Instant::now();
         let mut context = Context::default();
         let sink: Rc<RefCell<String>> = Rc::new(RefCell::new(String::new()));
@@ -65,6 +65,42 @@ impl Runtime for JsRuntime {
         context
             .register_global_callable(js_string!("__outl_log"), 1, log_fn)
             .map_err(|e| ExecError::Sandbox(format!("register __outl_log: {e}")))?;
+
+        // Register `outl.query(params)` — structured workspace query
+        // available to JS plugins and code blocks. Captures
+        // `workspace_root` so it can build a WorkspaceIndex lazily.
+        let ws_root = Rc::new(ctx.workspace_root.clone());
+        let query_fn = unsafe {
+            NativeFunction::from_closure(move |_, args, js_ctx| {
+                let root = ws_root.clone();
+                let arg0 = args.get(0).cloned().unwrap_or(JsValue::undefined());
+                let params = js_value_to_query_params(&arg0, js_ctx).map_err(|e| {
+                    boa_engine::JsError::from(
+                        boa_engine::error::JsNativeError::typ().with_message(e),
+                    )
+                })?;
+                let hits = super::query::run_query_structured(&params, &root).map_err(|e| {
+                    boa_engine::JsError::from(
+                        boa_engine::error::JsNativeError::typ().with_message(e),
+                    )
+                })?;
+                hits_to_js_array(&hits, js_ctx).map_err(|e| {
+                    boa_engine::JsError::from(
+                        boa_engine::error::JsNativeError::typ().with_message(e),
+                    )
+                })
+            })
+        };
+        let outl_obj = boa_engine::object::ObjectInitializer::new(&mut context)
+            .function(query_fn, js_string!("query"), 1)
+            .build();
+        context
+            .register_global_property(
+                js_string!("outl"),
+                JsValue::from(outl_obj),
+                boa_engine::property::Attribute::all(),
+            )
+            .map_err(|e| ExecError::Sandbox(format!("register outl: {e}")))?;
         // Run the shim that wires console.log → __outl_log. Errors
         // here would mean a broken Boa install, so just panic-via-?.
         let _ = context
@@ -81,6 +117,7 @@ impl Runtime for JsRuntime {
                     stderr: e.to_string(),
                     duration: start.elapsed(),
                     exit: ExitStatus::Trap("js-error".into()),
+                    format: OutputFormat::Text,
                 });
             }
         };
@@ -98,8 +135,101 @@ impl Runtime for JsRuntime {
             stderr: String::new(),
             duration: start.elapsed(),
             exit: ExitStatus::Ok,
+            format: OutputFormat::Text,
         })
     }
+}
+
+/// Convert a JS value (expected: plain object) into [`QueryParams`].
+fn js_value_to_query_params(
+    val: &JsValue,
+    ctx: &mut Context,
+) -> Result<super::query::QueryParams, String> {
+    let obj = val.as_object().ok_or("outl.query expects an object")?;
+    let mut params = super::query::QueryParams::default();
+    if let Some(v) = obj
+        .get(js_string!("status"), ctx)
+        .map_err(|e| e.to_string())?
+        .as_string()
+    {
+        params.status = Some(v.to_std_string_escaped());
+    }
+    if let Some(v) = obj
+        .get(js_string!("tag"), ctx)
+        .map_err(|e| e.to_string())?
+        .as_string()
+    {
+        params.tag = Some(v.to_std_string_escaped());
+    }
+    if let Some(v) = obj
+        .get(js_string!("kind"), ctx)
+        .map_err(|e| e.to_string())?
+        .as_string()
+    {
+        params.kind = Some(v.to_std_string_escaped());
+    }
+    if let Some(v) = obj
+        .get(js_string!("since"), ctx)
+        .map_err(|e| e.to_string())?
+        .as_string()
+    {
+        params.since = Some(v.to_std_string_escaped());
+    }
+    if let Some(v) = obj
+        .get(js_string!("text"), ctx)
+        .map_err(|e| e.to_string())?
+        .as_string()
+    {
+        params.text = Some(v.to_std_string_escaped());
+    }
+    if let Some(v) = obj
+        .get(js_string!("limit"), ctx)
+        .map_err(|e| e.to_string())?
+        .as_number()
+    {
+        params.limit = Some(v as usize);
+    }
+    let sort_val = obj
+        .get(js_string!("sort"), ctx)
+        .map_err(|e| e.to_string())?;
+    if let Some(s) = sort_val.as_string() {
+        params.sort.push(s.to_std_string_escaped());
+    }
+    Ok(params)
+}
+
+/// Convert query hits into a JS array of `{ handle, text, status, page }`.
+fn hits_to_js_array(hits: &[super::query::QueryHit], ctx: &mut Context) -> Result<JsValue, String> {
+    let arr = boa_engine::object::ObjectInitializer::new(ctx).build();
+    for (i, hit) in hits.iter().enumerate() {
+        let obj = boa_engine::object::ObjectInitializer::new(ctx)
+            .property(
+                js_string!("handle"),
+                js_string!(hit.handle.as_str()),
+                boa_engine::property::Attribute::all(),
+            )
+            .property(
+                js_string!("text"),
+                js_string!(hit.text.as_str()),
+                boa_engine::property::Attribute::all(),
+            )
+            .property(
+                js_string!("page"),
+                js_string!(hit.page.as_str()),
+                boa_engine::property::Attribute::all(),
+            )
+            .property(
+                js_string!("status"),
+                match hit.status.as_deref() {
+                    Some(s) => js_string!(s).into(),
+                    None => JsValue::null(),
+                },
+                boa_engine::property::Attribute::all(),
+            )
+            .build();
+        arr.set(i, obj, true, ctx).map_err(|e| e.to_string())?;
+    }
+    Ok(arr.into())
 }
 
 #[cfg(test)]

--- a/crates/outl-exec/src/runtimes/js.rs
+++ b/crates/outl-exec/src/runtimes/js.rs
@@ -47,6 +47,8 @@ impl Runtime for JsRuntime {
     fn execute(&self, source: &str, ctx: &ExecContext) -> Result<ExecOutput, ExecError> {
         let start = Instant::now();
         let mut context = Context::default();
+        // Prevent unused-variable warning when lang-query is off.
+        let _ = ctx;
         let sink: Rc<RefCell<String>> = Rc::new(RefCell::new(String::new()));
 
         // Register `__outl_log(string)` as a native fn that pushes

--- a/crates/outl-exec/src/runtimes/js.rs
+++ b/crates/outl-exec/src/runtimes/js.rs
@@ -69,38 +69,41 @@ impl Runtime for JsRuntime {
         // Register `outl.query(params)` — structured workspace query
         // available to JS plugins and code blocks. Captures
         // `workspace_root` so it can build a WorkspaceIndex lazily.
-        let ws_root = Rc::new(ctx.workspace_root.clone());
-        let query_fn = unsafe {
-            NativeFunction::from_closure(move |_, args, js_ctx| {
-                let root = ws_root.clone();
-                let arg0 = args.get(0).cloned().unwrap_or(JsValue::undefined());
-                let params = js_value_to_query_params(&arg0, js_ctx).map_err(|e| {
-                    boa_engine::JsError::from(
-                        boa_engine::error::JsNativeError::typ().with_message(e),
-                    )
-                })?;
-                let hits = super::query::run_query_structured(&params, &root).map_err(|e| {
-                    boa_engine::JsError::from(
-                        boa_engine::error::JsNativeError::typ().with_message(e),
-                    )
-                })?;
-                hits_to_js_array(&hits, js_ctx).map_err(|e| {
-                    boa_engine::JsError::from(
-                        boa_engine::error::JsNativeError::typ().with_message(e),
-                    )
+        #[cfg(feature = "lang-query")]
+        {
+            let ws_root = Rc::new(ctx.workspace_root.clone());
+            let query_fn = unsafe {
+                NativeFunction::from_closure(move |_, args, js_ctx| {
+                    let root = ws_root.clone();
+                    let arg0 = args.first().cloned().unwrap_or(JsValue::undefined());
+                    let params = js_value_to_query_params(&arg0, js_ctx).map_err(|e| {
+                        boa_engine::JsError::from(
+                            boa_engine::error::JsNativeError::typ().with_message(e),
+                        )
+                    })?;
+                    let hits = super::query::run_query_structured(&params, &root).map_err(|e| {
+                        boa_engine::JsError::from(
+                            boa_engine::error::JsNativeError::typ().with_message(e),
+                        )
+                    })?;
+                    hits_to_js_array(&hits, js_ctx).map_err(|e| {
+                        boa_engine::JsError::from(
+                            boa_engine::error::JsNativeError::typ().with_message(e),
+                        )
+                    })
                 })
-            })
-        };
-        let outl_obj = boa_engine::object::ObjectInitializer::new(&mut context)
-            .function(query_fn, js_string!("query"), 1)
-            .build();
-        context
-            .register_global_property(
-                js_string!("outl"),
-                JsValue::from(outl_obj),
-                boa_engine::property::Attribute::all(),
-            )
-            .map_err(|e| ExecError::Sandbox(format!("register outl: {e}")))?;
+            };
+            let outl_obj = boa_engine::object::ObjectInitializer::new(&mut context)
+                .function(query_fn, js_string!("query"), 1)
+                .build();
+            context
+                .register_global_property(
+                    js_string!("outl"),
+                    JsValue::from(outl_obj),
+                    boa_engine::property::Attribute::all(),
+                )
+                .map_err(|e| ExecError::Sandbox(format!("register outl: {e}")))?;
+        }
         // Run the shim that wires console.log → __outl_log. Errors
         // here would mean a broken Boa install, so just panic-via-?.
         let _ = context
@@ -141,6 +144,7 @@ impl Runtime for JsRuntime {
 }
 
 /// Convert a JS value (expected: plain object) into [`QueryParams`].
+#[cfg(feature = "lang-query")]
 fn js_value_to_query_params(
     val: &JsValue,
     ctx: &mut Context,
@@ -198,7 +202,8 @@ fn js_value_to_query_params(
     Ok(params)
 }
 
-/// Convert query hits into a JS array of `{ handle, text, status, page }`.
+/// Convert query hits into a JS array of objects.
+#[cfg(feature = "lang-query")]
 fn hits_to_js_array(hits: &[super::query::QueryHit], ctx: &mut Context) -> Result<JsValue, String> {
     let arr = boa_engine::object::ObjectInitializer::new(ctx).build();
     for (i, hit) in hits.iter().enumerate() {

--- a/crates/outl-exec/src/runtimes/lisp.rs
+++ b/crates/outl-exec/src/runtimes/lisp.rs
@@ -14,7 +14,7 @@ use steel::steel_vm::engine::Engine;
 use steel::steel_vm::register_fn::RegisterFn;
 use steel::SteelVal;
 
-use crate::runtime::{ExecContext, ExecError, ExecOutput, ExitStatus, Runtime};
+use crate::runtime::{ExecContext, ExecError, ExecOutput, ExitStatus, OutputFormat, Runtime};
 
 /// Steel-backed Scheme runtime.
 pub struct LispRuntime;
@@ -50,6 +50,7 @@ impl Runtime for LispRuntime {
                     stderr: String::new(),
                     duration: start.elapsed(),
                     exit: ExitStatus::Ok,
+                    format: OutputFormat::Text,
                 })
             }
             Err(e) => Ok(ExecOutput {
@@ -57,6 +58,7 @@ impl Runtime for LispRuntime {
                 stderr: format!("{e}"),
                 duration: start.elapsed(),
                 exit: ExitStatus::Trap("steel-error".into()),
+                format: OutputFormat::Text,
             }),
         }
     }

--- a/crates/outl-exec/src/runtimes/lua.rs
+++ b/crates/outl-exec/src/runtimes/lua.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 
 use mlua::{Lua, MultiValue, Value, Variadic};
 
-use crate::runtime::{ExecContext, ExecError, ExecOutput, ExitStatus, Runtime};
+use crate::runtime::{ExecContext, ExecError, ExecOutput, ExitStatus, OutputFormat, Runtime};
 
 /// mlua-backed Lua 5.4 runtime.
 pub struct LuaRuntime;
@@ -60,6 +60,7 @@ impl Runtime for LuaRuntime {
                     stderr: String::new(),
                     duration: start.elapsed(),
                     exit: ExitStatus::Ok,
+                    format: OutputFormat::Text,
                 })
             }
             Err(e) => Ok(ExecOutput {
@@ -67,6 +68,7 @@ impl Runtime for LuaRuntime {
                 stderr: e.to_string(),
                 duration: start.elapsed(),
                 exit: ExitStatus::Trap("lua-error".into()),
+                format: OutputFormat::Text,
             }),
         }
     }

--- a/crates/outl-exec/src/runtimes/mod.rs
+++ b/crates/outl-exec/src/runtimes/mod.rs
@@ -28,3 +28,6 @@ pub mod lua;
 
 #[cfg(feature = "lang-rust")]
 pub mod rust;
+
+#[cfg(feature = "lang-query")]
+pub mod query;

--- a/crates/outl-exec/src/runtimes/python.rs
+++ b/crates/outl-exec/src/runtimes/python.rs
@@ -18,7 +18,7 @@ use std::time::Instant;
 
 use rustpython_vm::{compiler, scope::Scope, Interpreter, PyObjectRef, Settings, VirtualMachine};
 
-use crate::runtime::{ExecContext, ExecError, ExecOutput, ExitStatus, Runtime};
+use crate::runtime::{ExecContext, ExecError, ExecOutput, ExitStatus, OutputFormat, Runtime};
 
 /// RustPython-backed runtime.
 pub struct PythonRuntime;
@@ -86,12 +86,14 @@ impl Runtime for PythonRuntime {
                 stderr: String::new(),
                 duration: start.elapsed(),
                 exit: ExitStatus::Ok,
+                format: OutputFormat::Text,
             }),
             Err(stderr) => Ok(ExecOutput {
                 stdout: String::new(),
                 stderr: stderr.0,
                 duration: start.elapsed(),
                 exit: ExitStatus::Trap("python-error".into()),
+                format: OutputFormat::Text,
             }),
         }
     }

--- a/crates/outl-exec/src/runtimes/query.rs
+++ b/crates/outl-exec/src/runtimes/query.rs
@@ -1,0 +1,535 @@
+//! `query` runtime — declarative workspace queries as code blocks.
+//!
+//! A ` ```query ` fence runs a line-by-line declarative DSL against the
+//! workspace and returns matching blocks as **embed references**
+//! (`!((blk-XXXXXX))`), not copies. This means toggling a TODO on the
+//! original block is reflected everywhere the query result appears.
+//!
+//! Two entry points into the same engine:
+//!
+//! - **DSL string** (` ```query ` code block) — user-facing, renders embeds.
+//! - **Structured API** (`run_query_structured`) — plugin-facing, returns
+//!   typed `QueryHit` values. Exposed to JS as `outl.query({ … })`.
+//!
+//! Both converge on the same `Query` + `engine::run` pipeline.
+
+use std::path::Path;
+use std::time::Instant;
+
+use outl_md::index::WorkspaceIndex;
+
+use crate::runtime::{ExecContext, ExecError, ExecOutput, ExitStatus, OutputFormat, Runtime};
+
+// ── Public query API (used by both ```query and plugin SDK) ─────────────
+
+/// Structured query parameters — the plugin-facing API.
+///
+/// Every field is optional; an empty struct matches every block.
+/// This is the shape that `outl.query({ … })` deserialises from JS.
+#[derive(Debug, Default, Clone)]
+pub struct QueryParams {
+    /// `"todo"`, `"done"`, or `"open"` (either).
+    pub status: Option<String>,
+    /// Partial tag match (without `#`).
+    pub tag: Option<String>,
+    /// `"journal"` or `"page"`.
+    pub kind: Option<String>,
+    /// Duration like `"7d"`, `"2w"`, `"3m"`.
+    pub since: Option<String>,
+    /// Substring search (case-insensitive).
+    pub text: Option<String>,
+    /// Sort keys in priority order.
+    pub sort: Vec<String>,
+    /// Maximum number of results.
+    pub limit: Option<usize>,
+}
+
+/// One query result — structured, typed, no markdown.
+#[derive(Debug, Clone)]
+pub struct QueryHit {
+    /// Block ref handle (`blk-XXXXXX`).
+    pub handle: String,
+    /// Slug of the hosting page.
+    pub page: String,
+    /// `"todo"`, `"done"`, or `None` when the block is not a task.
+    pub status: Option<String>,
+    /// Block text with TODO/DONE prefix stripped.
+    pub text: String,
+}
+
+/// Run a query from structured parameters against the workspace at
+/// `workspace_root`. Returns sorted, limited hits.
+pub fn run_query_structured(
+    params: &QueryParams,
+    workspace_root: &Path,
+) -> Result<Vec<QueryHit>, String> {
+    let query = build_query_from_params(params)?;
+    run_query_internal(&query, workspace_root)
+}
+
+/// Run a query from a DSL string against the workspace at
+/// `workspace_root`. Returns sorted, limited hits.
+pub fn run_query_dsl(dsl: &str, workspace_root: &Path) -> Result<Vec<QueryHit>, String> {
+    let query = dsl::parse(dsl).map_err(|e| e.to_string())?;
+    run_query_internal(&query, workspace_root)
+}
+
+fn run_query_internal(query: &dsl::Query, workspace_root: &Path) -> Result<Vec<QueryHit>, String> {
+    let index = WorkspaceIndex::build(workspace_root);
+    let mut hits = engine::run(&index, query);
+    engine::sort_hits(&mut hits, &query.sort);
+    if let Some(limit) = query.limit {
+        hits.truncate(limit);
+    }
+    Ok(hits
+        .into_iter()
+        .map(|h| QueryHit {
+            handle: h.handle,
+            page: h.page_slug,
+            status: h
+                .status
+                .map(|done| if done { "done" } else { "todo" })
+                .map(String::from),
+            text: h.text,
+        })
+        .collect())
+}
+
+fn build_query_from_params(p: &QueryParams) -> Result<dsl::Query, String> {
+    let mut filters = Vec::new();
+    if let Some(s) = &p.status {
+        filters.push(dsl::Filter::Status(match s.as_str() {
+            "todo" => dsl::StatusFilter::Todo,
+            "done" => dsl::StatusFilter::Done,
+            "open" => dsl::StatusFilter::Open,
+            other => return Err(format!("invalid status '{other}' (use todo|done|open)")),
+        }));
+    }
+    if let Some(t) = &p.tag {
+        filters.push(dsl::Filter::Tag(t.clone()));
+    }
+    if let Some(k) = &p.kind {
+        filters.push(dsl::Filter::Kind(match k.as_str() {
+            "journal" => dsl::KindFilter::Journal,
+            "page" => dsl::KindFilter::Page,
+            other => return Err(format!("invalid kind '{other}' (use journal|page)")),
+        }));
+    }
+    if let Some(s) = &p.since {
+        filters.push(dsl::Filter::Since(parse_duration_pub(s)?));
+    }
+    if let Some(t) = &p.text {
+        filters.push(dsl::Filter::Text(t.clone()));
+    }
+    let mut sort = Vec::new();
+    for s in &p.sort {
+        sort.push(match s.as_str() {
+            "page" => dsl::SortKey::Page,
+            "status" => dsl::SortKey::Status,
+            "text" => dsl::SortKey::Text,
+            other => return Err(format!("invalid sort key '{other}' (use page|status|text)")),
+        });
+    }
+    Ok(dsl::Query {
+        filters,
+        sort,
+        limit: p.limit,
+    })
+}
+
+fn parse_duration_pub(v: &str) -> Result<u32, String> {
+    if v.is_empty() {
+        return Err("since requires a duration like '7d', '2w', '3m'".into());
+    }
+    let (num_str, unit) = v.split_at(v.len() - 1);
+    let n: u32 = num_str
+        .parse()
+        .map_err(|_| format!("since: invalid number in '{v}'"))?;
+    match unit {
+        "d" => Ok(n),
+        "w" => Ok(n * 7),
+        "m" => Ok(n * 30),
+        _ => Err(format!("since: unknown unit '{unit}' (use d, w, or m)")),
+    }
+}
+
+/// Query runtime — runs the DSL against the workspace on disk.
+pub struct QueryRuntime;
+
+impl Runtime for QueryRuntime {
+    fn language(&self) -> &'static str {
+        "query"
+    }
+
+    fn auto_run(&self) -> bool {
+        true
+    }
+
+    fn execute(&self, source: &str, ctx: &ExecContext) -> Result<ExecOutput, ExecError> {
+        let start = Instant::now();
+
+        let hits = run_query_dsl(source, &ctx.workspace_root).map_err(ExecError::Language)?;
+
+        let stdout = hits
+            .iter()
+            .map(|h| format!("!(({}))", h.handle))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        Ok(ExecOutput {
+            stdout,
+            stderr: String::new(),
+            duration: start.elapsed(),
+            exit: ExitStatus::Ok,
+            format: OutputFormat::Embeds,
+        })
+    }
+}
+
+/// DSL parser.
+pub(crate) mod dsl {
+    use std::fmt;
+
+    /// Parsed query.
+    #[derive(Debug, Default)]
+    pub struct Query {
+        pub filters: Vec<Filter>,
+        pub sort: Vec<SortKey>,
+        pub limit: Option<usize>,
+    }
+
+    #[derive(Debug, Clone)]
+    pub enum Filter {
+        Status(StatusFilter),
+        Tag(String),
+        Kind(KindFilter),
+        Since(u32),
+        Text(String),
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum StatusFilter {
+        Todo,
+        Done,
+        Open,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum KindFilter {
+        Journal,
+        Page,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum SortKey {
+        Page,
+        Status,
+        Text,
+    }
+
+    #[derive(Debug)]
+    pub struct ParseError {
+        /// 1-based line number where the error occurred.
+        pub line: usize,
+        /// Human-readable description.
+        pub msg: String,
+    }
+
+    impl fmt::Display for ParseError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "line {}: {}", self.line, self.msg)
+        }
+    }
+
+    /// Parse a query DSL source string into a [`Query`].
+    pub fn parse(source: &str) -> Result<Query, ParseError> {
+        let mut filters = Vec::new();
+        let mut sort = Vec::new();
+        let mut limit = None;
+
+        for (i, raw) in source.lines().enumerate() {
+            let line = raw.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+
+            let (key, value) = split_kv(line, i)?;
+            let key = key.trim();
+            let value = value.trim();
+
+            match key {
+                "status" => filters.push(Filter::Status(parse_status(value, i)?)),
+                "tag" => filters.push(Filter::Tag(value.to_string())),
+                "kind" => filters.push(Filter::Kind(parse_kind(value, i)?)),
+                "since" => filters.push(Filter::Since(parse_duration(value, i)?)),
+                "text" => filters.push(Filter::Text(value.to_string())),
+                "sort" => {
+                    for part in value.split(',') {
+                        sort.push(parse_sort_key(part.trim(), i)?);
+                    }
+                }
+                "limit" => {
+                    limit = Some(parse_usize(value, i)?);
+                }
+                _ => {
+                    return Err(ParseError {
+                        line: i + 1,
+                        msg: format!("unknown key: '{key}'"),
+                    });
+                }
+            }
+        }
+
+        Ok(Query {
+            filters,
+            sort,
+            limit,
+        })
+    }
+
+    fn split_kv(line: &str, line_idx: usize) -> Result<(&str, &str), ParseError> {
+        line.split_once(':').ok_or_else(|| ParseError {
+            line: line_idx + 1,
+            msg: "expected 'key: value'".into(),
+        })
+    }
+
+    fn parse_status(v: &str, line_idx: usize) -> Result<StatusFilter, ParseError> {
+        match v {
+            "todo" => Ok(StatusFilter::Todo),
+            "done" => Ok(StatusFilter::Done),
+            "open" => Ok(StatusFilter::Open),
+            _ => Err(ParseError {
+                line: line_idx + 1,
+                msg: format!("status must be 'todo', 'done', or 'open', got '{v}'"),
+            }),
+        }
+    }
+
+    fn parse_kind(v: &str, line_idx: usize) -> Result<KindFilter, ParseError> {
+        match v {
+            "journal" => Ok(KindFilter::Journal),
+            "page" => Ok(KindFilter::Page),
+            _ => Err(ParseError {
+                line: line_idx + 1,
+                msg: format!("kind must be 'journal' or 'page', got '{v}'"),
+            }),
+        }
+    }
+
+    /// Parse `Nd` / `Nw` / `Nm` into a day count.
+    fn parse_duration(v: &str, line_idx: usize) -> Result<u32, ParseError> {
+        if v.is_empty() {
+            return Err(ParseError {
+                line: line_idx + 1,
+                msg: "since requires a duration like '7d', '2w', '3m'".into(),
+            });
+        }
+        let (num_str, unit) = v.split_at(v.len() - 1);
+        let n: u32 = num_str.parse().map_err(|_| ParseError {
+            line: line_idx + 1,
+            msg: format!("since: invalid number in '{v}'"),
+        })?;
+        match unit {
+            "d" => Ok(n),
+            "w" => Ok(n * 7),
+            "m" => Ok(n * 30),
+            _ => Err(ParseError {
+                line: line_idx + 1,
+                msg: format!("since: unknown unit '{unit}' (use d, w, or m)"),
+            }),
+        }
+    }
+
+    fn parse_sort_key(v: &str, line_idx: usize) -> Result<SortKey, ParseError> {
+        match v {
+            "page" => Ok(SortKey::Page),
+            "status" => Ok(SortKey::Status),
+            "text" => Ok(SortKey::Text),
+            _ => Err(ParseError {
+                line: line_idx + 1,
+                msg: format!("sort: must be 'page', 'status', or 'text', got '{v}'"),
+            }),
+        }
+    }
+
+    fn parse_usize(v: &str, line_idx: usize) -> Result<usize, ParseError> {
+        v.parse::<usize>().map_err(|_| ParseError {
+            line: line_idx + 1,
+            msg: format!("expected a number, got '{v}'"),
+        })
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn parses_status_todo() {
+            let q = parse("status: todo").unwrap();
+            assert_eq!(q.filters.len(), 1);
+            assert!(matches!(q.filters[0], Filter::Status(StatusFilter::Todo)));
+        }
+
+        #[test]
+        fn parses_multiple_filters() {
+            let q = parse("status: todo\ntag: ops\nlimit: 10").unwrap();
+            assert_eq!(q.filters.len(), 2);
+            assert_eq!(q.limit, Some(10));
+        }
+
+        #[test]
+        fn ignores_comments() {
+            let q = parse("# comment\nstatus: done").unwrap();
+            assert_eq!(q.filters.len(), 1);
+        }
+
+        #[test]
+        fn parses_sort() {
+            let q = parse("sort: page, status").unwrap();
+            assert_eq!(q.sort.len(), 2);
+        }
+
+        #[test]
+        fn parses_since() {
+            let q = parse("since: 2w").unwrap();
+            assert!(matches!(q.filters[0], Filter::Since(14)));
+        }
+
+        #[test]
+        fn rejects_unknown_key() {
+            assert!(parse("bogus: value").is_err());
+        }
+    }
+}
+
+/// Execution engine — filter + collect matching blocks.
+pub(crate) mod engine {
+    use super::dsl::{Filter, KindFilter, Query, SortKey, StatusFilter};
+    use chrono::{Duration, NaiveDate};
+    use outl_md::block_index::BlockEntry;
+    use outl_md::index::WorkspaceIndex;
+
+    /// One query hit — the data we need to render an embed.
+    pub struct Hit {
+        /// Block ref handle (`blk-XXXXXX`) for embed rendering.
+        pub handle: String,
+        /// Slug of the page hosting the block.
+        pub page_slug: String,
+        /// `Some(false)` = TODO, `Some(true)` = DONE, `None` = not a task.
+        pub status: Option<bool>,
+        /// Block text with the TODO prefix stripped.
+        pub text: String,
+    }
+
+    /// Run `query` against `index`, returning all matching blocks.
+    pub fn run(index: &WorkspaceIndex, query: &Query) -> Vec<Hit> {
+        let today = chrono::Local::now().date_naive();
+
+        index
+            .iter_blocks()
+            .filter_map(|entry| {
+                let (status, body) = split_todo(&entry.text);
+                let page = index.by_slug(&entry.source_slug);
+
+                for f in &query.filters {
+                    if !matches(f, entry, status, page.map(|p| p.is_journal), &today) {
+                        return None;
+                    }
+                }
+
+                Some(Hit {
+                    handle: entry.ref_handle.clone(),
+                    page_slug: entry.source_slug.clone(),
+                    status,
+                    text: body.to_string(),
+                })
+            })
+            .collect()
+    }
+
+    /// Sort hits by the given criteria, in priority order (last key first
+    /// so the first key dominates after stable sort).
+    pub fn sort_hits(hits: &mut [Hit], keys: &[SortKey]) {
+        for key in keys.iter().rev() {
+            match key {
+                SortKey::Page => hits.sort_by(|a, b| a.page_slug.cmp(&b.page_slug)),
+                SortKey::Status => hits.sort_by(|a, b| {
+                    let a_done = a.status.unwrap_or(false);
+                    let b_done = b.status.unwrap_or(false);
+                    a_done.cmp(&b_done)
+                }),
+                SortKey::Text => hits.sort_by(|a, b| a.text.cmp(&b.text)),
+            }
+        }
+    }
+
+    fn matches(
+        f: &Filter,
+        entry: &BlockEntry,
+        status: Option<bool>,
+        is_journal: Option<bool>,
+        today: &NaiveDate,
+    ) -> bool {
+        match f {
+            Filter::Status(sf) => match sf {
+                StatusFilter::Todo => status == Some(false),
+                StatusFilter::Done => status == Some(true),
+                StatusFilter::Open => status.is_some(),
+            },
+            Filter::Tag(tag) => {
+                let needle = format!("#{}", tag.to_lowercase());
+                entry.text_fold.contains(&needle)
+            }
+            Filter::Kind(kf) => match kf {
+                KindFilter::Journal => is_journal == Some(true),
+                KindFilter::Page => is_journal != Some(true),
+            },
+            Filter::Since(days) => {
+                let cutoff = *today - Duration::days(*days as i64);
+                if let Some(d) = parse_journal_date(&entry.source_slug) {
+                    d >= cutoff
+                } else {
+                    false
+                }
+            }
+            Filter::Text(needle) => entry.text_fold.contains(&needle.to_lowercase()),
+        }
+    }
+
+    /// Split `"TODO body"` / `"DONE body"` / `"body"` into `(status, body)`.
+    /// Returns `Some(false)` for TODO, `Some(true)` for DONE, `None` otherwise.
+    fn split_todo(raw: &str) -> (Option<bool>, &str) {
+        if let Some(rest) = raw.strip_prefix("TODO ") {
+            (Some(false), rest)
+        } else if let Some(rest) = raw.strip_prefix("DONE ") {
+            (Some(true), rest)
+        } else {
+            (None, raw)
+        }
+    }
+
+    fn parse_journal_date(slug: &str) -> Option<NaiveDate> {
+        NaiveDate::parse_from_str(slug, "%Y-%m-%d").ok()
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn split_todo_open() {
+            assert_eq!(split_todo("TODO buy milk"), (Some(false), "buy milk"));
+        }
+
+        #[test]
+        fn split_todo_done() {
+            assert_eq!(split_todo("DONE buy milk"), (Some(true), "buy milk"));
+        }
+
+        #[test]
+        fn split_todo_none() {
+            assert_eq!(split_todo("just text"), (None, "just text"));
+        }
+    }
+}

--- a/crates/outl-exec/src/runtimes/query.rs
+++ b/crates/outl-exec/src/runtimes/query.rs
@@ -486,12 +486,10 @@ pub(crate) mod engine {
                 KindFilter::Page => is_journal != Some(true),
             },
             Filter::Since(days) => {
-                let cutoff = *today - Duration::days(*days as i64);
-                if let Some(d) = parse_journal_date(&entry.source_slug) {
-                    d >= cutoff
-                } else {
-                    false
-                }
+                is_journal == Some(true)
+                    && parse_journal_date(&entry.source_slug)
+                        .map(|d| d >= *today - Duration::days(*days as i64))
+                        .unwrap_or(false)
             }
             Filter::Text(needle) => entry.text_fold.contains(&needle.to_lowercase()),
         }

--- a/crates/outl-exec/src/wasm/module.rs
+++ b/crates/outl-exec/src/wasm/module.rs
@@ -24,7 +24,7 @@ use wasmtime_wasi::p1::WasiP1Ctx;
 use wasmtime_wasi::p2::pipe::{MemoryInputPipe, MemoryOutputPipe};
 use wasmtime_wasi::WasiCtxBuilder;
 
-use crate::runtime::{ExecContext, ExecError, ExecOutput, ExitStatus, Runtime};
+use crate::runtime::{ExecContext, ExecError, ExecOutput, ExitStatus, OutputFormat, Runtime};
 use crate::wasm::engine::SandboxLimits;
 
 /// A WASM-hosted language runtime.
@@ -139,6 +139,7 @@ impl Runtime for WasmModule {
                 stderr,
                 duration,
                 exit: ExitStatus::Ok,
+                format: OutputFormat::Text,
             }),
             Err(e) => {
                 // Classify the trap.
@@ -164,6 +165,7 @@ impl Runtime for WasmModule {
                     stderr,
                     duration,
                     exit,
+                    format: OutputFormat::Text,
                 })
             }
         }

--- a/crates/outl-frontend-shared/src/api/commands.ts
+++ b/crates/outl-frontend-shared/src/api/commands.ts
@@ -395,6 +395,30 @@ export function runCodeBlock(
 }
 
 /**
+ * Sweep the page for query blocks (runtimes with `auto_run() == true`)
+ * and execute them. Returns the refreshed `PageView`.
+ */
+export function runAutoRunBlocks(
+  pageId: string,
+): Promise<{ ran: number; view: PageView }> {
+  return invoke<{ ran: number; view: PageView }>("run_auto_run_blocks", {
+    pageId,
+  });
+}
+
+/**
+ * Batch-resolve embed handles (`blk-XXXXXX`) to their source content.
+ * Returns a map from handle to `{ handle, text, page_slug }`.
+ */
+export function resolveEmbeds(
+  handles: string[],
+): Promise<Record<string, { handle: string; text: string; page_slug: string; status: string | null }>> {
+  return invoke<
+    Record<string, { handle: string; text: string; page_slug: string; status: string | null }>
+  >("resolve_embeds", { handles });
+}
+
+/**
  * Open an external `[label](url)` link in the user's default browser
  * via `tauri-plugin-opener`. Shared by every client's `onLinkClick`
  * handler so the scheme allow-list lives in one place.

--- a/crates/outl-frontend-shared/src/highlight/aliases.ts
+++ b/crates/outl-frontend-shared/src/highlight/aliases.ts
@@ -19,6 +19,7 @@ export const KNOWN_ALIASES: ReadonlyArray<readonly [string, ReadonlyArray<string
   ["lua", ["lua"]],
   ["lisp", ["lisp", "cl", "common-lisp", "elisp"]],
   ["echo", ["echo", "text", "txt", "plain"]],
+  ["query", ["query", "tasks"]],
   ["typescript", ["typescript", "ts"]],
   ["tsx", ["tsx"]],
   ["jsx", ["jsx"]],

--- a/crates/outl-frontend-shared/src/markdown/MarkdownInline.tsx
+++ b/crates/outl-frontend-shared/src/markdown/MarkdownInline.tsx
@@ -2,6 +2,11 @@ import { For, JSX, Show } from "solid-js";
 
 import type { InlineToken } from "../api/types";
 
+export type EmbedMap = Record<
+  string,
+  { handle: string; text: string; page_slug: string; status: string | null }
+>;
+
 /**
  * Render a block's pre-tokenized inline markdown.
  *
@@ -54,6 +59,9 @@ interface MarkdownInlineProps {
    * argument is the raw `href`. When omitted the link renders as inert
    * text (mobile / backlink contexts that don't open URLs yet). */
   onLinkClick?: (href: string) => void;
+  /** Resolved embed content keyed by handle. When present, `embed`
+   *  tokens render the source block's text instead of a chip. */
+  embeds?: EmbedMap;
 }
 
 export function MarkdownInline(props: MarkdownInlineProps): JSX.Element {
@@ -234,12 +242,27 @@ export function MarkdownInline(props: MarkdownInlineProps): JSX.Element {
                 {tok.value}
               </span>
             );
-          case "embed":
+          case "embed": {
+            const resolved = props.embeds?.[tok.value];
+            if (resolved) {
+              const mark =
+                resolved.status === "done"
+                  ? "✓ "
+                  : resolved.status === "todo"
+                    ? "☐ "
+                    : "";
+              return (
+                <span class="rounded bg-(--color-ios-accent)/8 px-1 py-0.5 text-[13px] text-(--color-ios-text) dark:bg-(--color-iosd-accent)/10 dark:text-(--color-iosd-text)">
+                  ↳ {mark}{resolved.text}
+                </span>
+              );
+            }
             return (
               <span class="rounded bg-(--color-ios-accent)/12 px-1 font-mono text-[13px] text-(--color-ios-accent) dark:bg-(--color-iosd-accent)/20 dark:text-(--color-iosd-accent)">
                 !{tok.value}
               </span>
             );
+          }
           case "emoji":
             // The backend's catalog gate guarantees `glyph` is set on
             // every Emoji token. Defensive fall-back: if a peer ever

--- a/crates/outl-frontend-shared/src/markdown/index.ts
+++ b/crates/outl-frontend-shared/src/markdown/index.ts
@@ -1,4 +1,4 @@
-export { MarkdownInline } from "./MarkdownInline";
+export { MarkdownInline, type EmbedMap } from "./MarkdownInline";
 export {
   QUOTE_PREFIX,
   isQuote,

--- a/crates/outl-md/CLAUDE.md
+++ b/crates/outl-md/CLAUDE.md
@@ -173,7 +173,7 @@ tags:: #project
 - `#tag` = tag (page reference with classification semantics).
 - `((blk-XXXXXX))` = inline block reference (renders as the source block's text).
 - `!((blk-XXXXXX))` = block embed (renders source block expanded with subtree).
-- `{{query: ...}}` = saved query (query DSL not yet implemented, parse as opaque for now).
+- `{{query: ...}}` = inline query token (legacy; parsed as opaque text; the ` ```query ` code block is the supported path — see `docs/query.md`).
 
 **No `id::`, no UUID, no HTML comments** — IDs go in the sidecar only.
 

--- a/crates/outl-md/src/lang.rs
+++ b/crates/outl-md/src/lang.rs
@@ -32,6 +32,7 @@ pub const KNOWN_ALIASES: &[(&str, &[&str])] = &[
     ("lua", &["lua"]),
     ("lisp", &["lisp", "cl", "common-lisp", "elisp"]),
     ("echo", &["echo", "text", "txt", "plain"]),
+    ("query", &["query", "tasks"]),
     // Highlight-only (no runtime, but the syntax highlighter on
     // every client should know these so a fence labelled `ts`,
     // `tsx`, `bash`, `yml`, etc. still gets colorized). Listed here

--- a/crates/outl-md/src/matching.rs
+++ b/crates/outl-md/src/matching.rs
@@ -114,15 +114,15 @@ pub fn match_blocks(
     // mint a fresh NodeId + ref_handle, breaking all `((blk-…))` refs
     // and `!((blk-…))` embeds pointing at the edited block.
     //
-    // Both `flat` (new) and `old_blocks` are in DFS preorder, so the
-    // indices align when the tree shape hasn't changed. If blocks were
-    // inserted or deleted, the indices shift and this pass is a no-op
-    // (the `used` guard + indent check prevent false matches).
-    for (i, maybe_id) in found.iter_mut().enumerate() {
-        if maybe_id.is_some() {
-            continue;
-        }
-        if let Some(old) = old_blocks.get(i) {
+    // Only runs when the flat block count matches — if blocks were
+    // inserted or deleted, DFS indices shift and positional matching
+    // would assign the wrong NodeId.
+    if flat.len() == old_blocks.len() {
+        for (i, maybe_id) in found.iter_mut().enumerate() {
+            if maybe_id.is_some() {
+                continue;
+            }
+            let old = &old_blocks[i];
             if !used.contains(&old.id) && old.indent == flat[i].indent {
                 *maybe_id = Some(old.id);
                 used.insert(old.id);

--- a/crates/outl-md/src/matching.rs
+++ b/crates/outl-md/src/matching.rs
@@ -1,17 +1,18 @@
 //! The block-matching algorithm that reconstructs IDs after an external
 //! edit to a `.md` file.
 //!
-//! Today the algorithm implements levels 1 and 3 from `docs/markdown-format.md`:
+//! Today the algorithm implements:
 //!
 //! - **Level 1** — `content_hash` exact match. Preserves the ID.
+//! - **Level 1.5 (positional fallback)** — same DFS index + same indent.
+//!   Preserves the ID when a block's text is edited without structural
+//!   changes. This is what keeps `((blk-…))` refs and `!((blk-…))`
+//!   embeds stable across text edits.
 //! - **Level 3** — no match. New ULID assigned for new blocks; old blocks
 //!   without a match become orphans (caller moves them to `TRASH_ROOT`).
 //!
 //! Level 2 (Levenshtein similarity > 80%) requires retaining the old text
 //! verbatim, which the sidecar doesn't store. It's not yet implemented.
-//! Until then, heavy edits silently lose the block ID — but the block
-//! **never disappears**: it shows up as an orphan and goes through
-//! `outl reconcile`.
 
 use crate::parse::OutlineNode;
 use crate::sidecar::{content_hash, SidecarBlock};
@@ -104,6 +105,30 @@ pub fn match_blocks(
     }
 
     // Pass 2 (reserved for level 2 — similarity-based, not yet implemented).
+
+    // Pass 1.5: positional fallback. For each unmatched new block at
+    // index `i`, if `old_blocks[i]` exists, is unused, and has the
+    // same indent, match them. This preserves the NodeId when a
+    // block's text is edited without structural changes (no blocks
+    // added, removed, or moved). Without this, every text edit would
+    // mint a fresh NodeId + ref_handle, breaking all `((blk-…))` refs
+    // and `!((blk-…))` embeds pointing at the edited block.
+    //
+    // Both `flat` (new) and `old_blocks` are in DFS preorder, so the
+    // indices align when the tree shape hasn't changed. If blocks were
+    // inserted or deleted, the indices shift and this pass is a no-op
+    // (the `used` guard + indent check prevent false matches).
+    for (i, maybe_id) in found.iter_mut().enumerate() {
+        if maybe_id.is_some() {
+            continue;
+        }
+        if let Some(old) = old_blocks.get(i) {
+            if !used.contains(&old.id) && old.indent == flat[i].indent {
+                *maybe_id = Some(old.id);
+                used.insert(old.id);
+            }
+        }
+    }
 
     // Final pass: level 3 for the remainder.
     for (i, maybe_id) in found.iter().enumerate() {
@@ -226,17 +251,47 @@ mod tests {
     }
 
     #[test]
-    fn heavy_edit_loses_id_and_orphans_old() {
-        // Block text completely changed → hash differs → no match.
-        let md = "- totally different content here\n";
+    fn text_edit_preserves_id_via_positional_fallback() {
+        // Block text changed but position (DFS index) and indent are
+        // the same → positional fallback preserves the NodeId.
+        // Without this, every text edit would mint a fresh NodeId,
+        // breaking all ((blk-…)) refs and !((blk-…)) embeds.
+        let md = "- TODO buy groceries\n";
         let new_ast = parse(md);
         let id = NodeId::new();
-        let old = vec![sidecar_block(id, "original wording", 1, 0)];
+        let old = vec![sidecar_block(id, "TODO buy milk", 1, 0)];
 
         let (matches, orphans) = match_blocks(&new_ast.blocks, &old);
         assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].old_id, Some(id));
+        assert!(orphans.is_empty());
+    }
+
+    #[test]
+    fn insert_shift_prevents_false_positional_match() {
+        // Inserting a block before an existing one shifts DFS indices,
+        // so positional fallback can't match the shifted block. The
+        // inserted block gets a new ID (level 3); the existing block
+        // still matches by hash (level 1).
+        let md = "- new block\n- original\n";
+        let new_ast = parse(md);
+        let id = NodeId::new();
+        let old = vec![sidecar_block(id, "original", 1, 0)];
+
+        let (matches, orphans) = match_blocks(&new_ast.blocks, &old);
+        assert_eq!(matches.len(), 2);
+        // new[0] = "new block" — no hash match, positional fallback tries
+        // old[0] = "original" → same indent, but "original" will be hash-
+        // matched to new[1] first, so it's already `used`. Thus new[0]
+        // falls through to level 3.
+        // Actually wait — hash matching happens in pass 1 before
+        // positional fallback. So "original" at new[1] hash-matches
+        // old[0]. Then positional fallback for new[0] finds old[0]
+        // already used → no match → level 3. Correct!
         assert_eq!(matches[0].old_id, None);
         assert_eq!(matches[0].level, MatchLevel::Low);
-        assert_eq!(orphans, vec![id]);
+        assert_eq!(matches[1].old_id, Some(id));
+        assert_eq!(matches[1].level, MatchLevel::High);
+        assert!(orphans.is_empty());
     }
 }

--- a/crates/outl-md/tests/heavy_edit.rs
+++ b/crates/outl-md/tests/heavy_edit.rs
@@ -1,11 +1,12 @@
 //! When a block's text changes substantially, the hash no longer matches
-//! the sidecar entry. The matcher (level 1 + level 3 only today) treats
-//! this as a delete + new block. The orphan must show up — never silent
-//! loss.
+//! the sidecar entry. The positional fallback (pass 1.5) catches this
+//! case when the block is at the same DFS index with the same indent,
+//! preserving the NodeId — so `((blk-…))` refs and `!((blk-…))` embeds
+//! stay stable across edits.
 //!
-//! Level 2 (similarity > 80%) and the warning path in `.outl/orphans.log`
-//! are not yet implemented. Until then this test documents the
-//! conservative-but-safe behavior.
+//! When blocks are inserted or deleted, the DFS indices shift and
+//! positional fallback can't help — the block falls through to level 3
+//! (new ID) and the old ID surfaces as an orphan.
 
 use outl_core::id::NodeId;
 use outl_md::matching::{match_blocks, MatchLevel};
@@ -13,7 +14,7 @@ use outl_md::parse::parse;
 use outl_md::sidecar::{content_hash, derive_ref_handle, SidecarBlock};
 
 #[test]
-fn heavy_edit_orphans_old_id_and_creates_new() {
+fn heavy_edit_preserves_id_via_positional_fallback() {
     let id = NodeId::new();
     let old = vec![SidecarBlock {
         id,
@@ -28,9 +29,12 @@ fn heavy_edit_orphans_old_id_and_creates_new() {
     let (matches, orphans) = match_blocks(&ast.blocks, &old);
 
     assert_eq!(matches.len(), 1);
-    assert_eq!(matches[0].old_id, None);
-    assert_eq!(matches[0].level, MatchLevel::Low);
-    assert_eq!(orphans, vec![id], "the old id must surface as an orphan");
+    assert_eq!(
+        matches[0].old_id,
+        Some(id),
+        "positional fallback must preserve the NodeId on text edit"
+    );
+    assert!(orphans.is_empty(), "no orphan on same-position edit");
 }
 
 #[test]

--- a/crates/outl-mobile/CLAUDE.md
+++ b/crates/outl-mobile/CLAUDE.md
@@ -17,9 +17,16 @@ outl-mobile (this crate)
    │   ├── workspace_open.rs       (boot orchestration over outl_tauri_shared::workspace_open primitives)
    │   ├── workspace_picker.rs     (set_workspace — folder choice + persistence; native picker deferred)
    │   ├── iroh_sync.rs            (wire_iroh_transport — boot the P2P transport, register the bg-sync handle)
-   │   ├── bg_sync.rs              (outl_ios_background_sync FFI — drives a forced sync from the iOS BGProcessingTask)
-   │   ├── plugin_service.rs       (mobile shim: CLIENT id + capability set over outl_tauri_shared::PluginService)
-   │   └── commands/               (thin #[tauri::command] wrappers over outl_tauri_shared::commands)
+   │   ├── bg_sync.rs             (outl_ios_background_sync FFI — drives a forced sync from the iOS BGProcessingTask)
+   │   ├── plugin_service.rs       (PluginService + dedicated plugin thread — Boa Context is !Send, so it can't live in AppState)
+   │   └── commands/               (Tauri command surface — split mirrors outl-desktop)
+   │       ├── mod.rs
+   │       ├── workspace.rs        (workspace_stats, reload_workspace)
+   │       ├── page.rs             (list_all_pages / search_pages / search_persons / outl_emoji_search / open_* / *_day / resolve_ref / legacy compat shims)
+   │       ├── block.rs            (create / edit / toggle_todo / toggle_quote / delete / indent / outdent / move_* / set_collapsed / paste_markdown_at / copy_markdown)
+   │       ├── peers.rs            (outl_peer_list / outl_peer_remove — read/edit <workspace>/.outl/peers.json, no workspace lock)
+   │       ├── plugin.rs           (plugin_list / plugin_run / plugin_sync_hooks — thin shims over PluginService)
+   │       └── exec.rs             (run_code_block — thin shim over outl_actions::exec::run_code_block)
    ├── gen/apple/.../main.mm       (NSMetadataQuery + NSFileCoordinator iCloud watcher)
    └── (frontend in ../src)        (Solid components, Tailwind, Tauri bridge)
 ```
@@ -217,6 +224,8 @@ Plain text routes to `outl_actions::paste_markdown` (`paste_markdown_at`) when `
 Multi-paragraph plain text splits into one block per paragraph; single-paragraph falls through to the browser's default splice.
 
 `create_block` has a **stale-anchor fallback**: if `after_id` is not in the tree (`NotInTree`), the block is appended at the end of the page instead of returning an error (mirrors the desktop fix).
+
+The long-press context menu's "Copy" action calls `copy_markdown` (`commands/block.rs` → `outl_actions::copy_markdown`), serialising the block and its full subtree as clean outl markdown to the iOS clipboard.
 
 ## Code execution (`run_code_block`)
 

--- a/crates/outl-tauri-shared/src/commands/exec.rs
+++ b/crates/outl-tauri-shared/src/commands/exec.rs
@@ -16,11 +16,17 @@
 //! Making this async + `spawn_blocking` to release the mutex earlier is
 //! tracked in the desktop polish backlog.
 
-use outl_actions::{run_code_block as action_run_code_block, ExecOutputDto, RunCodeBlockOutcome};
+use outl_actions::{
+    page_meta as page_meta_action, read_page_outline_with_workspace,
+    run_code_block as action_run_code_block, ExecOutputDto, RunCodeBlockOutcome,
+};
+use outl_exec::{extract_fence, run_block_at_index};
+use outl_md::lang;
 use serde::Serialize;
+use std::collections::HashMap;
 use tracing::warn;
 
-use crate::helpers::{build_page_view, parse_node_id, with_ws_mut};
+use crate::helpers::{build_page_view, parse_node_id, with_ws, with_ws_mut};
 use crate::host::AppHost;
 use crate::state::PageView;
 
@@ -72,4 +78,136 @@ pub fn run_code_block<S: AppHost>(
             view,
         })
     })
+}
+
+/// Wire reply for `run_auto_run_blocks`.
+#[derive(Debug, Clone, Serialize)]
+pub struct AutoRunReply {
+    /// How many blocks were executed.
+    pub ran: usize,
+    /// Refreshed view after running query blocks.
+    pub view: PageView,
+}
+
+/// Resolve a batch of embed handles (`blk-XXXXXX`) to their source
+/// content. Used by the frontend to expand `!((blk-…))` blocks.
+/// Wire reply for `resolve_embeds`.
+#[derive(Debug, Clone, Serialize)]
+pub struct EmbedContent {
+    pub handle: String,
+    pub text: String,
+    pub page_slug: String,
+    /// `"todo"`, `"done"`, or `None` when the block is not a task.
+    pub status: Option<String>,
+}
+
+/// Sweep the current page for blocks whose fence language has
+/// `auto_run() == true` (query blocks) and execute them. Returns the
+/// refreshed [`PageView`].
+pub fn run_auto_run_blocks<S: AppHost>(state: &S, page_id: String) -> Result<AutoRunReply, String> {
+    let root = state.storage_root()?;
+    let page = parse_node_id(&page_id)?;
+    let registry = state.exec_registry();
+
+    let auto_run_langs: Vec<String> = registry
+        .languages()
+        .filter(|lang| registry.get(lang).map(|r| r.auto_run()).unwrap_or(false))
+        .map(String::from)
+        .collect();
+
+    if auto_run_langs.is_empty() {
+        let view = with_ws(state, |ws| {
+            build_page_view(ws, &root, page).map_err(|e| e.to_string())
+        })?;
+        return Ok(AutoRunReply { ran: 0, view });
+    }
+
+    let ran = with_ws_mut(state, |ws| {
+        let meta =
+            page_meta_action(ws, page).ok_or_else(|| format!("page not found: {page_id}"))?;
+        let outline =
+            read_page_outline_with_workspace(&root, &meta, ws).map_err(|e| e.to_string())?;
+
+        let mut targets: Vec<usize> = Vec::new();
+        let mut cursor = 0usize;
+        collect_auto_run_flat_indices(&outline.nodes, &auto_run_langs, &mut cursor, &mut targets);
+
+        let md_path = outl_actions::journal::page_md_path(&root, &meta);
+        let hlc = state.hlc();
+        let mut count = 0usize;
+        for idx in targets {
+            if let Err(e) = run_block_at_index(
+                ws,
+                hlc,
+                &md_path,
+                idx,
+                &registry,
+                Some(&root.join(".outl").join("orphans.log")),
+            ) {
+                warn!("auto-run block {idx} failed: {e}");
+            } else {
+                count += 1;
+            }
+        }
+        Ok(count)
+    })?;
+
+    let view = with_ws(state, |ws| {
+        build_page_view(ws, &root, page).map_err(|e| e.to_string())
+    })?;
+    Ok(AutoRunReply { ran, view })
+}
+
+/// Batch-resolve embed handles to their source content.
+pub fn resolve_embeds<S: AppHost>(
+    state: &S,
+    handles: Vec<String>,
+) -> Result<HashMap<String, EmbedContent>, String> {
+    let root = state.storage_root()?;
+    let index = outl_md::index::WorkspaceIndex::build(&root);
+    let mut result = HashMap::new();
+    for handle in &handles {
+        if let Some(entry) = index.resolve_block_ref(handle) {
+            let (status, text) = split_todo_prefix(&entry.text);
+            result.insert(
+                handle.clone(),
+                EmbedContent {
+                    handle: entry.ref_handle.clone(),
+                    text,
+                    page_slug: entry.source_slug.clone(),
+                    status,
+                },
+            );
+        }
+    }
+    Ok(result)
+}
+
+/// Split `"TODO body"` / `"DONE body"` into `(Some("todo"|"done"), "body")`.
+fn split_todo_prefix(raw: &str) -> (Option<String>, String) {
+    if let Some(rest) = raw.strip_prefix("TODO ") {
+        (Some("todo".into()), rest.into())
+    } else if let Some(rest) = raw.strip_prefix("DONE ") {
+        (Some("done".into()), rest.into())
+    } else {
+        (None, raw.into())
+    }
+}
+
+fn collect_auto_run_flat_indices(
+    blocks: &[outl_actions::OutlineNode],
+    auto_run_langs: &[String],
+    cursor: &mut usize,
+    out: &mut Vec<usize>,
+) {
+    for b in blocks {
+        if let Some(parts) = extract_fence(&b.text) {
+            let canonical = lang::canonical(&parts.language).unwrap_or(&parts.language);
+            if auto_run_langs.iter().any(|l| l == canonical) {
+                out.push(*cursor);
+            }
+        }
+        *cursor += 1;
+        collect_auto_run_flat_indices(&b.children, auto_run_langs, cursor, out);
+    }
 }

--- a/crates/outl-tauri-shared/src/commands/exec.rs
+++ b/crates/outl-tauri-shared/src/commands/exec.rs
@@ -183,15 +183,13 @@ pub fn resolve_embeds<S: AppHost>(
     Ok(result)
 }
 
-/// Split `"TODO body"` / `"DONE body"` into `(Some("todo"|"done"), "body")`.
+/// Split `"TODO body"` / `"DONE body"` into `(Some("todo"|"done"), "body")`,
+/// reusing the canonical `outl_actions::split_todo` so TODO encoding
+/// stays consistent.
 fn split_todo_prefix(raw: &str) -> (Option<String>, String) {
-    if let Some(rest) = raw.strip_prefix("TODO ") {
-        (Some("todo".into()), rest.into())
-    } else if let Some(rest) = raw.strip_prefix("DONE ") {
-        (Some("done".into()), rest.into())
-    } else {
-        (None, raw.into())
-    }
+    let (state, body) = outl_actions::split_todo(raw);
+    let status = state.map(|s| s.as_str().to_lowercase());
+    (status, body.into())
 }
 
 fn collect_auto_run_flat_indices(

--- a/crates/outl-tui/src/actions/exec.rs
+++ b/crates/outl-tui/src/actions/exec.rs
@@ -18,11 +18,17 @@ impl App {
         let idx = self.selected;
         let orphans = self.orphans_log.clone();
 
-        // Commit any in-flight Insert first — otherwise the user's
-        // latest edits aren't on disk yet and the runtime would see
-        // stale source.
         if matches!(self.mode, Mode::Insert { .. }) {
             self.commit_insert();
+        }
+
+        // Skip auto-run runtimes on manual `gx` — they execute
+        // automatically on page load and after every save. Running
+        // them manually provides no additional value.
+        let auto_run_langs = self.collect_auto_run_langs();
+        if self.block_flat_is_auto_run_lang(idx, &auto_run_langs) {
+            self.status = "query blocks auto-run — no manual execution needed".into();
+            return;
         }
 
         match outl_exec::run_block_at_index(
@@ -40,41 +46,35 @@ impl App {
                             format!("ran {} in {}ms", report.language, out.duration.as_millis());
                     }
                     Err(e) => {
-                        // Infrastructure failure (rustc missing, timeout,
-                        // OOM, sandbox couldn't load the wasm). Multi-line
-                        // and detailed — show it in the modal so the
-                        // whole message lands on screen instead of being
-                        // truncated to one row.
                         let title = format!("{} runtime error", report.language);
                         self.show_error(title, format!("{e}"));
                     }
                 }
-                // Reparse — the `.md` now has the result subblock (or
-                // an error message embedded inside it) and we need it
-                // in the in-memory AST.
                 self.load_current();
             }
             Err(e) => {
-                // Couldn't even start: bad block, unknown language,
-                // failed read/write. Same modal treatment.
                 self.show_error("run failed", format!("{e}"));
             }
         }
     }
 
-    /// Run every block on the current page that has an `auto-run::`
-    /// property and whose source has changed since the last execution.
+    /// Run every block on the current page that either:
+    /// - carries an `auto-run::` property (cache-aware), or
+    /// - uses a runtime whose `auto_run()` returns `true` (always
+    ///   re-runs — results depend on workspace state, not the fence
+    ///   body).
     ///
-    /// Called after each `load_current`. Cache-aware via SHA-256 of
-    /// the fence body (vs `source-hash::` stamped on the result
-    /// subblock), so navigating away and back is a no-op when nothing
-    /// changed.
+    /// Called after each `load_current` and after each `save()`.
     pub(crate) fn run_auto_run_blocks(&mut self) {
-        // Collect candidate flat indices upfront so we don't fight
-        // the borrow checker mid-mutation.
+        let auto_run_langs = self.collect_auto_run_langs();
         let mut targets: Vec<usize> = Vec::new();
         let mut cursor = 0usize;
-        collect_auto_run_targets(&self.page.blocks, &mut cursor, &mut targets);
+        collect_auto_run_targets(
+            &self.page.blocks,
+            &auto_run_langs,
+            &mut cursor,
+            &mut targets,
+        );
         if targets.is_empty() {
             return;
         }
@@ -84,42 +84,118 @@ impl App {
         let mut ran = 0usize;
 
         for idx in targets {
-            match outl_exec::run_block_at_index_if_source_changed(
-                &mut self.workspace,
-                &self.hlc,
-                &path,
-                idx,
-                &self.exec_registry,
-                Some(&orphans),
-            ) {
+            // For runtimes with auto_run() == true, bypass the
+            // source-hash cache: query results depend on workspace
+            // state, not the fence body. For blocks with just the
+            // auto-run:: property (no auto_run runtime), keep the
+            // cache so navigation is cheap.
+            let force = self.block_flat_is_auto_run_lang(idx, &auto_run_langs);
+            let result = if force {
+                outl_exec::run_block_at_index(
+                    &mut self.workspace,
+                    &self.hlc,
+                    &path,
+                    idx,
+                    &self.exec_registry,
+                    Some(&orphans),
+                )
+                .map(Some)
+            } else {
+                outl_exec::run_block_at_index_if_source_changed(
+                    &mut self.workspace,
+                    &self.hlc,
+                    &path,
+                    idx,
+                    &self.exec_registry,
+                    Some(&orphans),
+                )
+            };
+            match result {
                 Ok(Some(_report)) => ran += 1,
-                Ok(None) => {} // cache hit; nothing to say
+                Ok(None) => {}
                 Err(e) => {
-                    // Don't show modal during auto-run — the user
-                    // didn't ask for this, surfacing a popup on
-                    // page-open would be jarring. Status line only.
                     self.status = format!("auto-run skipped block {idx}: {e}");
                 }
             }
         }
 
         if ran > 0 {
-            // Reparse so the AST picks up new/updated result subblocks.
             self.load_current_no_autorun();
             self.status = format!("auto-ran {ran} block{}", if ran == 1 { "" } else { "s" });
         }
     }
+
+    /// Build the set of fence languages whose runtime declares
+    /// `auto_run() == true`.
+    fn collect_auto_run_langs(&self) -> Vec<String> {
+        self.exec_registry
+            .languages()
+            .filter(|lang| {
+                self.exec_registry
+                    .get(lang)
+                    .map(|r| r.auto_run())
+                    .unwrap_or(false)
+            })
+            .map(String::from)
+            .collect()
+    }
+
+    /// Check whether the block at `flat_idx` uses a fence language
+    /// whose runtime has `auto_run() == true`.
+    fn block_flat_is_auto_run_lang(&self, flat_idx: usize, langs: &[String]) -> bool {
+        let mut cursor = 0usize;
+        let block = find_block_at_flat(&self.page.blocks, flat_idx, &mut cursor);
+        let Some(b) = block else {
+            return false;
+        };
+        let Some(parts) = outl_exec::extract_fence(&b.text) else {
+            return false;
+        };
+        let canonical = outl_md::lang::canonical(&parts.language).unwrap_or(&parts.language);
+        langs.iter().any(|l| l == canonical)
+    }
 }
 
-/// DFS-preorder walk collecting flat indices of blocks that carry an
-/// `auto-run::` property. Mirrors `block_at_flat_index_mut` in
-/// `outl-exec` so coordinates line up.
-fn collect_auto_run_targets(blocks: &[OutlineNode], cursor: &mut usize, out: &mut Vec<usize>) {
+/// DFS-preorder walk collecting flat indices of blocks that should
+/// auto-run: either they carry the `auto-run::` property, or their
+/// fence language is in `auto_run_langs`.
+fn collect_auto_run_targets(
+    blocks: &[OutlineNode],
+    auto_run_langs: &[String],
+    cursor: &mut usize,
+    out: &mut Vec<usize>,
+) {
     for b in blocks {
-        if b.properties.iter().any(|(k, _)| k == "auto-run") {
+        let has_prop = b.properties.iter().any(|(k, _)| k == "auto-run");
+        let is_auto_lang = if let Some(parts) = outl_exec::extract_fence(&b.text) {
+            let canonical = outl_md::lang::canonical(&parts.language).unwrap_or(&parts.language);
+            auto_run_langs.iter().any(|l| l == canonical)
+        } else {
+            false
+        };
+        if has_prop || is_auto_lang {
             out.push(*cursor);
         }
         *cursor += 1;
-        collect_auto_run_targets(&b.children, cursor, out);
+        collect_auto_run_targets(&b.children, auto_run_langs, cursor, out);
     }
+}
+
+/// Find the block at `target_idx` in DFS preorder. Returns `None` if
+/// out of range.
+fn find_block_at_flat<'a>(
+    blocks: &'a [OutlineNode],
+    target_idx: usize,
+    cursor: &mut usize,
+) -> Option<&'a OutlineNode> {
+    for b in blocks {
+        if *cursor == target_idx {
+            return Some(b);
+        }
+        *cursor += 1;
+        if let Some(found) = find_block_at_flat(&b.children, target_idx, cursor) {
+            return Some(found);
+        }
+    }
+    None
 }

--- a/crates/outl-tui/src/actions/lifecycle/persistence.rs
+++ b/crates/outl-tui/src/actions/lifecycle/persistence.rs
@@ -136,6 +136,9 @@ impl App {
         // mistake our own save for an external edit.
         self.last_mtime = file_mtime(&path);
         self.last_saved_at = Some(std::time::Instant::now());
+        // Re-run query / auto-run blocks — workspace state changed,
+        // so results may be different now.
+        self.run_auto_run_blocks();
         // Post-commit hook: tell the transport new local ops landed.
         // No-op for FileSyncTransport (the file is already on disk and
         // a peer's poller will notice it); IrohSyncTransport gossips

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -34,6 +34,7 @@
 ## Format
 
 * [Markdown dialect](markdown-format.md)
+* [Query code blocks](query.md)
 * [Workspace layout](concepts.md)
 
 ## Under the hood

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -308,6 +308,7 @@ The `doc-keeper` agent runs at the end of a feature to catch what slipped throug
 | Storage trait surface, `JsonlStorage` / `MemoryStorage` test contract | `docs/development.md` § 5 ("What to mock and what not to") + `docs/storage.md` + `outl-core/CLAUDE.md` |
 | New `Action` variant in `outl-shortcuts` / new keybinding / chord rebound | `docs/shortcuts.md` (the row that ships to users) + `outl-shortcuts/src/{action.rs,defaults.rs}` + every client's dispatcher (`outl-tui/src/input/*.rs`, `outl-desktop/src/lib/{shortcuts.ts,action-handlers.ts}`) + `outl-desktop/src/lib/api.ts` (TS mirror of the `Action` union — no codegen) |
 | New helper / DTO promoted into `outl-core` / `outl-md` / `outl-actions` (anything that should be reused across clients) | `docs/shared-primitives.md` + mirror at `.github/copilot-instructions.md` §5.1 |
+| New code-block runtime in `outl-exec`, new fence language, or `OutputFormat`/`auto_run` change | `docs/markdown-format.md` § Query code blocks + `crates/outl-exec/CLAUDE.md` + alias table in `crates/outl-md/src/lang.rs` and TS mirror |
 
 When in doubt: **if a contributor's first 30 minutes with the repo would land them on outdated guidance, update the doc.** That's the bar.
 
@@ -340,6 +341,7 @@ Map of canonical homes (extend as new ones are minted):
 | `outl` CLI subcommands + JSON envelope | [`docs/cli.md`](cli.md) | `outl-cli/CLAUDE.md` |
 | TUI manual (modes, overlays, visual conventions) | [`docs/tui.md`](tui.md) | `outl-tui/CLAUDE.md` |
 | Outl markdown dialect + sidecar spec | [`docs/markdown-format.md`](markdown-format.md) | `outl-md/CLAUDE.md` |
+| Query code block DSL + syntax | [`docs/markdown-format.md`](markdown-format.md) § Query code blocks | `outl-exec/CLAUDE.md` |
 | CRDT algorithm + invariants | [`docs/crdt.md`](crdt.md) | `outl-core/CLAUDE.md` |
 | Storage trait + JSONL backend | [`docs/storage.md`](storage.md) | `outl-core/CLAUDE.md` |
 | Sync model (iCloud / Syncthing / iroh roadmap) | [`docs/sync.md`](sync.md) | `outl-mobile/CLAUDE.md`, `outl-desktop/CLAUDE.md` |

--- a/docs/development.md
+++ b/docs/development.md
@@ -398,6 +398,18 @@ The iCloud peer-file watcher is the canonical pattern: predicate logic lives in 
 
 Always re-read `crates/outl-mobile/CLAUDE.md` § "Peer-file materialisation" before touching `main.mm` or the watcher — that section spells out the iCloud race that two lines of code prevent.
 
+### Add a code-block runtime (`outl-exec`)
+
+1. Add a `lang-<name>` feature in `crates/outl-exec/Cargo.toml`.
+2. Create `crates/outl-exec/src/runtimes/<name>.rs` — one struct + `impl Runtime`.
+   Use `echo.rs` as the simplest template, or `query.rs` for the full pattern (workspace access + embed output + auto-run).
+3. Register in `RuntimeRegistry::with_builtins` behind the feature.
+4. Add aliases to `KNOWN_ALIASES` in `crates/outl-md/src/lang.rs` **and** the TS mirror `crates/outl-frontend-shared/src/highlight/aliases.ts` (same commit — the `doc-sync-guard` hook checks this).
+5. If the runtime returns `OutputFormat::Embeds`, the orchestrator already handles it — no UI change needed.
+6. If the runtime should auto-run, override `auto_run()` to return `true`.
+7. Document the DSL in `docs/markdown-format.md` § Query code blocks (or create a new section for non-query runtimes).
+8. Read `crates/outl-exec/CLAUDE.md` for the full surface and "what this crate does NOT own".
+
 ---
 
 ## 7. Debugging

--- a/docs/markdown-format.md
+++ b/docs/markdown-format.md
@@ -165,7 +165,7 @@ A handful of the common aliases:
 | `md` | `markdown` | |
 | `c++`, `cxx`, `cc`, `cpp` | `cpp` | |
 | `cs`, `c#` | `csharp` | |
-| `clj` | `clojure` | |
+| `query`, `tasks` | `query` | Maps to the `query` runtime — workspace queries as code blocks (see [Query code blocks](#query-code-blocks) below). |
 
 The full table lives in `crates/outl-md/src/lang.rs::KNOWN_ALIASES`; the TS mirror is `crates/outl-frontend-shared/src/highlight/aliases.ts`.
 Add a row in both files in the same commit — the `doc-sync-guard` hook treats this as a shortcut-level change and refuses the edit otherwise.
@@ -182,6 +182,13 @@ The TUI renders fences as monospace text without syntax colouring today; the pla
 [`outl_md::lang::canonical`]: ../crates/outl-md/src/lang.rs
 [`@outl/shared/highlight::canonical`]: ../crates/outl-frontend-shared/src/highlight/aliases.ts
 [hljs-common]: https://github.com/highlightjs/highlight.js/blob/main/src/index.js
+
+#### Query code blocks
+
+A ` ```query ` fence runs a declarative DSL against the workspace and renders matching blocks as **live embed references**.
+Query blocks auto-run on every page load — no `gx` or `auto-run::` needed.
+
+Full syntax reference, examples, and architecture: [Query code blocks](query.md).
 
 ### Block properties
 
@@ -208,7 +215,7 @@ The third line (`- this is a regular child block`) is a real child.
 | `((blk-XXXXXX))` | Block reference — renders as the source block's text, links to it |
 | `!((blk-XXXXXX))` | Block embed — renders the source block expanded with its subtree |
 | `:shortcode:` | GitHub gemoji shortcode — renders as the unicode glyph (`:tada:` → 🎉) |
-| `{{query: ...}}` | Saved query (not yet implemented — parse as opaque) |
+| `{{query: ...}}` | Inline query token (legacy — parsed as opaque; use ` ```query ` code blocks instead, see [Query code blocks](#query-code-blocks) below) |
 | `**bold**`, `*italic*` / `_italic_`, `` `code` `` | Standard CommonMark (underscore emphasis rules apply — see below) |
 
 #### Underscore emphasis and intra-word identifiers

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -121,7 +121,8 @@ A capability the client can't honor lands in a warning, and the plugin still loa
 
 Live capabilities: `op-hook`, `slash-command`, `keybinding`, `config-schema` (read), `toolbar-button`, `ui-render`, and `content-transformer:text` / `:rich`.
 `sync-transport` is core-ready (the host serializes/applies ops through a registered transport) but no client polls it yet.
-A plugin that wants to be a query engine registers a `content-transformer` for the `query` fence language (` ```query `); `{{query}}` inline would need a new markdown token the parser defers, so there is no separate `query-provider` capability.
+A plugin that wants to be a query engine registers a `content-transformer` for the `query` fence language (` ```query `).
+Plugins and JS code blocks can also call `outl.query({ status: "todo", … })` to get structured `QueryHit[]` results — see [Query code blocks → Plugin SDK API](query.md#plugin-sdk-api-outlquery).
 
 ### `permissions[]`
 
@@ -241,7 +242,7 @@ These are typed in `@outl/plugin-sdk` and/or enumerated in the manifest schema s
 |---|---|---|
 | `sync-transport` client polling | **Core live, no client driver** | `ctx.sync.register` works and convergence is tested, but no client calls `push`/`pull` on a timer yet. |
 | `ctx.page.open(slug)` / `ctx.page.today()` | **Not present** | Typed in the SDK; the runtime `ctx.page` exposes only `list`/`create`. |
-| `{{query}}` inline | **Parser defers it** | A fenced ` ```query ` block already works through a `content-transformer`; inline `{{query}}` needs a new markdown token the project defers. |
+| `{{query}}` inline | **Parser defers it** | A fenced ` ```query ` block works natively (auto-run, embeds). Plugins can call `outl.query({ … })` for structured results. Inline `{{query}}` needs a new parser token the project defers. |
 
 `github:` install and `outl plugin init` ship today (see [Plugins → Installing](plugins.md#installing)).
 The remaining tooling roadmap (`outl plugin update`, `.outlpkg` pack, dev hot-reload, a dev console, a config-editing form UI, and discovery / marketplace / signing in the clients) is tracked in [Plugins](plugins.md).

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -226,7 +226,7 @@ Use a free chord like `Ctrl+G` or a two-chord sequence such as `Ctrl+G A`.
 Mobile has no keyboard, so it doesn't apply there.
 **`toolbar-button` is live**: desktop and mobile render a button in the chrome for the plugin's command, and the TUI surfaces that command in its slash menu (a terminal has no chrome bar).
 **`content-transformer` is live** today: `ctx.content.register(lang, fn)` renders a fenced block — `:text` on every read surface (inline in the TUI), `:rich` as HTML in a sandboxed iframe on the GUIs (the TUI drops it).
-A plugin that wants to be a query engine registers a transformer for the `query` fence; there is no separate `query-provider` capability, and inline `{{query}}` waits on a parser token the project defers.
+A plugin that wants to be a query engine registers a transformer for the `query` fence; plugins can also call `outl.query({ … })` from JS code blocks to get structured results (see [Query code blocks → Plugin SDK API](query.md#plugin-sdk-api-outlquery)).
 **`sync-transport` is core-ready**: `ctx.sync.register({ push, pull })` works and convergence is tested, but no client polls the transport on a timer yet — that wiring is roadmap.
 The CLI is headless, so anything visual or chord-driven (`keybinding`, `toolbar-button`, `content-transformer:*`) doesn't apply to it.
 

--- a/docs/query.md
+++ b/docs/query.md
@@ -1,0 +1,214 @@
+# Query code blocks
+
+` ```query ` is a fence language that runs a declarative DSL against the workspace and renders matching blocks as **live embed references** (`!((blk-XXXXXX))`), not copies.
+Toggling a TODO on the original block is reflected everywhere the query result appears.
+
+It solves the "tasks scattered across notes" problem ([issue #139](https://github.com/avelino/outl/issues/139)) without introducing a separate task manager — every block is already a potential task via the `TODO` / `DONE` prefix.
+
+## How it works
+
+1. You write a ` ```query ` fence inside any page.
+2. On page load, the query runtime scans the workspace's block index (`WorkspaceIndex`) — every block in every page and journal.
+3. Blocks matching **all** directives (implicit AND) are collected, sorted, and optionally limited.
+4. Each match is rendered as a child bullet containing `!((blk-XXXXXX))` — an embed reference to the original block.
+5. The result is a **live view**: edit the original block and every query that surfaces it updates on the next run.
+
+Query blocks **auto-run on every page load** — they never need `gx` or the `auto-run::` property.
+Results depend on workspace state, not the fence body, so caching by source-hash would be incorrect.
+
+## Syntax
+
+Each line is a `key: value` directive.
+Lines are implicitly ANDed — a block must match every directive to appear in the results.
+Blank lines and `#`-prefixed comments are ignored.
+
+````markdown
+- ```query
+  # all open tasks tagged #ops, sorted by page
+  status: todo
+  tag: ops
+  sort: page
+  limit: 50
+  ```
+````
+
+### Directives
+
+| Key | Example | Description |
+|-----|---------|-------------|
+| `status` | `status: todo` | Filter by TODO state: `todo` (open tasks), `done` (completed tasks), or `open` (either) |
+| `tag` | `tag: ops` | Block text contains `#ops` (partial match — `#ops/deploy` matches `tag: ops`) |
+| `kind` | `kind: journal` | Hosting page kind: `journal` or `page` |
+| `since` | `since: 7d` | Journal within N days. Units: `d` (days), `w` (weeks), `m` (months) |
+| `text` | `text: deploy` | Substring in block text (case-insensitive) |
+| `sort` | `sort: page, status` | Sort criteria, applied left-to-right. Keys: `page`, `status`, `text` |
+| `limit` | `limit: 50` | Maximum number of results |
+
+## Examples
+
+### All open tasks across the workspace
+
+````markdown
+- ```query
+  status: todo
+  sort: page
+  ```
+````
+
+### Today's open tasks in journals
+
+````markdown
+- ```query
+  status: todo
+  kind: journal
+  since: 1d
+  ```
+````
+
+### Tasks tagged #sprint-planning, grouped by page
+
+````markdown
+- ```query
+  status: open
+  tag: sprint-planning
+  sort: page, status
+  limit: 100
+  ```
+````
+
+### Blocks mentioning "deploy" in the last week
+
+````markdown
+- ```query
+  text: deploy
+  kind: journal
+  since: 7d
+  ```
+````
+
+### All completed tasks
+
+````markdown
+- ```query
+  status: done
+  sort: page
+  ```
+````
+
+## How results render
+
+The query runtime returns `OutputFormat::Embeds`, which tells the orchestrator to render each result as a child bullet with an embed reference instead of dumping stdout text.
+
+The rendered structure under the ` ```query ` block looks like:
+
+```markdown
+- ```query
+  status: todo
+  ```
+  - > **result:** (3 blocks)
+    - !((blk-abcdef))
+    - !((blk-ghijkl))
+    - !((blk-mnopqr))
+```
+
+When the page is opened in the TUI or desktop, each `!((blk-…))` expands to show the original block's text and subtree.
+Because these are embeds — not copies — toggling a TODO on the original block updates the query result on the next page load.
+
+## Architecture
+
+| Component | Location | Role |
+|-----------|----------|------|
+| DSL parser | `crates/outl-exec/src/runtimes/query.rs` (`dsl` module) | Line-by-line `key: value` parse into `Query` struct |
+| Execution engine | `crates/outl-exec/src/runtimes/query.rs` (`engine` module) | Filter + sort + limit against `WorkspaceIndex` |
+| Runtime | `crates/outl-exec/src/runtimes/query.rs` (`QueryRuntime`) | Implements `Runtime`, returns `OutputFormat::Embeds`, `auto_run() == true` |
+| Orchestrator | `crates/outl-exec/src/orchestrate.rs` | Detects `Embeds` format, calls `upsert_result_embeds` |
+| Result rendering | `crates/outl-exec/src/result_block.rs` (`upsert_result_embeds`) | Creates child bullets from stdout lines |
+| Feature flag | `crates/outl-exec/Cargo.toml` (`lang-query`) | On by default in the workspace |
+| Language aliases | `crates/outl-md/src/lang.rs` (`KNOWN_ALIASES`) | `query` and `tasks` both resolve to `query` |
+
+The runtime builds a `WorkspaceIndex` from `ctx.workspace_root` on every execution — no incremental index today.
+For workspaces under ~1000 pages this is sub-second; the per-page op log shards plan ([`docs/sync.md`](sync.md)) will be needed before 10k pages.
+
+## Relationship to `{{query: ...}}`
+
+The inline token `{{query: ...}}` is a **legacy Roam-ism** — the parser treats it as opaque text.
+The ` ```query ` code block supersedes it: it's standard CommonMark (no magic tokens), reuses the existing exec infrastructure, and produces live embeds instead of static text.
+
+There are no plans to implement the inline `{{query: ...}}` DSL.
+If a future need arises, it would be a separate parser token, not a reuse of the code block runtime.
+
+## Extensibility
+
+The DSL is designed to grow without breaking existing queries.
+
+Planned filters (not yet implemented):
+
+| Key | Description |
+|-----|-------------|
+| `prop` | Filter by block property (`prop priority: high`) — requires the block index to expose properties |
+| `page` | Filter by hosting page slug (`page: inbox`) |
+| `group` | Group results by field (`group: page`) |
+
+New filters are `enum Filter` variants in `crates/outl-exec/src/runtimes/query.rs` — one match arm per filter, no parser change needed beyond recognizing the key.
+
+## Plugin SDK API (`outl.query`)
+
+The query engine is also available as a **structured API** inside JS code blocks and plugins.
+Instead of the DSL string, pass a plain object — both paths converge on the same engine.
+
+```js
+// Inside a ```js block or plugin:
+const tasks = outl.query({
+  status: "todo",
+  tag: "ops",
+  sort: "page",
+  limit: 50,
+});
+
+for (const t of tasks) {
+  const mark = t.status === "done" ? "[x]" : "[ ]";
+  console.log(`${mark} ${t.text} — (${t.page})`);
+}
+```
+
+### Parameters
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | `"todo"` \| `"done"` \| `"open"` | Filter by TODO state |
+| `tag` | `string` | Block contains `#tag` (partial match) |
+| `kind` | `"journal"` \| `"page"` | Hosting page kind |
+| `since` | `string` | Duration: `"7d"`, `"2w"`, `"3m"` |
+| `text` | `string` | Substring search (case-insensitive) |
+| `sort` | `string` | Sort key: `"page"`, `"status"`, `"text"` |
+| `limit` | `number` | Max results |
+
+All fields are optional — `outl.query({})` returns every block.
+
+### Result shape
+
+Each hit is an object:
+
+```ts
+interface QueryHit {
+  handle: string;   // "blk-XXXXXX"
+  text: string;     // block text, TODO/DONE prefix stripped
+  status: string | null;  // "todo", "done", or null (not a task)
+  page: string;     // hosting page slug
+}
+```
+
+### Rust API
+
+The same engine is available as `outl_exec::run_query_structured` for code that runs outside the JS runtime:
+
+```rust
+use outl_exec::{QueryParams, run_query_structured};
+
+let params = QueryParams {
+    status: Some("todo".into()),
+    tag: Some("ops".into()),
+    ..Default::default()
+};
+let hits = run_query_structured(&params, &workspace_root)?;
+```

--- a/docs/shared-primitives.md
+++ b/docs/shared-primitives.md
@@ -221,6 +221,20 @@ The **cross-client glue** every UI uses to wire a "run this fence" gesture (TUI 
 The runtime catalog (which languages are available) is selected by the **binary** that consumes this crate, via `outl-exec` features in its own `Cargo.toml`.
 `outl-actions` itself depends on `outl-exec` with `default-features = false` so it doesn't drag `wasmtime` (Rust runtime) into the mobile IPA via the back door.
 
+The `query` runtime (`outl_exec::runtimes::query`) is a special case: it returns `OutputFormat::Embeds` instead of `OutputFormat::Text`, so the orchestrator renders results as live `!((blk-XXXXXX))` embeds rather than a code-fence stdout dump.
+It also overrides `Runtime::auto_run()` to return `true`, so query blocks always re-run on page load without needing the `auto-run::` property or manual `gx`.
+
+The query engine also exposes a **structured API** for plugins and code that runs outside the ` ```query ` fence:
+
+| Intent | Use this | File |
+|---|---|---|
+| Structured query from a `QueryParams` object (plugin-facing) | `outl_exec::run_query_structured` | `crates/outl-exec/src/runtimes/query.rs` |
+| DSL query from a string (user-facing) | `outl_exec::run_query_dsl` | `crates/outl-exec/src/runtimes/query.rs` |
+| Query parameters struct (status, tag, kind, since, text, sort, limit) | `outl_exec::QueryParams` | `crates/outl-exec/src/runtimes/query.rs` |
+| Query result hit (handle, text, status, page) | `outl_exec::QueryHit` | `crates/outl-exec/src/runtimes/query.rs` |
+
+In JS code blocks, the same API is available as `outl.query({ status: "todo", … })`.
+
 ## 14. Sync engine, locks, storage trait
 
 | Intent | Use this | File |


### PR DESCRIPTION
Tasks (TODOs) were scattered across the workspace with no way to aggregate them (#139). The inline syntax `{{query: ...}}` was a magic token coupled to Roam that broke external renderers. And the critical block ID stability bug broke all `((blk-…))`  refs and `!((blk-…))` embeds whenever a block's text was edited.

## What changed


Query code blocks (` ```query `)

* New runtime ( outl-exec/src/runtimes/query.rs ) that runs a declarative DSL against the workspace and returns results
as embed references (`!((blk-XXXXXX))`) — live references, not copies.
* Auto-executes on page load and after every save, without needing  gx  or the `auto-run::` property.
* `gx` on query blocks shows a status nudge instead of executing.
* DSL: `status`, `tag`, `kind`, `since`, `text`, `sort`, `limit` — line-by-line, implicitly ANDed.

Plugin SDK API (`outl.query`)

* Structured API for plugins and JS code blocks: `outl.query({ status: "todo", tag: "ops" })` returns a typed `QueryHit` array.
* Same engine as ` ```query `, two entry points: DSL string (user-facing) and struct object (plugin-facing).
* Available in any ` ```js ` block via `outl.query()`.

Block ID stability fix (`matching.rs`)

* Pass 1.5 (positional fallback): after hash matching, unmatched blocks try to match the old block at the same DFS index with the same indent.
* Preserves the NodeId when text changes without structural changes — no more breaking refs/embeds on text edits.

Desktop wiring

* `run_auto_run_blocks`: Tauri command that sweeps the page, executes query blocks, returns refreshed  PageView .
* `resolve_embeds`: batch-resolve of `blk-XXXXXX` handles with `status` field (`todo/done/null`).
* Frontend renders resolved embeds with a `TODO` checkbox (`☐/✓`) instead of an inert chip.

Exec infrastructure (`outl-exec`)

* `OutputFormat::Embeds`: orchestrator renders stdout as child bullets instead of a code fence.
* `Runtime::auto_run()`: runtimes can declare auto-run without the `auto-run::` property.
* `upsert_result_embeds`: creates child bullets from stdout lines.

fixed: #139 