### PR TITLE
feat: add multi-block batch ops to tui and desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Format inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the
 - **Multi-block batch operations, on the TUI and desktop (issue #23).**
   The TUI's Visual mode (`V`) gains **reorder**: `Alt+↑` / `Alt+↓` drag the whole selection among its siblings (mirror of the single-block `Alt`+arrows in Normal), alongside the existing range delete / indent / outdent / yank.
   On the desktop, multi-select no longer requires vim mode: **`Shift+↓` / `Shift+↑`** start and grow a contiguous block selection from anywhere (the non-vim entry), and a floating **batch toolbar** appears — `N selected` plus Indent, Outdent, Move up, Move down, Delete, and Done — so the range ops are reachable by mouse instead of only by chord.
-  The toolbar fires the **same** `action-handlers` the keyboard does, so button and chord can't drift; deleting a range that contains any block with nested children asks for confirmation first.
+  The toolbar fires the **same** `action-handlers` the keyboard does, so button and chord can't drift; only the toolbar's Delete confirms before erasing a range with nested children (the keyboard delete and the TUI erase without a prompt, matching vim).
   The range reorder (`Cmd/Ctrl+Shift+↑/↓` in Visual) loops the existing per-block move action, walking bottom-up for move-down so a block never drags over its own not-yet-moved neighbour; the selection follows because block ids are stable across the re-render.
   All four new bindings live in the shared `outl-shortcuts` catalog (`SelectRange{Down,Up}`, `MoveVisualRange{Up,Down}`), so a future client inherits them.
 - **Template engine — reusable block structures and callable code blocks (issue #146).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Format inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the
 
 ### Added
 
+- **Multi-block batch operations, on the TUI and desktop (issue #23).**
+  The TUI's Visual mode (`V`) gains **reorder**: `Alt+↑` / `Alt+↓` drag the whole selection among its siblings (mirror of the single-block `Alt`+arrows in Normal), alongside the existing range delete / indent / outdent / yank.
+  On the desktop, multi-select no longer requires vim mode: **`Shift+↓` / `Shift+↑`** start and grow a contiguous block selection from anywhere (the non-vim entry), and a floating **batch toolbar** appears — `N selected` plus Indent, Outdent, Move up, Move down, Delete, and Done — so the range ops are reachable by mouse instead of only by chord.
+  The toolbar fires the **same** `action-handlers` the keyboard does, so button and chord can't drift; deleting a range that contains any block with nested children asks for confirmation first.
+  The range reorder (`Cmd/Ctrl+Shift+↑/↓` in Visual) loops the existing per-block move action, walking bottom-up for move-down so a block never drags over its own not-yet-moved neighbour; the selection follows because block ids are stable across the re-render.
+  All four new bindings live in the shared `outl-shortcuts` catalog (`SelectRange{Down,Up}`, `MoveVisualRange{Up,Down}`), so a future client inherits them.
 - **Template engine — reusable block structures and callable code blocks (issue #146).**
   Any page becomes a template the moment it gets a `template:: <name>` property; the page's outline is the template body, so templates are searchable, have backlinks, and sync like any other page — no special folder, no file-based config.
   Two invocation modes.

--- a/crates/outl-desktop/CLAUDE.md
+++ b/crates/outl-desktop/CLAUDE.md
@@ -254,17 +254,17 @@ This section captures only the **architectural decisions** a contributor needs t
   3. **Pending-input** (`r{ch}`, `f{ch}`, `F{ch}`) — read a second character before applying.
      The dispatcher has no machinery for this today; categorised as char-cursor since they're blocked anyway.
 
-- **Visual mode is real**: `Mode::"vim-visual"` in the store with `visualAnchorId` + `lastVisualRange`.
-  `<BlockRow />`'s `isInVisualRange()` paints the range at 18% accent opacity (distinct from the 6% single-row selection tint).
-  Every Visual exit (`Esc`, `y`, `d`) captures the range to `lastVisualRange` so `g v` can restore it.
+- **Visual mode is real, and reachable without vim (issue #23)**: `Mode::"vim-visual"` in the store with `visualAnchorId` + `lastVisualRange`, painted at 18% accent opacity.
+  `Shift+↓` / `Shift+↑` (`SelectRange{Down,Up}`, bound in **both** Normal and Visual) start or grow the range via the DOM "nothing focused" → Normal fallback, so one machinery serves vim and non-vim.
+  `extendVisualRange` stays in the outline, never crossing into read-only backlinks.
+  Every exit funnels through one `exitVisual()` (captures `lastVisualRange` for `g v`); resting `vim-normal` folds to `normal` in `detectMode` + `StatusBar`.
 
-- **`*` / `#` is not vim-pure.**
-  Without a char cursor, "word under cursor" isn't defined — we seed the picker with the first 4 words of the selected block's text instead.
-  Document this in `docs/shortcuts.md` so users aren't surprised.
+- **`<BatchToolbar />`** (`components/BatchToolbar.tsx`) floats `N selected` + Indent / Outdent / Move ↑↓ / Delete / Done while `mode === "vim-visual"`, firing the **same** `handlers` the keyboard does so button and chord can't drift.
+  Its **Delete** confirms (`window.confirm`) when a selected block has children; keyboard `d` does not (vim convention).
 
-- **Range ops walk bottom-up + tolerate id-already-gone.**
-  `DeleteRange` iterates `[hi → lo]` so children go before parents (a parent's move-to-trash would otherwise pull a still-targeted descendant out from under us).
-  NodeIds are stable (`deleteBlock` is `Move(node, TRASH)`), so the pre-loop id snapshot stays valid; `safeCall` swallows per-id failures (a peer ate the same id, or the range straddled parent + descendants).
+- **Range ops walk bottom-up or top-down via `applyVisualBlockOp`, and tolerate id-already-gone.**
+  `DeleteRange` + `MoveVisualRangeDown` iterate `[hi → lo]` (children before parents; a descending move clears the block below first); `IndentVisualRange` + `MoveVisualRangeUp` walk `[lo → hi]`.
+  NodeIds are stable (`deleteBlock` is `Move(node, TRASH)`, moves preserve identity), so the highlight follows the re-render; `safeCall` swallows per-id failures.
 
 - **`UnfoldAll` / `FoldAll` walk via `flattenAll` / `flattenParents`, never `flattenVisible`.**
   `zR` must expand subtrees hidden under a collapsed parent; a visible-only walk would no-op on every descendant of a folded node.
@@ -273,27 +273,23 @@ This section captures only the **architectural decisions** a contributor needs t
   Mirrors `outl-tui`'s `collect_collapse_candidates` so the op count matches across clients.
 
 - **`A` (`EnterInsertAtEnd`) routes through `appState.caretIntent`.**
-  The handler sets `caretIntent: "end"` *before* `editingBlockId`; `<BlockRow />`'s `createEffect` reads it on mount, applies `setSelectionRange`, clears the signal (poking the textarea via `queueMicrotask` after flipping `editingBlockId` raced).
+  The handler sets `caretIntent: "end"` *before* `editingBlockId`; `<BlockRow />`'s `createEffect` reads it on mount, applies `setSelectionRange`, then clears the signal.
 
 - **Visual highlight uses a memoised `Set<id>` at the parent, not a per-row predicate.**
   `<OutlineView />` builds `visualSet = createMemo(() => visualRangeSet(...))` once per change; `<BlockRow />` answers `props.visualSet?.has(id) ?? false` in O(1).
-  The old per-row `isInVisualRange` (O(N²)/keystroke) survives in `@outl/shared/outline` for unit tests only — **no render path calls it**.
+  The old per-row `isInVisualRange` (O(N²)/keystroke) is kept in `@outl/shared/outline` for tests only.
 
-- **Char-cursor nudge is one shared handler.**
-  All 10 char-cursor catalog entries (`x` `X` `D` `C` `s` `r` `~` `e` `f` `F`) point at `charCursorNudge`, so the message can't drift between them.
+- **Char-cursor nudge is one shared handler:** the 10 char-cursor entries (`x` `X` `D` `C` `s` `r` `~` `e` `f` `F`) all point at `charCursorNudge`, so the message can't drift.
 
-- **`Y` / Visual `y` copy to the OS clipboard** via `copy_markdown` + `navigator.clipboard.writeText` (fills `yankRegister` too; paste-in `p`/`P` deferred).
+- **`Y` / Visual `y` copy to the OS clipboard** via `copy_markdown` + `navigator.clipboard.writeText` (fills `yankRegister`; paste-in `p`/`P` deferred).
 
 - **`NewBlockAbove` (`O`) uses `beforeId`, not a post-creation move walk.**
   `createBlock({ beforeId: anchor })` → `create_before` (floor-slot swap in core); never reintroduce the old create-at-tail + `moveBlockDown`-loop.
   `Cmd/Ctrl+Shift+Enter` is caret-aware in `BlockRow`'s keydown (col 0 → *before*, past col 0 → *below*); `stopImmediatePropagation` preempts the catalog's create-below binding.
 
 - **Block clipboard: view-mode cut/copy/paste of a whole block** (chords: [`docs/shortcuts.md`](../../docs/shortcuts.md)).
-  **Normal**-mode only; `appState.blockClipboard` = `{ kind: "cut", nodeId } | { kind: "copy", markdown }`, no `pageId` (backend resolves the page via `enclosing_page_id`).
+  **Normal**-mode only; `appState.blockClipboard` = `{ kind: "cut", nodeId } | { kind: "copy", markdown }` (backend resolves the page via `enclosing_page_id`).
   Cut is one identity-preserving `Op::Move` (`block::move_after`, cross-page, self-subtree rejected); copy duplicates via `paste_block_after` with fresh ids.
-
-- **Path to enable char-cursor ops.**
-  Add a visible Normal-mode caret in `<BlockRow />`, then move the 10 blocked handlers to real impls (separate PR).
 
 ### `Enter` outside a textarea (Normal mode)
 
@@ -301,9 +297,7 @@ With a block selected and no textarea focused (the DOM fallback puts the dispatc
 `Enter` resolves to the shared `OpenRefUnderCursor` action — but the desktop handler **always enters Insert on the selected block**.
 The one exception: when the selection sits on a **backlink row** (read-only), `Enter` opens the source page and lands the cursor on the referencing block.
 
-Why diverge from the TUI: the TUI has a char cursor so "open the ref under cursor" is well-defined.
-The desktop only has a selected block — approximating it as "first `[[ref]]` in the block" made ref-carrying blocks impossible to edit via `Enter`.
-On the desktop, **following a ref is the click on the token** (`onRefClick`); `Enter` means edit.
+Why diverge from the TUI: the TUI has a char cursor so "open the ref under cursor" is well-defined; the desktop only has a selected block, so **following a ref is the click on the token** (`onRefClick`) and `Enter` means edit.
 
 ### `:shortcode:` emoji autocomplete
 

--- a/crates/outl-desktop/src/components/AppShell.tsx
+++ b/crates/outl-desktop/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { Show, onCleanup, onMount } from "solid-js";
+import { Show, createSignal, onCleanup, onMount } from "solid-js";
 
 import {
   openJournalFor,
@@ -17,9 +17,10 @@ import {
   onWorkspaceReady,
 } from "../lib/events";
 import type { DeepLinkNavigate } from "../lib/events";
-import { installShortcuts } from "../lib/shortcuts";
+import { installShortcuts, type ActionHandlers } from "../lib/shortcuts";
 import { loadTransformers } from "@outl/shared/plugins/transformer-registry";
 import { buildHandlers } from "../lib/action-handlers";
+import { BatchToolbar } from "./BatchToolbar";
 import { Sidebar } from "./Sidebar";
 import { OutlineView } from "./OutlineView";
 import { Picker } from "./Picker";
@@ -44,6 +45,11 @@ import { ErrorToast } from "./ErrorToast";
  * `Cmd/Ctrl+Shift+E` toggles the sidebar.
  */
 export function AppShell() {
+  // The dispatcher's handler map, lifted into a signal so the
+  // `<BatchToolbar />` can fire the very same batch ops the keyboard
+  // does (built in `onMount`, so `null` until the shell wires up).
+  const [handlers, setHandlers] = createSignal<ActionHandlers | null>(null);
+
   function applyView(view: PageView) {
     setAppState({
       page: view.page,
@@ -159,6 +165,7 @@ export function AppShell() {
     }
 
     const handlers = buildHandlers({ applyView, setError });
+    setHandlers(handlers);
     const unbindShortcuts = await installShortcuts(handlers);
     onCleanup(unbindShortcuts);
 
@@ -218,6 +225,9 @@ export function AppShell() {
         <OutlineView />
       </div>
 
+      <Show when={handlers()}>
+        {(h) => <BatchToolbar handlers={h()} />}
+      </Show>
       <ChromeToggleBar />
       <Picker onPicked={applyView} />
       <PluginMarketplace />

--- a/crates/outl-desktop/src/components/BatchToolbar.tsx
+++ b/crates/outl-desktop/src/components/BatchToolbar.tsx
@@ -65,15 +65,15 @@ export function BatchToolbar(props: { handlers: ActionHandlers }) {
           {count()} selected
         </span>
         <span class="mx-1 h-5 w-px bg-(--color-outl-border)" />
-        <BatchButton label="Indent" title="Indent range (Tab)" onClick={run("IndentVisualRange")} />
+        <BatchButton label="Indent" title="Indent range (>)" onClick={run("IndentVisualRange")} />
         <BatchButton
           label="Outdent"
-          title="Outdent range (Shift+Tab)"
+          title="Outdent range (<)"
           onClick={run("OutdentVisualRange")}
         />
         <BatchButton label="↑" title="Move range up (⌘⇧↑)" onClick={run("MoveVisualRangeUp")} />
         <BatchButton label="↓" title="Move range down (⌘⇧↓)" onClick={run("MoveVisualRangeDown")} />
-        <BatchButton label="Delete" title="Delete range (d)" onClick={onDelete} danger />
+        <BatchButton label="Delete" title="Delete range (Delete)" onClick={onDelete} danger />
         <span class="mx-1 h-5 w-px bg-(--color-outl-border)" />
         <BatchButton label="Done" title="Clear selection (Esc)" onClick={run("ExitInsert")} />
       </div>
@@ -91,6 +91,7 @@ function BatchButton(props: {
     <button
       type="button"
       title={props.title}
+      aria-label={props.title}
       onClick={props.onClick}
       class="rounded-md px-2 py-1 text-sm text-(--color-outl-fg) hover:bg-(--color-outl-accent)/[0.12]"
       classList={{

--- a/crates/outl-desktop/src/components/BatchToolbar.tsx
+++ b/crates/outl-desktop/src/components/BatchToolbar.tsx
@@ -1,0 +1,104 @@
+import { Show } from "solid-js";
+
+import type { BlockNode } from "@outl/shared/api/types";
+import { visualRangeSet } from "@outl/shared/outline";
+
+import type { ActionHandlers } from "../lib/shortcuts";
+import { appState } from "../lib/store";
+
+/**
+ * Floating batch-operation toolbar for multi-block selection.
+ *
+ * Appears whenever a contiguous block range is selected — whether the
+ * user reached it via vim's `V` or the non-vim `Shift+↑/↓` entry — so
+ * the batch ops are discoverable without knowing the chords. It fires
+ * the **same** `action-handlers` the keyboard dispatcher does (passed
+ * in as `handlers`), so button and chord can never drift: the range
+ * walking, bottom-up ordering, and `g v` capture all live once in
+ * `action-handlers.ts`.
+ *
+ * Delete confirms first when any selected block has nested children —
+ * a batch delete of collapsed subtrees is the one destructive path a
+ * user can trigger without seeing what they're about to lose.
+ */
+export function BatchToolbar(props: { handlers: ActionHandlers }) {
+  const rangeSet = () =>
+    visualRangeSet(
+      appState.visualAnchorId,
+      appState.selectedBlockId,
+      appState.outline,
+    );
+  const count = () => rangeSet()?.size ?? 0;
+  const active = () => appState.mode === "vim-visual" && count() > 0;
+
+  /** Does any block in the range carry children (a nested subtree the
+   *  batch delete would take with it, possibly hidden behind a fold)? */
+  function anyHasDescendants(): boolean {
+    const set = rangeSet();
+    if (!set) return false;
+    const has = (nodes: BlockNode[]): boolean =>
+      nodes.some(
+        (n) => (set.has(n.id) && n.children.length > 0) || has(n.children),
+      );
+    return has(appState.outline);
+  }
+
+  const run = (kind: keyof ActionHandlers) => () => {
+    void props.handlers[kind]?.();
+  };
+
+  function onDelete() {
+    if (anyHasDescendants()) {
+      const ok = window.confirm(
+        `Delete ${count()} block(s)?\n\n` +
+          `Some of them have nested children that will be deleted too.`,
+      );
+      if (!ok) return;
+    }
+    void props.handlers.DeleteRange?.();
+  }
+
+  return (
+    <Show when={active()}>
+      <div class="fixed top-3 left-1/2 z-30 flex -translate-x-1/2 items-center gap-1 rounded-lg border border-(--color-outl-border) bg-(--color-outl-bg-elev) p-1 shadow-lg">
+        <span class="px-2 text-sm font-medium text-(--color-outl-fg)">
+          {count()} selected
+        </span>
+        <span class="mx-1 h-5 w-px bg-(--color-outl-border)" />
+        <BatchButton label="Indent" title="Indent range (Tab)" onClick={run("IndentVisualRange")} />
+        <BatchButton
+          label="Outdent"
+          title="Outdent range (Shift+Tab)"
+          onClick={run("OutdentVisualRange")}
+        />
+        <BatchButton label="↑" title="Move range up (⌘⇧↑)" onClick={run("MoveVisualRangeUp")} />
+        <BatchButton label="↓" title="Move range down (⌘⇧↓)" onClick={run("MoveVisualRangeDown")} />
+        <BatchButton label="Delete" title="Delete range (d)" onClick={onDelete} danger />
+        <span class="mx-1 h-5 w-px bg-(--color-outl-border)" />
+        <BatchButton label="Done" title="Clear selection (Esc)" onClick={run("ExitInsert")} />
+      </div>
+    </Show>
+  );
+}
+
+function BatchButton(props: {
+  label: string;
+  title: string;
+  onClick: () => void;
+  danger?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      title={props.title}
+      onClick={props.onClick}
+      class="rounded-md px-2 py-1 text-sm text-(--color-outl-fg) hover:bg-(--color-outl-accent)/[0.12]"
+      classList={{
+        "text-(--color-outl-danger) hover:bg-(--color-outl-danger)/[0.12]":
+          props.danger,
+      }}
+    >
+      {props.label}
+    </button>
+  );
+}

--- a/crates/outl-desktop/src/lib/action-handlers.test.ts
+++ b/crates/outl-desktop/src/lib/action-handlers.test.ts
@@ -50,7 +50,10 @@ vi.mock("./api", () => ({
 
 import {
   copyBlockMarkdown,
+  deleteBlock,
   moveBlockAfter,
+  moveBlockDown,
+  moveBlockUp,
   openRef,
   pasteBlockAfter,
 } from "@outl/shared/api/commands";
@@ -314,5 +317,132 @@ describe("block clipboard (cut / copy / paste)", () => {
 
     expect(moveBlockAfter).not.toHaveBeenCalled();
     expect(applyView).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Multi-select batch ops (issue #23).
+ *
+ * The desktop reaches a contiguous block range two ways — vim's `V`
+ * and the non-vim `Shift+↑/↓` entry — and both land in the same
+ * `vim-visual` selection state. These tests pin the non-vim entry
+ * (`SelectRange*`) and the batch reorder (`MoveVisualRange*`) that the
+ * `<BatchToolbar />` and the keyboard both fire.
+ */
+describe("multi-select batch ops (#23)", () => {
+  const applyView = vi.fn();
+  const setError = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setAppState({
+      page: { id: "pg-1", slug: "today", title: "Today", kind: "journal" },
+      outline: [
+        block("blk-a", "a"),
+        block("blk-b", "b"),
+        block("blk-c", "c"),
+        block("blk-d", "d"),
+      ],
+      backlinks: [],
+      selectedBlockId: null,
+      selectedBacklinkBlockId: null,
+      editingBlockId: null,
+      visualAnchorId: null,
+      mode: "normal",
+    });
+  });
+
+  it("Shift+Down (SelectRangeDown) from Normal anchors and extends into Visual", () => {
+    setAppState("selectedBlockId", "blk-b");
+
+    const handlers = buildHandlers({ applyView, setError });
+    handlers.SelectRangeDown?.();
+
+    expect(appState.mode).toBe("vim-visual");
+    expect(appState.visualAnchorId).toBe("blk-b");
+    expect(appState.selectedBlockId).toBe("blk-c");
+  });
+
+  it("a second SelectRangeDown keeps the anchor and grows the range", () => {
+    setAppState("selectedBlockId", "blk-b");
+
+    const handlers = buildHandlers({ applyView, setError });
+    handlers.SelectRangeDown?.();
+    handlers.SelectRangeDown?.();
+
+    expect(appState.visualAnchorId).toBe("blk-b");
+    expect(appState.selectedBlockId).toBe("blk-d");
+  });
+
+  it("SelectRangeUp extends upward without crossing into backlinks", () => {
+    setAppState("selectedBlockId", "blk-c");
+
+    const handlers = buildHandlers({ applyView, setError });
+    handlers.SelectRangeUp?.();
+
+    expect(appState.mode).toBe("vim-visual");
+    expect(appState.visualAnchorId).toBe("blk-c");
+    expect(appState.selectedBlockId).toBe("blk-b");
+  });
+
+  it("MoveVisualRangeUp moves every block in the range top-down", async () => {
+    setAppState({
+      mode: "vim-visual",
+      visualAnchorId: "blk-b",
+      selectedBlockId: "blk-c",
+    });
+
+    const handlers = buildHandlers({ applyView, setError });
+    await handlers.MoveVisualRangeUp?.();
+
+    expect(vi.mocked(moveBlockUp).mock.calls).toEqual([
+      ["pg-1", "blk-b"],
+      ["pg-1", "blk-c"],
+    ]);
+    expect(moveBlockDown).not.toHaveBeenCalled();
+  });
+
+  it("DeleteRange erases every selected line bottom-up and leaves Visual", async () => {
+    vi.mocked(deleteBlock).mockResolvedValue({
+      page: { id: "pg-1", slug: "today", title: "Today", kind: "journal" },
+      outline: [block("blk-a", "a"), block("blk-d", "d")],
+      backlinks: [],
+    });
+    setAppState({
+      mode: "vim-visual",
+      visualAnchorId: "blk-b",
+      selectedBlockId: "blk-c",
+    });
+
+    const handlers = buildHandlers({ applyView, setError });
+    await handlers.DeleteRange?.();
+
+    // Bottom-up so a parent's move-to-trash can't strand a targeted child.
+    expect(vi.mocked(deleteBlock).mock.calls).toEqual([
+      ["pg-1", "blk-c"],
+      ["pg-1", "blk-b"],
+    ]);
+    // Selection lands above the erased range and Visual is cleared.
+    expect(appState.mode).toBe("vim-normal");
+    expect(appState.visualAnchorId).toBeNull();
+    expect(appState.selectedBlockId).toBe("blk-a");
+  });
+
+  it("MoveVisualRangeDown moves every block in the range bottom-up", async () => {
+    setAppState({
+      mode: "vim-visual",
+      visualAnchorId: "blk-b",
+      selectedBlockId: "blk-c",
+    });
+
+    const handlers = buildHandlers({ applyView, setError });
+    await handlers.MoveVisualRangeDown?.();
+
+    // Bottom-up: the last block clears the block below the range first.
+    expect(vi.mocked(moveBlockDown).mock.calls).toEqual([
+      ["pg-1", "blk-c"],
+      ["pg-1", "blk-b"],
+    ]);
+    expect(moveBlockUp).not.toHaveBeenCalled();
   });
 });

--- a/crates/outl-desktop/src/lib/action-handlers.ts
+++ b/crates/outl-desktop/src/lib/action-handlers.ts
@@ -136,11 +136,18 @@ export function buildHandlers(deps: DesktopHandlerDeps): ActionHandlers {
   }
 
   /** Walk every block in the current Visual range and fire `op` for
-   *  each. Used by `>` / `<` so the multi-block indent ops share one
-   *  body. Range stays selected after the op (vim convention) so the
-   *  user can press `>` repeatedly. */
+   *  each. Used by `>` / `<` (indent) and `Cmd/Ctrl+Shift+↑/↓` (move)
+   *  so the multi-block ops share one body. Range stays selected after
+   *  the op (vim convention) so the user can repeat it — the anchor /
+   *  cursor are block ids, stable across the re-render.
+   *
+   *  `reverse` walks bottom-up: a move-**down** has to shift the last
+   *  block past the block below the range first, or an ascending walk
+   *  would drag each block over its own not-yet-moved neighbour. Indent
+   *  / move-up keep the default top-down order. */
   async function applyVisualBlockOp(
     op: (pageId: string, id: string) => Promise<PageView>,
+    reverse = false,
   ) {
     const pageId = appState.page?.id;
     if (!pageId) return;
@@ -153,12 +160,50 @@ export function buildHandlers(deps: DesktopHandlerDeps): ActionHandlers {
     const ids = flattenVisible(appState.outline);
     const loIdx = ids.indexOf(range.lo);
     const hiIdx = ids.indexOf(range.hi);
+    const targets = ids.slice(loIdx, hiIdx + 1);
+    if (reverse) targets.reverse();
     let lastView: PageView | undefined;
-    for (let i = loIdx; i <= hiIdx; i++) {
-      const view = await safeCall(op(pageId, ids[i]));
+    for (const id of targets) {
+      const view = await safeCall(op(pageId, id));
       if (view) lastView = view;
     }
     if (lastView) deps.applyView(lastView);
+  }
+
+  /** Enter (from Normal) or extend (already in Visual) a contiguous
+   *  block selection by one row, `dir` = +1 down / -1 up. The non-vim
+   *  multi-select path: `Shift+↓` / `Shift+↑` anchor at the current
+   *  block and grow the range. Stays inside the outline — unlike plain
+   *  `j` / `k`, it never crosses into the backlinks section, because a
+   *  batch op has nothing to do with a read-only backlink row. */
+  function extendVisualRange(dir: 1 | -1) {
+    if (appState.mode !== "vim-visual") {
+      const id = appState.selectedBlockId;
+      if (!id) return;
+      setAppState("visualAnchorId", id);
+      setAppState("mode", "vim-visual");
+    }
+    const cur = appState.selectedBlockId;
+    if (!cur) return;
+    const next =
+      dir === 1
+        ? nextVisibleId(cur, appState.outline)
+        : previousVisibleId(cur, appState.outline);
+    if (next) setAppState("selectedBlockId", next);
+  }
+
+  /** Capture the current range for `g v`, drop the anchor, and land
+   *  back in Normal. Shared by every Visual exit (`Esc`, `y`, `d`, the
+   *  toolbar's Done). */
+  function exitVisual() {
+    const range = visualRangeIds(
+      appState.visualAnchorId,
+      appState.selectedBlockId,
+      appState.outline,
+    );
+    if (range) setAppState("lastVisualRange", range);
+    setAppState("visualAnchorId", null);
+    setAppState("mode", "vim-normal");
   }
 
   /** Walk every block on the current page and set its `collapsed`
@@ -624,14 +669,7 @@ export function buildHandlers(deps: DesktopHandlerDeps): ActionHandlers {
       // (Visual mode has no focused textarea, so the blur is a no-op
       // anyway; the explicit return keeps the mode flip atomic).
       if (appState.mode === "vim-visual") {
-        const range = visualRangeIds(
-          appState.visualAnchorId,
-          appState.selectedBlockId,
-          appState.outline,
-        );
-        if (range) setAppState("lastVisualRange", range);
-        setAppState("visualAnchorId", null);
-        setAppState("mode", "vim-normal");
+        exitVisual();
         return;
       }
       const el = document.activeElement;
@@ -693,9 +731,7 @@ export function buildHandlers(deps: DesktopHandlerDeps): ActionHandlers {
         if (block) texts.push(block.text);
       }
       setAppState("yankRegister", texts);
-      setAppState("lastVisualRange", range);
-      setAppState("visualAnchorId", null);
-      setAppState("mode", "vim-normal");
+      exitVisual();
       // Copy the whole range as markdown; the backend drops any block
       // whose ancestor is also selected so a parent+child range doesn't
       // duplicate the child.
@@ -737,9 +773,7 @@ export function buildHandlers(deps: DesktopHandlerDeps): ActionHandlers {
       // Land selection on the block above the deleted range, or the
       // first block if the range was at the top.
       const prev = ids[Math.max(loIdx - 1, 0)];
-      setAppState("lastVisualRange", range);
-      setAppState("visualAnchorId", null);
-      setAppState("mode", "vim-normal");
+      exitVisual();
       setAppState("selectedBlockId", prev ?? null);
     },
     IndentVisualRange: async () => {
@@ -747,6 +781,27 @@ export function buildHandlers(deps: DesktopHandlerDeps): ActionHandlers {
     },
     OutdentVisualRange: async () => {
       await applyVisualBlockOp((pageId, id) => outdentBlock(pageId, id));
+    },
+    // `Cmd/Ctrl+Shift+↑` — drag the whole range up among its siblings.
+    // Top-down walk: the first block slides up past the block above the
+    // range, then each following block moves into the slot it vacated.
+    // Selection follows (block ids are stable) so the user can repeat.
+    MoveVisualRangeUp: async () => {
+      await applyVisualBlockOp((pageId, id) => moveBlockUp(pageId, id));
+    },
+    // `Cmd/Ctrl+Shift+↓` — same, downward. Bottom-up walk so the last
+    // block clears the block below the range before its neighbours move.
+    MoveVisualRangeDown: async () => {
+      await applyVisualBlockOp((pageId, id) => moveBlockDown(pageId, id), true);
+    },
+    // `Shift+↓` / `Shift+↑` — start (from Normal) or extend a contiguous
+    // selection. The non-vim multi-select entry; both chords keep
+    // extending once the client is in Visual.
+    SelectRangeDown: () => {
+      extendVisualRange(1);
+    },
+    SelectRangeUp: () => {
+      extendVisualRange(-1);
     },
 
     // ── Fold control over the whole page (zR / zM) ───────────────

--- a/crates/outl-desktop/src/lib/api.ts
+++ b/crates/outl-desktop/src/lib/api.ts
@@ -263,6 +263,10 @@ export type Action =
   | { kind: "YankCurrentBlock" }
   | { kind: "YankRange" }
   | { kind: "DeleteRange" }
+  | { kind: "SelectRangeDown" }
+  | { kind: "SelectRangeUp" }
+  | { kind: "MoveVisualRangeUp" }
+  | { kind: "MoveVisualRangeDown" }
   | { kind: "RunCodeBlock" }
   | { kind: "Undo" }
   | { kind: "Redo" }

--- a/crates/outl-shortcuts/CLAUDE.md
+++ b/crates/outl-shortcuts/CLAUDE.md
@@ -95,8 +95,12 @@ A binding that only the TUI cares about still lives here (with `Mode::Normal` / 
 | `Global` | Always active. Chrome chords (`Cmd+P`, `Cmd+J`, `Cmd+T`, `Cmd+,`). | Every client. |
 | `Normal` | Vim Normal mode — outline navigation (`j`, `k`, `i`, `o`, `dd`). | TUI always; desktop when `vim_mode == true`. |
 | `Insert` | Inside a textarea / EditBuffer. Movement (`Up`, `Down`, `Left`, `Right`), commit (`Esc`), inline-markdown wrappers (`Cmd+B`, `Cmd+I`). | TUI + desktop. |
-| `Visual` | Range selection (vim Visual). | TUI; desktop when `vim_mode == true`. |
+| `Visual` | Range selection (vim Visual). | TUI; desktop via `V` (vim) **or** `Shift+↑/↓` (`SelectRange*`, any mode — issue #23). |
 | `Overlay` | Picker / settings modal / help is open. | TUI + desktop — used to give the overlay its own escape chord without it colliding with `Normal` mode bindings. |
+
+**`SelectRangeDown` / `SelectRangeUp` are the "enter a mode from another mode" example** (issue #23).
+Bound in **both** `Normal` and `Visual`, they start a contiguous selection from Normal — the desktop's non-vim multi-select entry, reached via its DOM "nothing focused" → Normal fallback — and keep extending it once Visual is active.
+`MoveVisualRange{Up,Down}` are Visual-only, mirroring the single-block `MoveBlock{Up,Down}` chords one mode over.
 
 **`Cmd+B` is the canonical "context-dependent chord" example:**
 

--- a/crates/outl-shortcuts/src/action.rs
+++ b/crates/outl-shortcuts/src/action.rs
@@ -179,6 +179,16 @@ pub enum Action {
     YankRange,
     /// Delete the visual range.
     DeleteRange,
+    /// Extend (or start, from Normal mode) the selection one block down.
+    /// The non-vim multi-select entry: `Shift+Down` anchors at the
+    /// current block if no range is active, then grows it downward.
+    SelectRangeDown,
+    /// Extend (or start) the selection one block up (`Shift+Up`).
+    SelectRangeUp,
+    /// Move every block in the Visual range up among its siblings.
+    MoveVisualRangeUp,
+    /// Move every block in the Visual range down among its siblings.
+    MoveVisualRangeDown,
 
     // ── code execution ───────────────────────────────────────────
     /// Run the code block under the cursor through `outl-exec`.

--- a/crates/outl-shortcuts/src/defaults.rs
+++ b/crates/outl-shortcuts/src/defaults.rs
@@ -500,6 +500,23 @@ pub fn default_bindings() -> Vec<Binding> {
             "Copy block ref handle",
         ),
         Binding::new(ch('v'), Normal, Action::EnterVisual, "Enter Visual mode"),
+        // Non-vim multi-select entry: `Shift+↓` / `Shift+↑` start a
+        // contiguous block selection (anchored at the current block)
+        // and grow it. Bound in Normal so the no-vim-mode user reaches
+        // it via the DOM "nothing focused" → Normal fallback; it flips
+        // the client into Visual, where the same chords keep extending.
+        Binding::new(
+            shift(Key::Down),
+            Normal,
+            Action::SelectRangeDown,
+            "Select range down",
+        ),
+        Binding::new(
+            shift(Key::Up),
+            Normal,
+            Action::SelectRangeUp,
+            "Select range up",
+        ),
         Binding::new(ch('u'), Normal, Action::Undo, "Undo"),
         Binding::new(ctrl('r'), Normal, Action::Redo, "Redo"),
         // OS-standard undo / redo chords (desktop). Deliberately
@@ -555,8 +572,67 @@ pub fn default_bindings() -> Vec<Binding> {
         Binding::new(key(Key::Esc), Visual, Action::ExitInsert, "Leave Visual"),
         Binding::new(ch('y'), Visual, Action::YankRange, "Yank range"),
         Binding::new(ch('d'), Visual, Action::DeleteRange, "Delete range"),
+        // `Delete` / `Backspace` delete the range too — the vim-free
+        // way to erase a multi-selection (a non-vim user never reaches
+        // for `d`). The TUI keeps `d` / `x`; these are the desktop's
+        // standard-keyboard spellings of the same batch delete.
+        Binding::new(
+            key(Key::Delete),
+            Visual,
+            Action::DeleteRange,
+            "Delete range (Delete)",
+        ),
+        Binding::new(
+            key(Key::Backspace),
+            Visual,
+            Action::DeleteRange,
+            "Delete range (Backspace)",
+        ),
         Binding::new(ch('j'), Visual, Action::SelectionDown, "Extend down"),
         Binding::new(ch('k'), Visual, Action::SelectionUp, "Extend up"),
+        // `Shift+↓` / `Shift+↑` keep extending once selection mode is
+        // active (the non-vim entry chord stays consistent inside the
+        // range).
+        Binding::new(
+            shift(Key::Down),
+            Visual,
+            Action::SelectRangeDown,
+            "Extend down (Shift+Down)",
+        ),
+        Binding::new(
+            shift(Key::Up),
+            Visual,
+            Action::SelectRangeUp,
+            "Extend up (Shift+Up)",
+        ),
+        // Reorder the whole range among its siblings. Mirrors the
+        // single-block `Cmd/Ctrl+Shift+↑/↓` (Normal) but acts on every
+        // block in the Visual range; dual-spelled per OS because the
+        // desktop adapter never rewrites `Cmd`↔`Ctrl`.
+        Binding::new(
+            shift_meta_key(Key::Up),
+            Visual,
+            Action::MoveVisualRangeUp,
+            "Move range up (Cmd+Shift+Up)",
+        ),
+        Binding::new(
+            shift_ctrl_key(Key::Up),
+            Visual,
+            Action::MoveVisualRangeUp,
+            "Move range up (Ctrl+Shift+Up)",
+        ),
+        Binding::new(
+            shift_meta_key(Key::Down),
+            Visual,
+            Action::MoveVisualRangeDown,
+            "Move range down (Cmd+Shift+Down)",
+        ),
+        Binding::new(
+            shift_ctrl_key(Key::Down),
+            Visual,
+            Action::MoveVisualRangeDown,
+            "Move range down (Ctrl+Shift+Down)",
+        ),
         // ── Overlay (picker / palette have their own keys; arrow + Enter + Esc) ──
         Binding::new(key(Key::Esc), Overlay, Action::ExitInsert, "Close overlay"),
         Binding::new(

--- a/crates/outl-tui/CLAUDE.md
+++ b/crates/outl-tui/CLAUDE.md
@@ -78,6 +78,9 @@ This section captures only the **architectural / TUI-specific behaviour** a cont
 - **Sidebar intercept.** With the sidebar open (`\` / `Ctrl+E`), `j` / `k` move the row selection, `Tab` cycles the section (Today / Pinned / Recent / Calendar), and `Enter` opens the focused page. `d` on a **regular page** arms a `delete page '<title>'? y/n` confirmation in the status line (`App::pending_sidebar_delete: Option<PendingSidebarDelete>`); `y` / `Y` confirms and runs `outl_actions::delete_page` + `remove_page_projection` + `spawn_index_rebuild`, navigates to today if the deleted page was current, and announces to peers. Any other key cancels (and is swallowed, matching the `pending_input_op` contract). Calendar rows are a no-op, and journals pinned/recent are excluded — only regular pages can be deleted from the sidebar. The `g d` chord (Normal mode) routes through the same confirmation flow via `App::delete_page_from_chord`: with the sidebar focused it delegates to `sidebar_delete_current`, otherwise it arms the confirmation against the current page (refusing journals).
 - **Visual range capture.**
   Every Visual exit (`Esc`, `y`, `d`) routes through `remember_visual_range` so `g v` can restore the last range.
+- **Visual range reorder (`Alt+↑` / `Alt+↓`).**
+  `move_{up,down}_visual_range` drag the whole selection among its siblings — mirror of the single-block `Alt`+arrows in Normal (the plain arrows extend the range, so `Alt` is what separates reorder from grow).
+  They loop `move_{up,down}_at_path` (`lo→hi` for up, `hi→lo` for down) and follow the selection one row; if the leading block can't move (already first/last sibling) the op aborts before the rest of the range scrambles against itself.
 
 ## Insert mode
 

--- a/crates/outl-tui/src/actions/visual.rs
+++ b/crates/outl-tui/src/actions/visual.rs
@@ -2,7 +2,7 @@
 //! user can act on N blocks at once (delete, indent, outdent).
 
 use crate::outline_ops::{
-    delete_at_path, flat_count, indent_at_path, move_down_at_path, move_up_at_path,
+    delete_at_path, flat_count, indent_at_path, move_down_at_path, move_up_at_path, node_at_path,
     outdent_at_path, path_for_index,
 };
 use crate::state::{App, Mode};
@@ -115,65 +115,80 @@ impl App {
         self.save();
     }
 
+    /// Does the block at `path` have a sibling after it? Used to detect
+    /// a blocked range reorder before paying for a snapshot + save.
+    fn has_next_sibling(&self, path: &[usize]) -> bool {
+        let Some((&last, parent)) = path.split_last() else {
+            return false;
+        };
+        let siblings = if parent.is_empty() {
+            &self.page.blocks
+        } else {
+            match node_at_path(&self.page.blocks, parent) {
+                Some(node) => &node.children,
+                None => return false,
+            }
+        };
+        last + 1 < siblings.len()
+    }
+
     /// Move every block in the Visual range up among its siblings,
     /// keeping the range selected so the user can repeat. Ascending
     /// order: the top block slides up past the block above the range,
     /// then each following block moves into the slot the previous one
-    /// vacated, so the whole range shifts up by one. If the top block
-    /// can't move (it's already the first sibling) the op aborts before
-    /// the rest of the range scrambles against each other.
+    /// vacated, so the whole range shifts up by one.
     pub(crate) fn move_up_visual_range(&mut self) {
         let Some((lo, hi)) = self.visual_range() else {
             return;
         };
+        // Bail before the expensive snapshot + save when the leading
+        // block is already the first sibling: the whole range is blocked,
+        // and `Alt+↑` at the top edge shouldn't churn undo/redo or disk.
+        let Some(lead) = path_for_index(&self.page.blocks, lo) else {
+            return;
+        };
+        if lead.last() == Some(&0) {
+            return;
+        }
         self.snapshot_for_undo();
-        let mut moved = false;
         for idx in lo..=hi {
-            let Some(path) = path_for_index(&self.page.blocks, idx) else {
-                continue;
-            };
-            if move_up_at_path(&mut self.page.blocks, &path).is_some() {
-                moved = true;
-            } else if idx == lo {
-                break;
+            if let Some(path) = path_for_index(&self.page.blocks, idx) {
+                let _ = move_up_at_path(&mut self.page.blocks, &path);
             }
         }
-        if moved {
-            self.mode = Mode::Visual {
-                anchor: lo.saturating_sub(1),
-            };
-            self.selected = hi.saturating_sub(1);
-        }
+        self.mode = Mode::Visual {
+            anchor: lo.saturating_sub(1),
+        };
+        self.selected = hi.saturating_sub(1);
         self.save();
     }
 
     /// Move every block in the Visual range down among its siblings.
     /// Descending order (mirror of `move_up_visual_range`): the bottom
-    /// block slides down past the block below the range first. Aborts
-    /// if the bottom block is already the last sibling.
+    /// block slides down past the block below the range first.
     pub(crate) fn move_down_visual_range(&mut self) {
         let Some((lo, hi)) = self.visual_range() else {
             return;
         };
+        // Same no-op guard as `move_up`, on the trailing edge: if the
+        // bottom block is already the last sibling the range can't move.
+        let Some(trail) = path_for_index(&self.page.blocks, hi) else {
+            return;
+        };
+        if !self.has_next_sibling(&trail) {
+            return;
+        }
         self.snapshot_for_undo();
-        let mut moved = false;
         for idx in (lo..=hi).rev() {
-            let Some(path) = path_for_index(&self.page.blocks, idx) else {
-                continue;
-            };
-            if move_down_at_path(&mut self.page.blocks, &path).is_some() {
-                moved = true;
-            } else if idx == hi {
-                break;
+            if let Some(path) = path_for_index(&self.page.blocks, idx) {
+                let _ = move_down_at_path(&mut self.page.blocks, &path);
             }
         }
-        if moved {
-            let max_idx = flat_count(&self.page.blocks).saturating_sub(1);
-            self.mode = Mode::Visual {
-                anchor: (lo + 1).min(max_idx),
-            };
-            self.selected = (hi + 1).min(max_idx);
-        }
+        let max_idx = flat_count(&self.page.blocks).saturating_sub(1);
+        self.mode = Mode::Visual {
+            anchor: (lo + 1).min(max_idx),
+        };
+        self.selected = (hi + 1).min(max_idx);
         self.save();
     }
 }
@@ -246,6 +261,8 @@ mod tests {
         app.move_up_visual_range();
         assert_eq!(texts(&app), ["a", "b", "c", "d"]);
         assert_eq!(app.visual_range(), Some((0, 1)));
+        // The no-op bails before snapshotting, so it never churns undo.
+        assert!(app.undo.is_empty());
     }
 
     #[test]
@@ -254,5 +271,6 @@ mod tests {
         app.move_down_visual_range();
         assert_eq!(texts(&app), ["a", "b", "c", "d"]);
         assert_eq!(app.visual_range(), Some((2, 3)));
+        assert!(app.undo.is_empty());
     }
 }

--- a/crates/outl-tui/src/actions/visual.rs
+++ b/crates/outl-tui/src/actions/visual.rs
@@ -2,7 +2,8 @@
 //! user can act on N blocks at once (delete, indent, outdent).
 
 use crate::outline_ops::{
-    delete_at_path, flat_count, indent_at_path, outdent_at_path, path_for_index,
+    delete_at_path, flat_count, indent_at_path, move_down_at_path, move_up_at_path,
+    outdent_at_path, path_for_index,
 };
 use crate::state::{App, Mode};
 
@@ -112,5 +113,146 @@ impl App {
             }
         }
         self.save();
+    }
+
+    /// Move every block in the Visual range up among its siblings,
+    /// keeping the range selected so the user can repeat. Ascending
+    /// order: the top block slides up past the block above the range,
+    /// then each following block moves into the slot the previous one
+    /// vacated, so the whole range shifts up by one. If the top block
+    /// can't move (it's already the first sibling) the op aborts before
+    /// the rest of the range scrambles against each other.
+    pub(crate) fn move_up_visual_range(&mut self) {
+        let Some((lo, hi)) = self.visual_range() else {
+            return;
+        };
+        self.snapshot_for_undo();
+        let mut moved = false;
+        for idx in lo..=hi {
+            let Some(path) = path_for_index(&self.page.blocks, idx) else {
+                continue;
+            };
+            if move_up_at_path(&mut self.page.blocks, &path).is_some() {
+                moved = true;
+            } else if idx == lo {
+                break;
+            }
+        }
+        if moved {
+            self.mode = Mode::Visual {
+                anchor: lo.saturating_sub(1),
+            };
+            self.selected = hi.saturating_sub(1);
+        }
+        self.save();
+    }
+
+    /// Move every block in the Visual range down among its siblings.
+    /// Descending order (mirror of `move_up_visual_range`): the bottom
+    /// block slides down past the block below the range first. Aborts
+    /// if the bottom block is already the last sibling.
+    pub(crate) fn move_down_visual_range(&mut self) {
+        let Some((lo, hi)) = self.visual_range() else {
+            return;
+        };
+        self.snapshot_for_undo();
+        let mut moved = false;
+        for idx in (lo..=hi).rev() {
+            let Some(path) = path_for_index(&self.page.blocks, idx) else {
+                continue;
+            };
+            if move_down_at_path(&mut self.page.blocks, &path).is_some() {
+                moved = true;
+            } else if idx == hi {
+                break;
+            }
+        }
+        if moved {
+            let max_idx = flat_count(&self.page.blocks).saturating_sub(1);
+            self.mode = Mode::Visual {
+                anchor: (lo + 1).min(max_idx),
+            };
+            self.selected = (hi + 1).min(max_idx);
+        }
+        self.save();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use outl_core::id::ActorId;
+    use outl_core::workspace::Workspace;
+    use outl_md::parse::OutlineNode;
+    use tempfile::TempDir;
+
+    fn leaf(text: &str) -> OutlineNode {
+        OutlineNode {
+            text: text.into(),
+            ..Default::default()
+        }
+    }
+
+    /// App seeded with four top-level sibling blocks (a, b, c, d) and a
+    /// Visual range over `anchor..=selected`.
+    fn app_with_range(anchor: usize, selected: usize) -> (App, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let actor = ActorId::new();
+        let ws = Workspace::open_in_memory(actor).unwrap();
+        let mut app = App::new(
+            dir.path().to_path_buf(),
+            ws,
+            actor,
+            crate::theme::default_theme(),
+            false,
+            outl_config::SyncConfig::default(),
+        )
+        .unwrap();
+        app.page.blocks = vec![leaf("a"), leaf("b"), leaf("c"), leaf("d")];
+        app.flat_len = 4;
+        app.selected = selected;
+        app.mode = Mode::Visual { anchor };
+        (app, dir)
+    }
+
+    fn texts(app: &App) -> Vec<String> {
+        app.page.blocks.iter().map(|b| b.text.clone()).collect()
+    }
+
+    #[test]
+    fn move_up_slides_the_whole_range_past_the_block_above() {
+        // Range {b, c}; the block above (a) drops below the range.
+        let (mut app, _dir) = app_with_range(1, 2);
+        app.move_up_visual_range();
+        assert_eq!(texts(&app), ["b", "c", "a", "d"]);
+        // Selection follows the range up one row.
+        assert_eq!(app.visual_range(), Some((0, 1)));
+    }
+
+    #[test]
+    fn move_down_slides_the_whole_range_past_the_block_below() {
+        // Range {b, c}; the block below (d) rises above the range.
+        let (mut app, _dir) = app_with_range(1, 2);
+        app.move_down_visual_range();
+        assert_eq!(texts(&app), ["a", "d", "b", "c"]);
+        assert_eq!(app.visual_range(), Some((2, 3)));
+    }
+
+    #[test]
+    fn move_up_is_a_no_op_when_the_range_is_already_at_the_top() {
+        // Range {a, b}; nothing above to slide past — order + selection
+        // stay put rather than scrambling the range against itself.
+        let (mut app, _dir) = app_with_range(0, 1);
+        app.move_up_visual_range();
+        assert_eq!(texts(&app), ["a", "b", "c", "d"]);
+        assert_eq!(app.visual_range(), Some((0, 1)));
+    }
+
+    #[test]
+    fn move_down_is_a_no_op_when_the_range_is_already_at_the_bottom() {
+        let (mut app, _dir) = app_with_range(2, 3);
+        app.move_down_visual_range();
+        assert_eq!(texts(&app), ["a", "b", "c", "d"]);
+        assert_eq!(app.visual_range(), Some((2, 3)));
     }
 }

--- a/crates/outl-tui/src/input/visual.rs
+++ b/crates/outl-tui/src/input/visual.rs
@@ -6,7 +6,7 @@
 
 use crate::state::App;
 use anyhow::Result;
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 pub(crate) fn handle_visual_key(app: &mut App, key: KeyEvent) -> Result<()> {
     match key.code {
@@ -21,6 +21,12 @@ pub(crate) fn handle_visual_key(app: &mut App, key: KeyEvent) -> Result<()> {
         // without losing the `Tab` discoverability.
         KeyCode::Tab | KeyCode::Char('>') => app.indent_visual_range(),
         KeyCode::BackTab | KeyCode::Char('<') => app.outdent_visual_range(),
+        // `Alt`+arrows drag the whole range among its siblings —
+        // mirrors the single-block `Alt`+arrows in Normal mode. The
+        // plain arrows below extend the selection, so `Alt` is what
+        // separates "reorder the range" from "grow the range".
+        KeyCode::Up if key.modifiers.contains(KeyModifiers::ALT) => app.move_up_visual_range(),
+        KeyCode::Down if key.modifiers.contains(KeyModifiers::ALT) => app.move_down_visual_range(),
         KeyCode::Down | KeyCode::Char('j') => app.move_selection(1),
         KeyCode::Up | KeyCode::Char('k') => app.move_selection(-1),
         _ => {}

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -179,14 +179,14 @@ TUI + desktop; mobile has no Visual equivalent yet.
 
 On the desktop, `Shift+↑` / `Shift+↓` start (and keep growing) a contiguous selection **without** vim mode — the non-vim multi-select entry.
 It flips the client into Visual and pops a floating **batch toolbar** (`N selected` + Indent / Outdent / Move up / Move down / Delete / Done) so the range ops are reachable by mouse; the toolbar fires the same actions the chords do.
-Deleting a range that contains any block with nested children asks for confirmation first.
+Only the toolbar's **Delete** confirms before erasing a range that contains nested children; the keyboard delete (`d` / `x` / `Delete` / `Backspace`) and the TUI delete without a prompt, matching vim.
 
 | Action | TUI | Desktop |
 |---|---|---|
 | Start / extend selection down | `j` / `↓` | `Shift+↓` (any mode) · `j` / `↓` (vim) |
 | Start / extend selection up | `k` / `↑` | `Shift+↑` (any mode) · `k` / `↑` (vim) |
 | Yank range | `y` | `y` |
-| Delete range (confirms if any block has children) | `d` / `x` | `d` / `x` · `Delete` / `Backspace` · toolbar **Delete** |
+| Delete range (toolbar **Delete** confirms if a block has children; the keys don't) | `d` / `x` | `d` / `x` · `Delete` / `Backspace` · toolbar **Delete** |
 | Indent range (vim `>`) | `Tab` / `>` | `>` · toolbar **Indent** |
 | Outdent range (vim `<`) | `Shift+Tab` / `<` | `<` · toolbar **Outdent** |
 | Move range up among siblings | `Alt+↑` | `Cmd/Ctrl+Shift+↑` · toolbar **↑** |

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -175,17 +175,23 @@ The TUI ships it natively; the desktop has only a selected block id, so the char
 
 ## Visual mode (range)
 
-TUI + desktop (vim on); mobile has no Visual equivalent yet.
+TUI + desktop; mobile has no Visual equivalent yet.
+
+On the desktop, `Shift+↑` / `Shift+↓` start (and keep growing) a contiguous selection **without** vim mode — the non-vim multi-select entry.
+It flips the client into Visual and pops a floating **batch toolbar** (`N selected` + Indent / Outdent / Move up / Move down / Delete / Done) so the range ops are reachable by mouse; the toolbar fires the same actions the chords do.
+Deleting a range that contains any block with nested children asks for confirmation first.
 
 | Action | TUI | Desktop |
 |---|---|---|
-| Extend selection down | `j` / `↓` | `j` / `↓` |
-| Extend selection up | `k` / `↑` | `k` / `↑` |
+| Start / extend selection down | `j` / `↓` | `Shift+↓` (any mode) · `j` / `↓` (vim) |
+| Start / extend selection up | `k` / `↑` | `Shift+↑` (any mode) · `k` / `↑` (vim) |
 | Yank range | `y` | `y` |
-| Delete range | `d` / `x` | `d` / `x` |
-| Indent range (vim `>`) | `Tab` / `>` | `>` |
-| Outdent range (vim `<`) | `Shift+Tab` / `<` | `<` |
-| Leave Visual (captures range so a follow-up `g v` restores it) | `Esc` | `Esc` |
+| Delete range (confirms if any block has children) | `d` / `x` | `d` / `x` · `Delete` / `Backspace` · toolbar **Delete** |
+| Indent range (vim `>`) | `Tab` / `>` | `>` · toolbar **Indent** |
+| Outdent range (vim `<`) | `Shift+Tab` / `<` | `<` · toolbar **Outdent** |
+| Move range up among siblings | `Alt+↑` | `Cmd/Ctrl+Shift+↑` · toolbar **↑** |
+| Move range down among siblings | `Alt+↓` | `Cmd/Ctrl+Shift+↓` · toolbar **↓** |
+| Leave Visual (captures range so a follow-up `g v` restores it) | `Esc` | `Esc` · toolbar **Done** |
 
 ---
 


### PR DESCRIPTION
The TUI's Visual mode could delete, indent, and outdent a range but not reorder it, and on the desktop every batch edit needed vim mode plus the vim chords. A non-vim user had no way to act on more than one block at once

The TUI now reorders a selection with Alt+arrows. The desktop enters multi-select without vim via Shift+arrows and shows a floating toolbar (indent, outdent, move up/down, delete) so the ops are reachable by mouse. Delete and Backspace erase the selected lines. The four new actions live in the shared outl-shortcuts catalog, so a future client inherits them

Fixes #23 