### PR TITLE
perf: make page backlinks O(n) instead of O(n²)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ Format inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the
 
 ### Fixed
 
-- **Opening a page with many backlinks is no longer slow (issue #169).**
+- **Opening a page with many backlinks is much faster (issue #169).**
   A user with a template referenced from 760 places reported multi-second page opens.
   The cause was `backlinks_for_page` being **quadratic**: it walks every block in the workspace and, per match, materializes the block's subtree — and both steps went through `children_of`, which rescans *every* node in the tree on each call (`Tree` stores only `node -> (parent, position)`, with no child index).
-  The walk now builds a `parent -> children` map in a single `O(n)` pass and threads it through the walk and the subtree projection, restoring `O(n)`.
-  In simulation (`crates/outl-actions/tests/bench_backlinks.rs`) the report's shape — 760 backlinks in a ~35k-block workspace — drops from **3.83 s to 41 ms** (~94×), with **no change to results** (the full backlinks test suite is the correctness oracle).
+  The walk now builds a `parent -> children` map once per call (one scan + per-parent sort; `O(n log n)` worst case) and threads it through the walk and subtree projection, eliminating the `O(n²)` rescans.
+  This still does a full workspace walk (no inverted index), but the report's shape — 760 backlinks in a ~35k-block workspace — drops from **3.83 s to 41 ms** (~94×), with **no change to results** (the full backlinks test suite is the correctness oracle).
   This is a pure internal refactor: `backlinks_for_page` / `project_outline` / `project_outline_node` keep their signatures and output; the index is scratch state rebuilt per call, never cached, so it can't go stale.
 
 - **Snapshot fast-boot now actually works in production, and can no longer drop a synced edit (issues #156, #128, #109).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Format inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the
 
 ### Fixed
 
+- **Opening a page with many backlinks is no longer slow (issue #169).**
+  A user with a template referenced from 760 places reported multi-second page opens.
+  The cause was `backlinks_for_page` being **quadratic**: it walks every block in the workspace and, per match, materializes the block's subtree — and both steps went through `children_of`, which rescans *every* node in the tree on each call (`Tree` stores only `node -> (parent, position)`, with no child index).
+  The walk now builds a `parent -> children` map in a single `O(n)` pass and threads it through the walk and the subtree projection, restoring `O(n)`.
+  In simulation (`crates/outl-actions/tests/bench_backlinks.rs`) the report's shape — 760 backlinks in a ~35k-block workspace — drops from **3.83 s to 41 ms** (~94×), with **no change to results** (the full backlinks test suite is the correctness oracle).
+  This is a pure internal refactor: `backlinks_for_page` / `project_outline` / `project_outline_node` keep their signatures and output; the index is scratch state rebuilt per call, never cached, so it can't go stale.
+
 - **Snapshot fast-boot now actually works in production, and can no longer drop a synced edit (issues #156, #128, #109).**
   The materialized-state snapshot that short-circuits full op-log replay on open was **inert in production**: the workspace wrote it to `<root>/.outl/snapshots` while the storage backend read it from `<root>/snapshots` (it derived the path from `ops_dir.parent()`, but production keeps the op log at `<root>/ops`, not `<root>/.outl/ops`).
   Writer and reader never met, so every boot silently fell back to a full replay — every existing test passed only because tests use `<root>/.outl/ops`, which makes the two paths coincide.

--- a/crates/outl-actions/src/backlinks.rs
+++ b/crates/outl-actions/src/backlinks.rs
@@ -15,17 +15,18 @@
 //! backlinks cache — that earlier duplication was the bug that made
 //! self-references invisible on one surface but not the other.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use outl_core::fractional::Fractional;
 use outl_core::id::NodeId;
 use outl_core::workspace::Workspace;
 use serde::{Serialize, Serializer};
 
 use crate::journal::page_md_path;
-use crate::outline::{project_outline_node, OutlineNode};
+use crate::outline::{project_outline_node_indexed, ChildrenIndex, OutlineNode};
 use crate::page::{page_meta, PageMeta};
 use crate::todo::{split_todo, TodoState};
-use crate::tree::children_of;
 
 /// One backlink reference from a source block to a target page.
 ///
@@ -100,13 +101,50 @@ where
 /// its `source_path` (the `.md` of the page the source block lives
 /// in).
 pub fn backlinks_for_target(workspace: &Workspace, root: &Path, target: &str) -> Vec<Backlink> {
-    collect_backlinks(workspace, root, &TargetMatcher::refs(target))
+    let index = build_children_index(workspace);
+    collect_backlinks(workspace, root, &TargetMatcher::refs(target), &index)
+}
+
+/// Build a `parent -> children (in fractional order)` map in a single
+/// `O(n)` pass over the tree.
+///
+/// The walk visits every block in the workspace and, for each match,
+/// materialises its subtree. Both steps used to go through
+/// [`children_of`], which **rescans every node** on each call (`Tree`
+/// stores only `node -> (parent, position)`, with no child index) —
+/// making the whole pass `O(n²)`. Building this map once and threading
+/// it through the walk + [`project_outline_node_indexed`] brings it back
+/// to `O(n)`. Rebuilt per `backlinks_for_page` call, so it never goes
+/// stale: it is a scratch accelerator, not cached state.
+fn build_children_index(workspace: &Workspace) -> ChildrenIndex {
+    let mut grouped: HashMap<NodeId, Vec<(NodeId, Fractional)>> = HashMap::new();
+    for (id, parent, pos) in workspace.tree().iter_nodes() {
+        grouped.entry(parent).or_default().push((id, pos.clone()));
+    }
+    grouped
+        .into_iter()
+        .map(|(parent, mut kids)| {
+            kids.sort_by(|a, b| a.1.cmp(&b.1));
+            (parent, kids.into_iter().map(|(id, _)| id).collect())
+        })
+        .collect()
 }
 
 /// Walk every page's blocks and collect the ones `matcher` accepts.
-fn collect_backlinks(workspace: &Workspace, root: &Path, matcher: &TargetMatcher) -> Vec<Backlink> {
+/// `index` is the shared `parent -> children` map (see
+/// [`build_children_index`]); pages are the children of
+/// [`NodeId::root`].
+fn collect_backlinks(
+    workspace: &Workspace,
+    root: &Path,
+    matcher: &TargetMatcher,
+    index: &ChildrenIndex,
+) -> Vec<Backlink> {
     let mut out: Vec<Backlink> = Vec::new();
-    for (page_id, _) in children_of(workspace, NodeId::root()) {
+    let Some(pages) = index.get(&NodeId::root()) else {
+        return out;
+    };
+    for &page_id in pages {
         let Some(meta) = page_meta(workspace, page_id) else {
             continue;
         };
@@ -120,6 +158,7 @@ fn collect_backlinks(workspace: &Workspace, root: &Path, matcher: &TargetMatcher
             &mut path,
             matcher,
             &mut out,
+            index,
         );
     }
     out
@@ -224,34 +263,35 @@ fn template_name_of(workspace: &Workspace, meta: &PageMeta) -> Option<String> {
 /// Without scanning the alias, every mention of `@avelino` would fall
 /// off the person's backlinks panel.
 pub fn backlinks_for_page(workspace: &Workspace, root: &Path, meta: &PageMeta) -> Vec<Backlink> {
-    let mut acc = backlinks_for_target(workspace, root, &meta.slug);
-    let mut push = |extra: Vec<Backlink>| {
-        for link in extra {
+    // Build the `parent -> children` index once and reuse it across every
+    // channel below, so a template page (up to four scans) still walks the
+    // tree a single logical time instead of rebuilding the accelerator per
+    // target.
+    let index = build_children_index(workspace);
+    let mut acc: Vec<Backlink> = Vec::new();
+    let mut add = |matcher: TargetMatcher| {
+        for link in collect_backlinks(workspace, root, &matcher, &index) {
             if !acc.iter().any(|l| l.block_id == link.block_id) {
                 acc.push(link);
             }
         }
     };
+
+    add(TargetMatcher::refs(&meta.slug));
     if meta.title != meta.slug {
-        push(backlinks_for_target(workspace, root, &meta.title));
+        add(TargetMatcher::refs(&meta.title));
     }
     if meta.page_type.as_deref() == Some(crate::person::PERSON_TYPE) {
-        let at_slug = format!("@{}", meta.slug);
-        push(backlinks_for_target(workspace, root, &at_slug));
+        add(TargetMatcher::refs(&format!("@{}", meta.slug)));
         if meta.title != meta.slug {
-            let at_title = format!("@{}", meta.title);
-            push(backlinks_for_target(workspace, root, &at_title));
+            add(TargetMatcher::refs(&format!("@{}", meta.title)));
         }
     }
-    // When this page is a template, also surface where it was rendered
-    // (`call:<name>` fences) or instantiated (`from-template:: <slug>`).
-    // These aren't `[[refs]]`, so the plain text scan above misses them.
+    // A template page also surfaces where it was rendered (`call:<name>`
+    // fences) or instantiated (`from-template:: <slug>`) — neither is a
+    // `[[ref]]`, so the scans above miss them.
     if let Some(name) = template_name_of(workspace, meta) {
-        push(collect_backlinks(
-            workspace,
-            root,
-            &TargetMatcher::template(&meta.slug, &name),
-        ));
+        add(TargetMatcher::template(&meta.slug, &name));
     }
     acc
 }
@@ -268,13 +308,17 @@ fn walk_inside_page(
     path: &mut Vec<usize>,
     matcher: &TargetMatcher,
     out: &mut Vec<Backlink>,
+    index: &ChildrenIndex,
 ) {
-    for (idx, (child_id, _)) in children_of(workspace, parent).into_iter().enumerate() {
+    let Some(children) = index.get(&parent) else {
+        return;
+    };
+    for (idx, child_id) in children.iter().copied().enumerate() {
         path.push(idx);
         let text = workspace.block_text(child_id).unwrap_or_default();
         if matcher.matches(workspace, child_id, &text) {
             let (todo, body) = split_todo(&text);
-            let source_block = project_outline_node(workspace, child_id);
+            let source_block = project_outline_node_indexed(workspace, child_id, index);
             out.push(Backlink {
                 block_id: child_id.to_string(),
                 block_text: body.to_string(),
@@ -285,7 +329,16 @@ fn walk_inside_page(
                 source_path: Some(source_path.to_path_buf()),
             });
         }
-        walk_inside_page(workspace, child_id, meta, source_path, path, matcher, out);
+        walk_inside_page(
+            workspace,
+            child_id,
+            meta,
+            source_path,
+            path,
+            matcher,
+            out,
+            index,
+        );
         path.pop();
     }
 }

--- a/crates/outl-actions/src/backlinks.rs
+++ b/crates/outl-actions/src/backlinks.rs
@@ -105,17 +105,18 @@ pub fn backlinks_for_target(workspace: &Workspace, root: &Path, target: &str) ->
     collect_backlinks(workspace, root, &TargetMatcher::refs(target), &index)
 }
 
-/// Build a `parent -> children (in fractional order)` map in a single
-/// `O(n)` pass over the tree.
+/// Build a `parent -> children (in fractional order)` map once per
+/// backlinks pass (one scan + per-parent sort; `O(n log n)` worst case).
 ///
 /// The walk visits every block in the workspace and, for each match,
 /// materialises its subtree. Both steps used to go through
 /// [`children_of`], which **rescans every node** on each call (`Tree`
 /// stores only `node -> (parent, position)`, with no child index) —
 /// making the whole pass `O(n²)`. Building this map once and threading
-/// it through the walk + [`project_outline_node_indexed`] brings it back
-/// to `O(n)`. Rebuilt per `backlinks_for_page` call, so it never goes
-/// stale: it is a scratch accelerator, not cached state.
+/// it through the walk + [`project_outline_node_indexed`] eliminates the
+/// `O(n²)` rescans (the remaining cost is one full walk + sorting).
+/// Rebuilt per `backlinks_for_page` call, so it never goes stale: it is a
+/// scratch accelerator, not cached state.
 fn build_children_index(workspace: &Workspace) -> ChildrenIndex {
     let mut grouped: HashMap<NodeId, Vec<(NodeId, Fractional)>> = HashMap::new();
     for (id, parent, pos) in workspace.tree().iter_nodes() {

--- a/crates/outl-actions/src/outline.rs
+++ b/crates/outl-actions/src/outline.rs
@@ -7,6 +7,7 @@
 //! [`project_outline`] variant stays around for tools that need to
 //! materialise straight from the op log (e.g. doctor, debug dumps).
 
+use std::collections::HashMap;
 use std::path::Path;
 use std::str::FromStr;
 
@@ -102,24 +103,24 @@ pub fn flat_index_for_block(outline: &[OutlineNode], target: NodeId) -> Option<u
 /// its children and properties, instead of forcing the caller to
 /// reach back into the workspace per backlink.
 pub fn project_outline_node(workspace: &Workspace, node: NodeId) -> OutlineNode {
-    let raw = workspace.block_text(node).unwrap_or_default();
-    let (todo, body) = split_todo(&raw);
-    let mut properties: Vec<(String, String)> = workspace
-        .tree()
-        .properties_of(node)
-        .map(|(k, v)| (k.to_string(), prop_value_to_string(v)))
-        .collect();
-    properties.sort_by(|a, b| a.0.cmp(&b.0));
-    let tokens = outl_md::tokenize_owned(body);
-    OutlineNode {
-        id: node.to_string(),
-        text: body.to_string(),
-        todo,
-        collapsed: workspace.tree().is_collapsed(node),
-        properties,
-        tokens,
-        children: project_outline(workspace, node),
-    }
+    project_node(workspace, node, None)
+}
+
+/// Same shape as [`project_outline_node`], but resolves children through
+/// a pre-built `parent -> children` index instead of [`children_of`].
+///
+/// [`children_of`] rescans **every** node in the workspace on each call,
+/// so projecting a subtree with it is `O(subtree × total-nodes)`. The
+/// backlinks builder materialises hundreds of source blocks per pass and
+/// builds the index once (see [`crate::backlinks`]), turning that into
+/// `O(subtree)`. A parent missing from `index` means "no children" — the
+/// same result [`children_of`] would give for a leaf.
+pub(crate) fn project_outline_node_indexed(
+    workspace: &Workspace,
+    node: NodeId,
+    index: &ChildrenIndex,
+) -> OutlineNode {
+    project_node(workspace, node, Some(index))
 }
 use outl_md::parse::OutlineNode as ParsedOutlineNode;
 use outl_md::sidecar::SidecarBlock;
@@ -199,32 +200,69 @@ where
     }
 }
 
+/// A pre-built `parent -> children (in fractional order)` map.
+///
+/// Built once and reused across a whole traversal so recursive
+/// projection / walking doesn't pay [`children_of`]'s per-call
+/// `O(total-nodes)` scan. See [`crate::backlinks`] for the builder and
+/// why the naive walk was quadratic without it.
+pub(crate) type ChildrenIndex = HashMap<NodeId, Vec<NodeId>>;
+
 /// Walk the workspace tree starting from `parent` and return the
 /// outline below it. `NodeId::root()` is the usual starting point.
 pub fn project_outline(workspace: &Workspace, parent: NodeId) -> Vec<OutlineNode> {
-    children_of(workspace, parent)
-        .into_iter()
-        .map(|(id, _)| {
-            let raw = workspace.block_text(id).unwrap_or_default();
-            let (todo, body) = split_todo(&raw);
-            let mut properties: Vec<(String, String)> = workspace
-                .tree()
-                .properties_of(id)
-                .map(|(k, v)| (k.to_string(), prop_value_to_string(v)))
-                .collect();
-            properties.sort_by(|a, b| a.0.cmp(&b.0));
-            let tokens = outl_md::tokenize_owned(body);
-            OutlineNode {
-                id: id.to_string(),
-                text: body.to_string(),
-                todo,
-                collapsed: workspace.tree().is_collapsed(id),
-                properties,
-                tokens,
-                children: project_outline(workspace, id),
-            }
-        })
-        .collect()
+    project_children(workspace, parent, None)
+}
+
+/// Project the outline below `parent`. With `Some(index)` children are
+/// resolved in `O(children)`; with `None` through [`children_of`]
+/// (`O(total-nodes)` per level — fine for a one-off read, quadratic for
+/// a full-workspace walk). Shared by [`project_outline`] and the
+/// backlinks builder.
+fn project_children(
+    workspace: &Workspace,
+    parent: NodeId,
+    index: Option<&ChildrenIndex>,
+) -> Vec<OutlineNode> {
+    match index {
+        Some(idx) => idx
+            .get(&parent)
+            .map(|kids| {
+                kids.iter()
+                    .map(|&child| project_node(workspace, child, index))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        None => children_of(workspace, parent)
+            .into_iter()
+            .map(|(child, _)| project_node(workspace, child, None))
+            .collect(),
+    }
+}
+
+/// Build one [`OutlineNode`] for `node` — body, todo, properties,
+/// tokens, and its subtree. Shared core behind [`project_outline`],
+/// [`project_outline_node`], and [`project_outline_node_indexed`]; the
+/// only difference between them is how children are resolved (`index`).
+fn project_node(workspace: &Workspace, node: NodeId, index: Option<&ChildrenIndex>) -> OutlineNode {
+    let raw = workspace.block_text(node).unwrap_or_default();
+    let (todo, body) = split_todo(&raw);
+    let mut properties: Vec<(String, String)> = workspace
+        .tree()
+        .properties_of(node)
+        .map(|(k, v)| (k.to_string(), prop_value_to_string(v)))
+        .collect();
+    properties.sort_by(|a, b| a.0.cmp(&b.0));
+    let tokens = outl_md::tokenize_owned(body);
+    OutlineNode {
+        id: node.to_string(),
+        text: body.to_string(),
+        todo,
+        collapsed: workspace.tree().is_collapsed(node),
+        properties,
+        tokens,
+        children: project_children(workspace, node, index),
+    }
 }
 
 /// Read the page's `.md`, parse it, attach `NodeId`s from the sidecar,

--- a/crates/outl-actions/tests/bench_backlinks.rs
+++ b/crates/outl-actions/tests/bench_backlinks.rs
@@ -1,0 +1,257 @@
+//! Backlinks performance simulation — reproduces the "note with 760
+//! backlinks is slow" report and isolates where the time goes.
+//!
+//! This is **not** a correctness test. It is a reproducible micro-bench
+//! that separates the three cost layers a page's backlinks pass through
+//! every time the page is opened:
+//!
+//!   1. **compute**  — `backlinks_for_page` walks *every block in the
+//!      workspace* (O(total blocks), no inverted index for page refs).
+//!   2. **transfer** — the resulting `Vec<Backlink>` serialized to JSON.
+//!      This is the payload that crosses the Tauri IPC boundary on
+//!      desktop/mobile. Each `Backlink` carries `source_block` as a full
+//!      `OutlineNode` **subtree** (children + props), but desktop/mobile
+//!      render only `source_block.tokens` — the children are shipped and
+//!      thrown away. The bench quantifies that waste by re-serializing a
+//!      "shallow" copy (children dropped) and diffing the byte size.
+//!   3. **render**   — real DOM/TUI cost lives in the client and can't be
+//!      measured here; proxied by the total node + token counts the
+//!      client has to reconcile.
+//!
+//! Run (release is mandatory — debug numbers are meaningless):
+//!
+//! ```sh
+//! cargo test -p outl-actions --release --test bench_backlinks -- --ignored --nocapture
+//! ```
+
+use std::path::Path;
+use std::time::Instant;
+
+use outl_actions::{
+    append_block, backlinks_for_page, open_or_create_page, page_meta, set_property, Backlink,
+    OutlineNode, PageKind, PageMeta, FROM_TEMPLATE_KEY, TEMPLATE_KEY,
+};
+use outl_core::hlc::HlcGenerator;
+use outl_core::id::ActorId;
+use outl_core::property::PropValue;
+use outl_core::workspace::Workspace;
+
+const ROOT: &str = "/tmp/outl-bench";
+/// Samples per timed operation; the median is reported.
+const SAMPLES: usize = 7;
+
+#[derive(Clone, Copy)]
+enum Mechanism {
+    /// A block whose text literally contains `[[hub]]` — the cheapest
+    /// matching channel (substring scan).
+    Ref,
+    /// The report's actual case: `hub` is a `template::` page and each
+    /// source block carries a `from-template:: hub` property, so the
+    /// template channel (property lookups) fires instead of a substring.
+    Template,
+}
+
+fn new_ws() -> (Workspace, HlcGenerator) {
+    let actor = ActorId::new();
+    (
+        Workspace::open_in_memory(actor).unwrap(),
+        HlcGenerator::new(actor),
+    )
+}
+
+/// Build a workspace with `n_backlinks` blocks that reference `hub`, each
+/// carrying `subtree` children, plus `noise_per_note` non-matching blocks
+/// per note so the O(total-blocks) walk has realistic weight.
+fn build(
+    n_backlinks: usize,
+    subtree: usize,
+    noise_per_note: usize,
+    mech: Mechanism,
+) -> (Workspace, PageMeta) {
+    let (mut w, hlc) = new_ws();
+    let hub = open_or_create_page(&mut w, &hlc, "hub", "hub", PageKind::Page).unwrap();
+    if matches!(mech, Mechanism::Template) {
+        set_property(
+            &mut w,
+            &hlc,
+            hub,
+            TEMPLATE_KEY,
+            Some(PropValue::Text("mytpl".into())),
+        )
+        .unwrap();
+    }
+
+    for i in 0..n_backlinks {
+        let slug = format!("note-{i}");
+        let note = open_or_create_page(&mut w, &hlc, &slug, &slug, PageKind::Page).unwrap();
+
+        let src = match mech {
+            Mechanism::Ref => append_block(
+                &mut w,
+                &hlc,
+                Some(note),
+                Some("see [[hub]] for the weekly context"),
+            )
+            .unwrap(),
+            Mechanism::Template => {
+                let b = append_block(
+                    &mut w,
+                    &hlc,
+                    Some(note),
+                    Some("**Item:** follow-up from the 1:1"),
+                )
+                .unwrap();
+                set_property(
+                    &mut w,
+                    &hlc,
+                    b,
+                    FROM_TEMPLATE_KEY,
+                    Some(PropValue::Text("hub".into())),
+                )
+                .unwrap();
+                b
+            }
+        };
+
+        for c in 0..subtree {
+            append_block(
+                &mut w,
+                &hlc,
+                Some(src),
+                Some(&format!(
+                    "child {c}: some body text to make the subtree non-trivial"
+                )),
+            )
+            .unwrap();
+        }
+        for n in 0..noise_per_note {
+            append_block(
+                &mut w,
+                &hlc,
+                Some(note),
+                Some(&format!("filler line {n} with no reference at all")),
+            )
+            .unwrap();
+        }
+    }
+
+    let meta = page_meta(&w, hub).unwrap();
+    (w, meta)
+}
+
+fn median(mut v: Vec<u128>) -> u128 {
+    v.sort_unstable();
+    v[v.len() / 2]
+}
+
+fn count_nodes(n: &OutlineNode) -> usize {
+    1 + n.children.iter().map(count_nodes).sum::<usize>()
+}
+
+/// Drop every backlink's subtree children — the shape desktop/mobile
+/// actually consume (they render `source_block.tokens`, never children).
+fn shallow(links: &[Backlink]) -> Vec<Backlink> {
+    links
+        .iter()
+        .cloned()
+        .map(|mut b| {
+            b.source_block.children = Vec::new();
+            b
+        })
+        .collect()
+}
+
+fn bench_one(label: &str, n_backlinks: usize, subtree: usize, noise: usize, mech: Mechanism) {
+    let (w, meta) = build(n_backlinks, subtree, noise, mech);
+    let root = Path::new(ROOT);
+
+    // Warm up caches / branch predictors before timing.
+    let bl = backlinks_for_page(&w, root, &meta);
+    let n_results = bl.len();
+    let total_nodes: usize = bl.iter().map(|b| count_nodes(&b.source_block)).sum();
+
+    // Layer 1 — compute (full workspace walk + match + materialize).
+    let walk_us = median(
+        (0..SAMPLES)
+            .map(|_| {
+                let t = Instant::now();
+                let r = backlinks_for_page(&w, root, &meta);
+                std::hint::black_box(&r);
+                t.elapsed().as_micros()
+            })
+            .collect(),
+    );
+
+    // Layer 2 — transfer (JSON payload over the IPC boundary).
+    let full = &bl;
+    let shal = shallow(&bl);
+    let bytes_full = serde_json::to_vec(full).unwrap().len();
+    let bytes_shallow = serde_json::to_vec(&shal).unwrap().len();
+
+    let ser_full_us = median(
+        (0..SAMPLES)
+            .map(|_| {
+                let t = Instant::now();
+                let v = serde_json::to_vec(full).unwrap();
+                std::hint::black_box(&v);
+                t.elapsed().as_micros()
+            })
+            .collect(),
+    );
+    let ser_shallow_us = median(
+        (0..SAMPLES)
+            .map(|_| {
+                let t = Instant::now();
+                let v = serde_json::to_vec(&shal).unwrap();
+                std::hint::black_box(&v);
+                t.elapsed().as_micros()
+            })
+            .collect(),
+    );
+
+    let ws_blocks = n_backlinks * (1 + subtree + noise);
+    let saved_pct = 100.0 * (bytes_full as f64 - bytes_shallow as f64) / bytes_full as f64;
+
+    println!(
+        "{label:<34} | {n_results:>4} | {ws_blocks:>7} | {total_nodes:>7} | \
+         {walk_ms:>8.2} | {ser_full_ms:>8.2} | {ser_shallow_ms:>8.2} | \
+         {kb_full:>8.1} | {kb_shallow:>8.1} | {saved_pct:>5.0}%",
+        walk_ms = walk_us as f64 / 1000.0,
+        ser_full_ms = ser_full_us as f64 / 1000.0,
+        ser_shallow_ms = ser_shallow_us as f64 / 1000.0,
+        kb_full = bytes_full as f64 / 1024.0,
+        kb_shallow = bytes_shallow as f64 / 1024.0,
+    );
+}
+
+#[test]
+#[ignore = "performance simulation; run manually with --release --nocapture"]
+fn simulate_760_backlinks() {
+    println!();
+    println!("outl backlinks performance simulation ({SAMPLES} samples, median)");
+    println!(
+        "{:<34} | {:>4} | {:>7} | {:>7} | {:>8} | {:>8} | {:>8} | {:>8} | {:>8} | saved",
+        "scenario", "n", "ws_blk", "nodes", "walk ms", "serF ms", "serS ms", "fullKB", "shalKB"
+    );
+    println!("{}", "-".repeat(130));
+
+    // Pure baseline: 760 refs, no subtree, no noise — isolates the walk
+    // floor for a tiny workspace.
+    bench_one("ref  760  st=0  noise=0", 760, 0, 0, Mechanism::Ref);
+
+    // Add workspace noise: same 760 backlinks, but the walk now crosses a
+    // realistic block count. Shows how much the missing inverted index costs.
+    bench_one("ref  760  st=0  noise=10", 760, 0, 10, Mechanism::Ref);
+    bench_one("ref  760  st=0  noise=30", 760, 0, 30, Mechanism::Ref);
+
+    // Add subtree weight per backlink: the children desktop/mobile ship
+    // but never render. Watch fullKB vs shalKB diverge.
+    bench_one("ref  760  st=5  noise=10", 760, 5, 10, Mechanism::Ref);
+    bench_one("ref  760  st=15 noise=10", 760, 15, 10, Mechanism::Ref);
+
+    // The report's real shape: a template used 760 times, each instance a
+    // non-trivial subtree, in a busy workspace.
+    bench_one("tmpl 760  st=5  noise=10", 760, 5, 10, Mechanism::Template);
+    bench_one("tmpl 760  st=15 noise=30", 760, 15, 30, Mechanism::Template);
+    println!();
+}


### PR DESCRIPTION
Opening a page with many backlinks took seconds. A user hit multi-second opens on a template referenced from 760 places.

backlinks_for_page walked every block and called children_of per node, and children_of rescans the whole tree on each call (Tree has no child index), so the pass was quadratic. The per-match subtree projection had the same problem. Now a parent -> children map is built once per call and threaded through the walk and the projection, bringing it back to O(n). The report's shape drops from 3.8s to 41ms, with the backlinks test suite proving identical results.

Fixes #169 