### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #175)

### DIFF
--- a/.claude/commands/coverage.md
+++ b/.claude/commands/coverage.md
@@ -1,7 +1,7 @@
 ---
 description: Measures coverage in outl-core via cargo-llvm-cov. Focuses on the 4 critical functions (do_op, undo_op, apply_op, creates_cycle) that must be at 100%.
 allowed-tools: Bash(cargo llvm-cov:*), Bash(cargo install:*)
-argument-hint: [crate] (default: outl-core)
+argument-hint: "[crate] (default: outl-core)"
 ---
 
 Target: `${1:-outl-core}`


### PR DESCRIPTION
Closes #175.

## Summary

Purely mechanical single-character transform to 1 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (1)

- `.claude/commands/coverage.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
