### PR TITLE
Correcting formatting on a code block.

### DIFF
--- a/docs/query.md
+++ b/docs/query.md
@@ -101,7 +101,7 @@ The query runtime returns `OutputFormat::Embeds`, which tells the orchestrator t
 
 The rendered structure under the ` ```query ` block looks like:
 
-```markdown
+````markdown
 - ```query
   status: todo
   ```
@@ -109,7 +109,7 @@ The rendered structure under the ` ```query ` block looks like:
     - !((blk-abcdef))
     - !((blk-ghijkl))
     - !((blk-mnopqr))
-```
+````
 
 When the page is opened in the TUI or desktop, each `!((blk-…))` expands to show the original block's text and subtree.
 Because these are embeds — not copies — toggling a TODO on the original block updates the query result on the next page load.


### PR DESCRIPTION
Added an extra ` symbol on lines 104 and 112 so that the system recognises them as fenced markdown code and doesn't try to render the following sections as code.

## What this PR does

One paragraph.
The formatting was missing some back ticks and so was rendering the following text incorrectly so I added them in.

## How to verify

N/A
```bash
cargo test --workspace --all-targets
cargo clippy --workspace --all-targets -- -D warnings
cargo fmt --all -- --check
```

Plus any feature-specific checks (manual smoke, fixture files, screenshot of TUI state, ...).

## Related issues / docs

Updated docs: `docs/...` only text nothing actually changed really.

## Anything reviewers should look at carefully

- Is there a CRDT-correctness implication? No
  Did `crdt-invariant-checker` pass?
- Is there a markdown-format implication? No
  Did `markdown-roundtrip-tester` pass?
- New public API on `outl-core` / `outl-md`? No
  Is it documented in the per-crate CLAUDE.md?
- Any change to keymaps in `outl-tui`? No
  Updated `docs/tui.md` and the in-app help popup?

## Out of scope for this PR
