### PR TITLE
feat: open the markdown link under the cursor with gx

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -248,6 +248,7 @@ Recently added — check these before writing a parallel template helper (catalo
 | Apply an already-rendered `.md` string back into the workspace + sidecar, skipping a redundant re-render (the GUI commit path renders once for the undo diff and reuses it) | `outl_actions::journal::apply_page_md_with_sidecar_rendered` | `crates/outl-actions/src/journal.rs` |
 | Split a block at a character offset (Enter mid-text): head stays in the block, tail becomes a new sibling right after it, children stay with the head | `outl_actions::block::split_block` | `crates/outl-actions/src/block/split.rs` |
 | Insert a sibling after a path, seeded with text (the TUI's in-flight block-split: tail of the split goes into the new sibling) | `outline_ops::insert_sibling_after_with_text` | `crates/outl-md/src/outline_ops.rs` |
+| Resolve the markdown link `[text](url)` under a caret position (anchor OR url) — the URL a client opens externally (TUI `gx` opens it in the browser when the block isn't code) | `outl_md::inline::link_at_cursor` → `Option<&str>` | `crates/outl-md/src/cursor.rs` |
 
 ### 5.2 Reuse-first violations — no parallel implementations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Format inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the
 
 ### Added
 
+- **The TUI's `g x` now opens the markdown link under the cursor when the block isn't code (issue #183).**
+  Links `[text](url)` already rendered in the TUI (blue, underlined) but there was no way to follow one — the desktop and mobile apps let you click, the terminal had nothing.
+  `g x` keeps running fenced code blocks exactly as before (code always wins), and only when the current block isn't code does it look for a markdown link under the cursor and open it in your system browser.
+  The cursor can sit on the link's text or its URL — both open the same link, matching vim's `gx` on `.md` files.
+  Only `http` / `https` / `mailto` links are opened; anything else is refused, the same guard the desktop uses.
+  Following a `[[page]]` / `#tag` / `((block ref))` is still `Enter`, unchanged.
+
 - **The pairing screen now shows live sync progress instead of a frozen "Loading…".**
   Pairing a device to a large workspace transfers a ~15 MB snapshot plus a couple hundred thousand ops, which takes the better part of a minute — and until now the screen gave no sign anything was happening.
   The Sync section (desktop) and the Devices sheet (mobile) now show, as a pass runs: a **real progress bar** for the snapshot download (the only phase with an honest percentage — the total is known from the frame's length prefix before the body arrives), a **live count** of ops received / sent (op totals are only known once a batch finishes, so they surface as a number, not a bar), and an **activity feed** of "device → what synced".

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6443,6 +6443,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm",
+ "open",
  "outl-actions",
  "outl-config",
  "outl-core",

--- a/crates/outl-md/CLAUDE.md
+++ b/crates/outl-md/CLAUDE.md
@@ -48,7 +48,11 @@ Treat matching with the same paranoia as the CRDT.
   `is_valid_shortcode_char(c)` is the char-level alphabet check — exported so consumers walking buffers char-by-char (`try_emoji`, TUI's `detect_trigger`) avoid allocating a 1-char `String` per keystroke.
   The parser only tokenizes `:foo:` when `shortcode_to_unicode` finds `foo`, so unknown input (`:notarealemoji:`, `meeting at 14:00`) stays plain.
   **Never retro-translate `glyph → shortcode`** — multiple shortcodes can alias the same codepoint (`:+1:` and `:thumbsup:` both → 👍) so the disk form would become lossy.
-- **Inline tokenization** (`inline.rs`) — `**bold**`, `[[refs]]`, `#tags`, `((blk-XXXXXX))`, `!((blk-XXXXXX))`, `:shortcode:` — and `ref_at_cursor` (resolves to `RefTarget::Page`, `Journal`, `Tag`, or `Block`).
+- **Inline tokenization** (`inline.rs`) — `**bold**`, `[[refs]]`, `#tags`, `((blk-XXXXXX))`, `!((blk-XXXXXX))`, `:shortcode:`.
+- **Cursor introspection** (`cursor.rs`) — "what token sits under the caret?", re-exported through `inline` so `outl_md::inline::{…}` paths still resolve.
+  `ref_at_cursor` resolves to a navigable `RefTarget::{Page, Journal, Tag, Block}`;
+  `link_at_cursor` resolves a markdown link `[text](url)` under the caret (anchor OR url) and returns its URL — the building block for a client that opens links externally (the TUI's `g x`, issue #183);
+  `byte_index_for_char` converts a char index (cursor column) to a byte offset.
   **UI-agnostic.**
   TUI, future Tauri GUI, and mobile clients all consume the same `InlineTok` / `RefTarget` types and map them to their own primitives (`Span`, HTML, `AttributedString`, `AnnotatedString`).
   Two forms:
@@ -61,7 +65,7 @@ Treat matching with the same paranoia as the CRDT.
   `chamados_chat`, `inc_lag1`, `prod.ml_atendimento` stay literal.
   `*` is not subject to this restriction — it works mid-word.
   Enforced in `try_italic_under` / `try_bold_under` via the `closing_underscore` helper.
-  **`inline.rs` is over 900 lines** — known refactor debt; invoke `refactor-architect` before adding further features to this file.
+  The cursor-introspection concern was split out to `cursor.rs` to keep `inline.rs` under the file-size guard; keep new inline-token variants in `inline.rs` and new caret-resolution helpers in `cursor.rs`.
 - **External frontmatter** (`frontmatter.rs`) — metadata extraction for markdown authored by other tools.
   `split_frontmatter` splits the leading `---` fence off a `.md` body (CRLF-safe, honours the `...` end marker; no closing fence → whole file stays body).
   `parse_frontmatter(yaml, drop_keys) → Frontmatter { title, props, dropped }` flattens the YAML into `key:: value` properties: `title` lifted, `tags` normalized to `#name`, caller-supplied drop-list, values verbatim.
@@ -196,7 +200,8 @@ src/
 ├── sidecar.rs      # read/write .outl JSON, derive_ref_handle, content_hash
 ├── matching.rs     # 3-level matching algorithm
 ├── diff.rs         # AST diff → Op sequence (takes old_blocks to preserve ref_handle)
-├── inline.rs       # InlineTok (Plain/Bold/.../BlockRef/Embed/Emoji), RefTarget, ref_at_cursor
+├── inline.rs       # InlineTok (Plain/Bold/.../BlockRef/Embed/Emoji), RefTarget
+├── cursor.rs       # ref_at_cursor, link_at_cursor, byte_index_for_char (re-exported via inline)
 ├── emoji.rs        # shortcode_to_unicode, search, is_valid_shortcode, EmojiHit
 ├── frontmatter.rs  # split_frontmatter, parse_frontmatter, extract_leading_h1 (external md metadata)
 ├── wikilink.rs     # rewrite_wikilinks, clean_wikilink_target, convert_image_links, is_image_target

--- a/crates/outl-md/src/cursor.rs
+++ b/crates/outl-md/src/cursor.rs
@@ -1,0 +1,149 @@
+//! Cursor introspection over inline block content — "what token sits
+//! under the caret?".
+//!
+//! UI-agnostic, like [`crate::inline`]: the TUI's `Enter` / `gx` chords,
+//! a future GUI's click handler, and mobile's tap handler all ask the
+//! same questions here instead of re-parsing block text per client.
+//!
+//! - [`ref_at_cursor`] resolves a navigable outl reference
+//!   ([`RefTarget::Page`] / `Journal` / `Tag` / `Block`) under the caret.
+//! - [`link_at_cursor`] resolves a standard markdown link `[text](url)`
+//!   under the caret and returns its URL.
+//! - [`byte_index_for_char`] converts a char index (what a cursor column
+//!   is) into a byte offset (what `str` slicing needs).
+
+use chrono::NaiveDate;
+
+use crate::inline::{is_valid_block_handle, try_md_link, InlineTok, RefTarget};
+
+/// If `char_index` falls inside a `[[ref]]`, `#tag`, or `[[date]]` token
+/// in `text`, return the corresponding [`RefTarget`]. Otherwise `None`.
+pub fn ref_at_cursor(text: &str, char_index: usize) -> Option<RefTarget> {
+    let cursor_byte = byte_index_for_char(text, char_index);
+
+    // Scan `[[...]]` ranges.
+    let mut search = 0usize;
+    while let Some(rel_open) = text[search..].find("[[") {
+        let abs_open = search + rel_open;
+        let inner_start = abs_open + 2;
+        let Some(rel_close) = text[inner_start..].find("]]") else {
+            break;
+        };
+        let inner_end = inner_start + rel_close;
+        let abs_close_end = inner_end + 2;
+        if cursor_byte >= abs_open && cursor_byte <= abs_close_end {
+            let inner = &text[inner_start..inner_end];
+            if let Ok(date) = NaiveDate::parse_from_str(inner, "%Y-%m-%d") {
+                return Some(RefTarget::Journal(date));
+            }
+            return Some(RefTarget::Page(inner.to_string()));
+        }
+        search = abs_close_end;
+    }
+
+    // Scan `((blk-...))` ranges. A preceding `!` (embed form) widens
+    // the match by one byte so a cursor sitting on `!` still resolves
+    // to the same target.
+    //
+    // Bug fix: when the candidate handle fails validation we advance
+    // by ONE byte (not past the closing `))`) so an overlapping valid
+    // handle still gets a chance. Example: `((((blk-x))))` — the
+    // outer `((` captures `((blk-x` (invalid). Skipping to the first
+    // `))` would step past the real `((blk-x))` at offset 2.
+    let mut search = 0usize;
+    while let Some(rel_open) = text[search..].find("((") {
+        let abs_open = search + rel_open;
+        let inner_start = abs_open + 2;
+        let Some(rel_close) = text[inner_start..].find("))") else {
+            break;
+        };
+        let inner_end = inner_start + rel_close;
+        let abs_close_end = inner_end + 2;
+        let handle = &text[inner_start..inner_end];
+        if !is_valid_block_handle(handle) {
+            search = abs_open + 1;
+            continue;
+        }
+        let starts_at = if abs_open > 0 && text.as_bytes()[abs_open - 1] == b'!' {
+            abs_open - 1
+        } else {
+            abs_open
+        };
+        if cursor_byte >= starts_at && cursor_byte <= abs_close_end {
+            return Some(RefTarget::Block(handle.to_string()));
+        }
+        search = abs_close_end;
+    }
+
+    // Scan `#tag` ranges.
+    let mut idx = 0usize;
+    while idx < text.len() {
+        if text[idx..].starts_with('#') {
+            let after = &text[idx + 1..];
+            let mut tag_byte_end = 0usize;
+            for (rel, ch) in after.char_indices() {
+                if ch.is_alphanumeric() || ch == '-' || ch == '_' || ch == '/' {
+                    tag_byte_end = rel + ch.len_utf8();
+                } else {
+                    break;
+                }
+            }
+            if tag_byte_end > 0 {
+                let abs_end = idx + 1 + tag_byte_end;
+                if cursor_byte >= idx && cursor_byte <= abs_end {
+                    let name = &text[idx + 1..abs_end];
+                    return Some(RefTarget::Tag(name.to_string()));
+                }
+                idx = abs_end;
+                continue;
+            }
+        }
+        let ch = text[idx..].chars().next()?;
+        idx += ch.len_utf8();
+    }
+
+    None
+}
+
+/// If `char_index` falls anywhere inside a standard markdown link
+/// `[text](url)` in `text` — over the anchor text *or* the URL — return
+/// the link's URL. Otherwise `None`.
+///
+/// Reuses the canonical `try_md_link` matcher so the notion of "what is
+/// a link" stays owned in one place; `[[page]]` refs are skipped (they are
+/// not links). Consumed by clients that follow a link under the cursor
+/// (e.g. the TUI's `gx` chord) without reimplementing link parsing.
+pub fn link_at_cursor(text: &str, char_index: usize) -> Option<&str> {
+    let cursor_byte = byte_index_for_char(text, char_index);
+
+    let mut search = 0usize;
+    while let Some(rel_open) = text[search..].find('[') {
+        let abs_open = search + rel_open;
+        match try_md_link(&text[abs_open..]) {
+            Some((InlineTok::Link { url, .. }, consumed)) => {
+                // Cursor inside `[abs_open, abs_open + consumed]` (inclusive
+                // of the trailing `)` so a cursor parked on it still opens).
+                if cursor_byte >= abs_open && cursor_byte <= abs_open + consumed {
+                    return Some(url);
+                }
+                search = abs_open + consumed;
+            }
+            // Not a link here (bare `[`, `[[ref]]`, unbalanced). Advance one
+            // byte so an overlapping link right after still gets a chance.
+            _ => search = abs_open + 1,
+        }
+    }
+
+    None
+}
+
+/// Convert a char index (0-based) into the corresponding byte offset.
+///
+/// Returns `s.len()` when the char index is at or past the end. Always
+/// safe to pass into `s.split_at(...)`.
+pub fn byte_index_for_char(s: &str, char_index: usize) -> usize {
+    s.char_indices()
+        .nth(char_index)
+        .map(|(b, _)| b)
+        .unwrap_or(s.len())
+}

--- a/crates/outl-md/src/inline.rs
+++ b/crates/outl-md/src/inline.rs
@@ -315,105 +315,10 @@ pub fn tokenize(text: &str) -> Vec<InlineTok<'_>> {
     out
 }
 
-/// If `char_index` falls inside a `[[ref]]`, `#tag`, or `[[date]]` token
-/// in `text`, return the corresponding [`RefTarget`]. Otherwise `None`.
-pub fn ref_at_cursor(text: &str, char_index: usize) -> Option<RefTarget> {
-    let cursor_byte = byte_index_for_char(text, char_index);
-
-    // Scan `[[...]]` ranges.
-    let mut search = 0usize;
-    while let Some(rel_open) = text[search..].find("[[") {
-        let abs_open = search + rel_open;
-        let inner_start = abs_open + 2;
-        let Some(rel_close) = text[inner_start..].find("]]") else {
-            break;
-        };
-        let inner_end = inner_start + rel_close;
-        let abs_close_end = inner_end + 2;
-        if cursor_byte >= abs_open && cursor_byte <= abs_close_end {
-            let inner = &text[inner_start..inner_end];
-            if let Ok(date) = NaiveDate::parse_from_str(inner, "%Y-%m-%d") {
-                return Some(RefTarget::Journal(date));
-            }
-            return Some(RefTarget::Page(inner.to_string()));
-        }
-        search = abs_close_end;
-    }
-
-    // Scan `((blk-...))` ranges. A preceding `!` (embed form) widens
-    // the match by one byte so a cursor sitting on `!` still resolves
-    // to the same target.
-    //
-    // Bug fix: when the candidate handle fails validation we advance
-    // by ONE byte (not past the closing `))`) so an overlapping valid
-    // handle still gets a chance. Example: `((((blk-x))))` — the
-    // outer `((` captures `((blk-x` (invalid). Skipping to the first
-    // `))` would step past the real `((blk-x))` at offset 2.
-    let mut search = 0usize;
-    while let Some(rel_open) = text[search..].find("((") {
-        let abs_open = search + rel_open;
-        let inner_start = abs_open + 2;
-        let Some(rel_close) = text[inner_start..].find("))") else {
-            break;
-        };
-        let inner_end = inner_start + rel_close;
-        let abs_close_end = inner_end + 2;
-        let handle = &text[inner_start..inner_end];
-        if !is_valid_block_handle(handle) {
-            search = abs_open + 1;
-            continue;
-        }
-        let starts_at = if abs_open > 0 && text.as_bytes()[abs_open - 1] == b'!' {
-            abs_open - 1
-        } else {
-            abs_open
-        };
-        if cursor_byte >= starts_at && cursor_byte <= abs_close_end {
-            return Some(RefTarget::Block(handle.to_string()));
-        }
-        search = abs_close_end;
-    }
-
-    // Scan `#tag` ranges.
-    let mut idx = 0usize;
-    while idx < text.len() {
-        if text[idx..].starts_with('#') {
-            let after = &text[idx + 1..];
-            let mut tag_byte_end = 0usize;
-            for (rel, ch) in after.char_indices() {
-                if ch.is_alphanumeric() || ch == '-' || ch == '_' || ch == '/' {
-                    tag_byte_end = rel + ch.len_utf8();
-                } else {
-                    break;
-                }
-            }
-            if tag_byte_end > 0 {
-                let abs_end = idx + 1 + tag_byte_end;
-                if cursor_byte >= idx && cursor_byte <= abs_end {
-                    let name = &text[idx + 1..abs_end];
-                    return Some(RefTarget::Tag(name.to_string()));
-                }
-                idx = abs_end;
-                continue;
-            }
-        }
-        let ch = text[idx..].chars().next()?;
-        idx += ch.len_utf8();
-    }
-
-    None
-}
-
-/// Convert a char index (0-based) into the corresponding byte offset.
-///
-/// Returns `s.len()` when the char index is at or past the end. Always
-/// safe to pass into `s.split_at(...)`.
-pub fn byte_index_for_char(s: &str, char_index: usize) -> usize {
-    s.char_indices()
-        .nth(char_index)
-        .map(|(b, _)| b)
-        .unwrap_or(s.len())
-}
+// Cursor introspection (`ref_at_cursor`, `link_at_cursor`,
+// `byte_index_for_char`) lives in the sibling [`crate::cursor`] module and
+// is re-exported here so `outl_md::inline::{…}` paths keep resolving.
+pub use crate::cursor::{byte_index_for_char, link_at_cursor, ref_at_cursor};
 
 // --- private matchers ----------------------------------------------------
 
@@ -734,7 +639,7 @@ fn try_code(s: &str) -> Option<(InlineTok<'_>, usize)> {
     Some((InlineTok::Code { inner }, 1 + close + 1))
 }
 
-fn try_md_link(s: &str) -> Option<(InlineTok<'_>, usize)> {
+pub(crate) fn try_md_link(s: &str) -> Option<(InlineTok<'_>, usize)> {
     if s.starts_with("[[") {
         return None;
     }

--- a/crates/outl-md/src/lib.rs
+++ b/crates/outl-md/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod atomic;
 pub mod block_index;
+pub mod cursor;
 pub mod diff;
 pub mod emoji;
 pub mod frontmatter;
@@ -35,7 +36,8 @@ pub use diff::{diff_to_ops, DiffPlan};
 pub use emoji::{is_valid_shortcode, search as search_emoji, shortcode_to_unicode, EmojiHit};
 pub use index::{PageEntry, WorkspaceIndex};
 pub use inline::{
-    byte_index_for_char, ref_at_cursor, tokenize, tokenize_owned, InlineTok, InlineToken, RefTarget,
+    byte_index_for_char, link_at_cursor, ref_at_cursor, tokenize, tokenize_owned, InlineTok,
+    InlineToken, RefTarget,
 };
 pub use matching::{match_blocks, Match, MatchLevel};
 pub use parse::{parse, OutlineNode, ParseWarning, ParseWarningKind, ParsedPage};

--- a/crates/outl-md/tests/inline.rs
+++ b/crates/outl-md/tests/inline.rs
@@ -2,7 +2,9 @@
 //! Moved out of `src/inline.rs` to keep that module under the
 //! file-size-guard. Every test here exercises only the public API.
 
-use outl_md::inline::{byte_index_for_char, ref_at_cursor, tokenize, InlineTok, RefTarget};
+use outl_md::inline::{
+    byte_index_for_char, link_at_cursor, ref_at_cursor, tokenize, InlineTok, RefTarget,
+};
 
 #[test]
 fn plain_text_is_one_token() {
@@ -561,4 +563,46 @@ fn mixed_star_italic_and_underscore_identifier_same_line() {
             .any(|t| matches!(t, InlineTok::Italic { marker: '_', .. })),
         "chamados_chat must not produce an underscore italic, got {toks:?}"
     );
+}
+
+// --- link_at_cursor -----------------------------------------------------
+
+#[test]
+fn link_at_cursor_hits_anchor_text() {
+    let text = "see [docs](https://outl.app) now";
+    // Cursor on the "docs" anchor.
+    assert_eq!(link_at_cursor(text, 6), Some("https://outl.app"));
+}
+
+#[test]
+fn link_at_cursor_hits_url_part() {
+    let text = "see [docs](https://outl.app) now";
+    // Cursor inside the URL.
+    assert_eq!(link_at_cursor(text, 15), Some("https://outl.app"));
+}
+
+#[test]
+fn link_at_cursor_misses_outside_the_link() {
+    let text = "see [docs](https://outl.app) now";
+    assert_eq!(link_at_cursor(text, 1), None); // "see"
+    assert_eq!(link_at_cursor(text, 30), None); // "now"
+}
+
+#[test]
+fn link_at_cursor_ignores_page_refs() {
+    // `[[page]]` is a ref, not a markdown link.
+    assert_eq!(link_at_cursor("go to [[home]] page", 9), None);
+}
+
+#[test]
+fn link_at_cursor_picks_the_right_one_of_many() {
+    let text = "[a](http://a.x) and [b](http://b.y)";
+    assert_eq!(link_at_cursor(text, 1), Some("http://a.x"));
+    assert_eq!(link_at_cursor(text, 21), Some("http://b.y"));
+    assert_eq!(link_at_cursor(text, 16), None); // " and "
+}
+
+#[test]
+fn link_at_cursor_empty_when_no_link() {
+    assert_eq!(link_at_cursor("just prose here", 4), None);
 }

--- a/crates/outl-shortcuts/src/defaults.rs
+++ b/crates/outl-shortcuts/src/defaults.rs
@@ -192,7 +192,9 @@ pub fn default_bindings() -> Vec<Binding> {
             pair('g', 'x'),
             Normal,
             Action::RunCodeBlock,
-            "Run code block (TUI chord)",
+            // TUI falls back to opening the markdown link under the
+            // cursor when the block isn't code (issue #183).
+            "Run code block / open link (TUI chord)",
         ),
         // ── Inline markdown wrappers (Insert mode — textarea focused) ──
         //

--- a/crates/outl-tui/CLAUDE.md
+++ b/crates/outl-tui/CLAUDE.md
@@ -81,6 +81,13 @@ This section captures only the **architectural / TUI-specific behaviour** a cont
 - **`Enter` is overloaded.**
   Open `[[ref]]` / `#tag` / journal / block ref (`((blk-X))` / `!((blk-X))`) under cursor, else enter Insert.
   On a block ref it jumps to the source page and positions the cursor on the referenced block; orphan handles surface a status message and stay put.
+  It deliberately does **not** follow markdown links `[text](url)` — that's `g x` (below).
+- **`g x` is overloaded (code exec first, then link).**
+  The decision is the pure `decide_gx(text, cursor_col)` in `actions/exec.rs`.
+  A fenced code block always runs — `extract_fence` wins, so `call:` / `query` / any ` ```lang ` still executes.
+  Only when the block is **not** code does it consult `link_at_cursor` and open the markdown link under the cursor (anchor or URL) in the system browser via `App::open_external_url` (the `open` crate).
+  Scheme-guarded to `http` / `https` / `mailto`, mirroring the desktop frontend's `openExternalUrl`.
+  Neither present → a status-line message, not the old `run failed` modal (issue #183).
 - **Quit is chord-only.**
   `q q` arms + confirms (single `q` is too easy to hit by accident).
   `Z Z` is the vim "save and quit" alias — outl auto-commits on every Normal boundary, so it reduces to `q q`.

--- a/crates/outl-tui/Cargo.toml
+++ b/crates/outl-tui/Cargo.toml
@@ -53,6 +53,10 @@ arboard = { version = "3", default-features = false }
 # copy-as-markdown. Reaches the outer clipboard over SSH / Crostini /
 # tmux where `arboard` (which needs a local display server) can't.
 base64 = "0.22"
+# Open a markdown link `[text](url)` under the cursor (`gx`) in the
+# system's default browser / handler (issue #183). Desktop/mobile use
+# `tauri-plugin-opener`; the TUI isn't Tauri, so it uses the `open` crate.
+open = "5"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/outl-tui/src/actions/exec.rs
+++ b/crates/outl-tui/src/actions/exec.rs
@@ -93,18 +93,34 @@ impl App {
         }
     }
 
-    /// Run the code block under the current selection through
-    /// [`outl_exec`]. The result lands as a `> **result:**` subblock
-    /// (or replaces an existing one), the `.md` is rewritten, and the
-    /// op log is reconciled — all in one shot.
+    /// Dispatch the `gx` chord: run the fenced code block under the
+    /// cursor, or — when the block isn't code — open the markdown link
+    /// `[text](url)` under the cursor in the system browser (issue #183).
+    ///
+    /// Code execution wins: a fenced block always runs, and only a
+    /// non-fence block consults the link under the caret. Neither present
+    /// is a friendly status message, not the old `run failed` modal.
     pub(crate) fn run_current_block(&mut self) {
+        if matches!(self.mode, Mode::Insert { .. }) {
+            self.commit_insert();
+        }
+
+        match decide_gx(&self.current_block_text(), self.cursor_col) {
+            GxAction::OpenLink(url) => {
+                self.open_external_url(&url);
+                return;
+            }
+            GxAction::Nothing => {
+                self.status = "no code block or link under cursor".into();
+                return;
+            }
+            GxAction::Run => {}
+        }
+
         let path = self.current_path();
         let idx = self.selected;
         let orphans = self.orphans_log.clone();
 
-        if matches!(self.mode, Mode::Insert { .. }) {
-            self.commit_insert();
-        }
         // Execution reads the code block from the workspace / `.md`, so
         // persist any coalesced edit first — otherwise `gx` would run the
         // stale source.
@@ -150,6 +166,23 @@ impl App {
             Err(e) => {
                 self.show_error("run failed", format!("{e}"));
             }
+        }
+    }
+
+    /// Open an external URL in the system's default handler (browser,
+    /// mail client). Scheme-guarded to mirror the desktop frontend's
+    /// `openExternalUrl` (`outl-frontend-shared/src/api/commands.ts`):
+    /// only `http` / `https` / `mailto` are allowed; `file:`,
+    /// `javascript:`, and anything else are refused so a crafted link in
+    /// a synced note can't launch an arbitrary handler.
+    pub(crate) fn open_external_url(&mut self, url: &str) {
+        if !is_safe_external_url(url) {
+            self.status = format!("refused to open non-web link: {url}");
+            return;
+        }
+        match open::that(url) {
+            Ok(()) => self.status = format!("opened {url}"),
+            Err(e) => self.show_error("open failed", format!("{e}")),
         }
     }
 
@@ -293,4 +326,89 @@ fn find_block_at_flat<'a>(
         }
     }
     None
+}
+
+/// What the `gx` chord should do for the block under the cursor.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum GxAction {
+    /// The block is a fenced code block — run it (code exec has priority).
+    Run,
+    /// The block isn't code but a markdown link sits under the cursor.
+    OpenLink(String),
+    /// Neither a code block nor a link under the cursor.
+    Nothing,
+}
+
+/// Decide what `gx` does given the block `text` and the cursor column.
+///
+/// Pure so the priority rule (code beats link) is unit-testable without
+/// touching the terminal or the browser.
+pub(crate) fn decide_gx(text: &str, cursor_col: usize) -> GxAction {
+    if outl_exec::extract_fence(text).is_some() {
+        GxAction::Run
+    } else if let Some(url) = outl_md::link_at_cursor(text, cursor_col) {
+        GxAction::OpenLink(url.to_string())
+    } else {
+        GxAction::Nothing
+    }
+}
+
+/// Only web-ish schemes may be opened externally: `http`, `https`,
+/// `mailto`. Mirrors the desktop frontend's `openExternalUrl` guard.
+fn is_safe_external_url(url: &str) -> bool {
+    url.split_once(':').is_some_and(|(scheme, _)| {
+        matches!(
+            scheme.to_ascii_lowercase().as_str(),
+            "http" | "https" | "mailto"
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn code_block_runs_even_with_a_link_in_it() {
+        // A fence wins over any link text inside it.
+        let text = "```sh\ncurl https://example.com\n```";
+        assert_eq!(decide_gx(text, 10), GxAction::Run);
+    }
+
+    #[test]
+    fn non_code_block_opens_link_under_cursor() {
+        let text = "see [docs](https://outl.app) for more";
+        // Cursor on the anchor text.
+        assert_eq!(
+            decide_gx(text, 6),
+            GxAction::OpenLink("https://outl.app".into())
+        );
+        // Cursor on the URL portion.
+        assert_eq!(
+            decide_gx(text, 15),
+            GxAction::OpenLink("https://outl.app".into())
+        );
+    }
+
+    #[test]
+    fn plain_block_with_no_link_does_nothing() {
+        assert_eq!(decide_gx("just some prose", 3), GxAction::Nothing);
+    }
+
+    #[test]
+    fn cursor_off_the_link_does_nothing() {
+        let text = "tail [x](https://y.z)";
+        assert_eq!(decide_gx(text, 1), GxAction::Nothing);
+    }
+
+    #[test]
+    fn scheme_guard_allows_web_and_mail_only() {
+        assert!(is_safe_external_url("https://outl.app"));
+        assert!(is_safe_external_url("http://outl.app"));
+        assert!(is_safe_external_url("HTTPS://OUTL.APP"));
+        assert!(is_safe_external_url("mailto:a@b.c"));
+        assert!(!is_safe_external_url("file:///etc/passwd"));
+        assert!(!is_safe_external_url("javascript:alert(1)"));
+        assert!(!is_safe_external_url("outl.app"));
+    }
 }

--- a/docs/shared-primitives.md
+++ b/docs/shared-primitives.md
@@ -197,10 +197,11 @@ UI-agnostic; both TUI and mobile consume them.
 | Tokenize inline markdown (`**bold**`, `[[refs]]`, `#tags`, `((blk-…))`, `!((blk-…))`) | `outl_md::inline::tokenize` → `InlineTok` | `crates/outl-md/src/inline.rs` |
 | Tokenize inline markdown into an **owned, Serde-friendly** form for wire / DTO payloads (mobile renders these straight; no parallel TS tokenizer) | `outl_md::inline::tokenize_owned` → `InlineToken` | `crates/outl-md/src/inline.rs` |
 | Reconstruct the source markdown from a `Vec<InlineTok>` (Bold / Italic / Strike now carry recursively-tokenized inners; use this when a surface wants the whole inner span as one styled string instead of dispatching per-variant) | `outl_md::inline::inline_to_source` | `crates/outl-md/src/inline.rs` |
-| Resolve the ref under a caret position (`Page` / `Journal` / `Tag` / `Block`) | `outl_md::inline::ref_at_cursor` → `RefTarget` | `crates/outl-md/src/inline.rs` |
+| Resolve the ref under a caret position (`Page` / `Journal` / `Tag` / `Block`) | `outl_md::inline::ref_at_cursor` → `RefTarget` | `crates/outl-md/src/cursor.rs` |
+| Resolve the markdown link `[text](url)` under a caret position (anchor OR url) — the URL a client opens externally (TUI `gx`) | `outl_md::inline::link_at_cursor` → `Option<&str>` | `crates/outl-md/src/cursor.rs` |
 | Does a text mention `#tag` as a whole tag token? Boundary-correct via the tokenizer (`#tag-longer` / `#tagged` never match `tag`; `#tag` inside a code span is not a tag) — never use `text.contains("#tag")` | `outl_md::tag::text_contains_tag` | `crates/outl-md/src/tag.rs` |
 | Validate a `((blk-XXXXXX))` handle string | `outl_md::inline::is_valid_block_handle` | `crates/outl-md/src/inline.rs` |
-| Byte offset for a char index (UTF-8 safe) | `outl_md::inline::byte_index_for_char` | `crates/outl-md/src/inline.rs` |
+| Byte offset for a char index (UTF-8 safe) | `outl_md::inline::byte_index_for_char` | `crates/outl-md/src/cursor.rs` |
 | Canonicalize a fence info-string (`rs` → `rust`, `js`/`javascript`/`node` → `js`, …) — single source of truth for both `outl-exec`'s runtime dispatch and the frontend syntax highlighter | `outl_md::lang::canonical`, `outl_md::lang::KNOWN_ALIASES` | `crates/outl-md/src/lang.rs` |
 | Resolve a `:shortcode:` to its unicode glyph (one-way; never retro-translate glyph → shortcode, multiple shortcodes can alias the same codepoint) | `outl_md::emoji::shortcode_to_unicode` | `crates/outl-md/src/emoji.rs` |
 | Validate the `[a-z0-9_+-]+` shape of an emoji shortcode (does **not** check the catalog — that's `shortcode_to_unicode`) | `outl_md::emoji::is_valid_shortcode` | `crates/outl-md/src/emoji.rs` |

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -32,7 +32,7 @@ If a row below disagrees with what you observe in the app, **the code is right a
 | Quick switcher (fuzzy pages + journals) | `Ctrl+P` | `Cmd/Ctrl+P` | tap toolbar |
 | Open today's **j**ournal | `t` / `Home` | `Cmd/Ctrl+J` | toolbar |
 | Toggle TODO / DONE on focused or selected block (T for **t**ask) | `Ctrl+T` / `Ctrl+Enter` | `Cmd/Ctrl+T` / `Cmd/Ctrl+Enter` | tap checkbox |
-| Run code block under cursor / selected block (X for e**x**ecute) | `g x` chord / `:run` | `Cmd/Ctrl+Shift+X` (inside a textarea the Insert-mode strikethrough wins — commit first or use the Run button; plain `Cmd+X` is the OS cut / block cut) | tap "Run" button |
+| Run code block under cursor / selected block (X for e**x**ecute). TUI: when the block isn't code, `g x` instead opens the markdown link `[text](url)` under the cursor in the browser (issue #183) | `g x` chord / `:run` | `Cmd/Ctrl+Shift+X` (inside a textarea the Insert-mode strikethrough wins — commit first or use the Run button; plain `Cmd+X` is the OS cut / block cut) | tap "Run" button |
 | Previous journal day | `[` | `Cmd/Ctrl+[` | swipe right |
 | Next journal day | `]` | `Cmd/Ctrl+]` | swipe left |
 | Toggle sidebar | `Ctrl+E` | `Cmd/Ctrl+Shift+E` | _(single pane)_ |

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -412,8 +412,13 @@ The result lands as a `> **result:**` subblock right below the source, and re-ru
 
 | Key | Action |
 |-----|--------|
-| `g x` | Run the code block under the cursor |
+| `g x` | Run the code block under the cursor — or, when the block isn't code, open the markdown link `[text](url)` under the cursor in the system browser (issue #183) |
 | `:run` (also `:x`) | Same, via the command palette |
+
+`g x` prioritizes code: a fenced block always runs.
+Only when the current block is **not** a code block does `g x` look for a markdown link under the cursor and open it — the cursor may sit on the link's text or its URL.
+Only `http` / `https` / `mailto` links are opened; anything else is refused.
+Following a `[[page]]` / `#tag` / `((block ref))` is still `Enter`, unchanged.
 
 ```
 - ```lisp


### PR DESCRIPTION
Markdown links rendered in the TUI (blue, underlined) but there was no way to follow one. Desktop and mobile let you click, the terminal had nothing.

`gx` still runs a fenced code block when the cursor is on one (code wins). When the block isn't code, it opens the markdown link under the cursor in the system browser, cursor on the anchor text or the URL both work. Only http, https and mailto are allowed, same guard the desktop uses. The link-under-cursor lookup lives in outl-md (link_at_cursor, split into a new cursor module alongside ref_at_cursor); the TUI decides run-vs-open with a pure decide_gx and opens via the open crate.

Fixes #183 