### PR TITLE
fix: open quick-switcher pages by literal on-disk slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the
 
 ### Fixed
 
+- **TUI: opening a page from the quick switcher (`Ctrl+P`) no longer lands on an empty duplicate when the page's on-disk slug contains slug-unsafe characters (issue #195).**
+  The switcher's preview resolved the page by its literal `pages/*.md` file stem, but Enter round-tripped that same stem through `slugify()` before opening — for a slug that isn't slugify-idempotent (`~`, `%`, uppercase; e.g. slugs written verbatim by the MCP's `page create`), the re-slugified path missed the real file and the "not found" branch silently created a fresh empty page (`title::` plus one empty bullet) next to the real one.
+  Enter now opens the candidate's literal on-disk slug, the same identifier the preview already used; opening by a user-visible name (following a `[[ref]]`, `/open`) still slugifies as before.
+
 - **Re-rendering a page from the op log no longer deletes its block-level `key:: value` property lines from the `.md`.**
   `reconcile` correctly turned block properties into `Op::SetProp` on the block node, but the reverse projection (`render_page_md` / `render_block_md` via `build_outline`) never wrote them back — so any mutation that re-rendered the page (a GUI edit, the importer's ref-resolution pass) silently dropped every `priority:: high`-style line from disk, and the next external-edit reconcile would emit property-removal ops: convergent data loss.
   Block properties now project back alpha-sorted, matching the page-property behavior, and the importer's end-to-end suite pins the round trip.

--- a/crates/outl-tui/src/actions/nav.rs
+++ b/crates/outl-tui/src/actions/nav.rs
@@ -664,6 +664,20 @@ impl App {
     /// preserved in the page's `title::` property.
     pub(crate) fn open_page_by_name(&mut self, name: &str) -> Result<()> {
         let slug = outl_md::slug::slugify(name);
+        self.open_page_slug(&slug, name)
+    }
+
+    /// Open (or create) a page whose on-disk slug is already known.
+    /// On-disk slugs are not always slugify-idempotent (MCP/CLI `page
+    /// create` writes the caller's slug verbatim, so `~`, `%`, or
+    /// uppercase can appear in the filename); re-slugifying one here
+    /// would resolve to a different path and silently create an empty
+    /// duplicate page.
+    pub(crate) fn open_page_by_slug(&mut self, slug: &str) -> Result<()> {
+        self.open_page_slug(slug, slug)
+    }
+
+    fn open_page_slug(&mut self, slug: &str, name: &str) -> Result<()> {
         let path = self.workspace_root.join("pages").join(format!("{slug}.md"));
         let created_new = !path.exists();
         if created_new {
@@ -724,5 +738,62 @@ mod word_tests {
             Some("hello".to_string()),
             "cursor past EOL still picks up the last word"
         );
+    }
+}
+
+#[cfg(test)]
+mod open_page_tests {
+    use crate::state::App;
+    use outl_core::{ActorId, Workspace};
+    use tempfile::TempDir;
+
+    fn fresh_app() -> (App, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let actor = ActorId::new();
+        let ws = Workspace::open_in_memory(actor).unwrap();
+        let app = App::new(
+            dir.path().to_path_buf(),
+            ws,
+            actor,
+            crate::theme::default_theme(),
+            false,
+            outl_config::SyncConfig::default(),
+        )
+        .unwrap();
+        (app, dir)
+    }
+
+    // Regression for the quick-switcher "preview shows content, open is
+    // empty" bug: an on-disk slug that isn't slugify-idempotent (`~`,
+    // `%` — MCP-written) must open verbatim, not be re-slugified into a
+    // fresh empty duplicate page.
+    #[test]
+    fn open_by_slug_uses_the_literal_stem() {
+        let (mut app, dir) = fresh_app();
+        let pages = dir.path().join("pages");
+        std::fs::create_dir_all(&pages).unwrap();
+        let slug = "ai-memory~abc~sessions%2Fdef.md";
+        let real = pages.join(format!("{slug}.md"));
+        std::fs::write(&real, "- real content\n").unwrap();
+
+        app.open_page_by_slug(slug).unwrap();
+
+        assert_eq!(app.current_path(), real);
+        assert_eq!(app.page.blocks[0].text, "real content");
+        let slugified = pages.join(format!("{}.md", outl_md::slug::slugify(slug)));
+        assert!(
+            !slugified.exists(),
+            "opening by literal slug must not mint a slugified duplicate"
+        );
+    }
+
+    // `open_page_by_name` keeps its semantics: a user-visible name is
+    // slugified before hitting disk.
+    #[test]
+    fn open_by_name_still_slugifies() {
+        let (mut app, dir) = fresh_app();
+        app.open_page_by_name("My Fancy Page").unwrap();
+        let expected = dir.path().join("pages").join("my-fancy-page.md");
+        assert_eq!(app.current_path(), expected);
     }
 }

--- a/crates/outl-tui/src/actions/overlay.rs
+++ b/crates/outl-tui/src/actions/overlay.rs
@@ -145,7 +145,9 @@ impl App {
             return Ok(());
         };
         match c.kind {
-            SwitchKind::Page => self.open_page_by_name(&c.key)?,
+            // `key` is the literal on-disk file stem, not a user-typed
+            // name — never re-slugify it (see `open_page_by_slug`).
+            SwitchKind::Page => self.open_page_by_slug(&c.key)?,
             SwitchKind::Journal => {
                 if let Ok(date) = chrono::NaiveDate::parse_from_str(&c.key, "%Y-%m-%d") {
                     self.view = View::Journal(date);


### PR DESCRIPTION
Enter in the quick switcher (Ctrl+P) round-tripped the candidate's file stem through slugify() before opening. For slugs that aren't slugify-idempotent (MCP-written names with ~ or %2F), the re-slugified path missed the real file and the not-found branch silently created an empty duplicate page, while the preview pane showed the real content.

The switcher now opens the candidate's literal on-disk slug via a new open_page_by_slug. open_page_by_name keeps slugifying for name-based call sites ([[refs]], /open). Regression tests pin both paths.

Fixes #195 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the TUI quick-switcher (`Ctrl+P`) opening pages with slug-unsafe characters.
  - Prevented duplicate or empty pages from being created when selecting pages from quick search.
  - Preserved existing slugification behavior when opening pages by name, including `[[ref]]` and `/open`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->