### PR TITLE
Update keybinding for toggling sidebar to Ctrl+E

### DIFF
--- a/crates/outl-tui/src/view/overlays.rs
+++ b/crates/outl-tui/src/view/overlays.rs
@@ -971,6 +971,8 @@ pub(crate) fn render_help_popup(f: &mut ratatui::Frame<'_>, full: Rect, app: &Ap
 /// `outl-shortcuts`, so a chord added to the catalog does NOT appear
 /// here on its own. The guard test at the bottom of this file is what
 /// keeps the reminder chords from silently dropping out again.
+/// Note however, that at least one keybinding *change* was missed -
+/// `\` -> Ctrl+E for the sidebar toggle.
 fn help_tab_body(tab: usize, theme: &Theme) -> Vec<Line<'static>> {
     match HELP_TABS.get(tab).copied().unwrap_or("Normal") {
         "Normal" => vec![
@@ -1006,7 +1008,7 @@ fn help_tab_body(tab: usize, theme: &Theme) -> Vec<Line<'static>> {
             Line::from("  Ctrl+S      force save"),
             Line::from("  Ctrl+L      reload workspace from disk"),
             Line::from("  B           toggle inline backlinks"),
-            Line::from("  \\           toggle left sidebar (opens with focus on Pinned)"),
+            Line::from("  Ctrl+E           toggle left sidebar (opens with focus on Pinned)"),
             Line::from("  q q         quit (chord)"),
             Line::from(""),
             Line::from(Span::styled("Properties (key:: value)", theme.help_title)),
@@ -1058,7 +1060,7 @@ fn help_tab_body(tab: usize, theme: &Theme) -> Vec<Line<'static>> {
         ],
         "Sidebar" => vec![
             Line::from(Span::styled("Open / close", theme.help_title)),
-            Line::from("  \\           toggle sidebar (opens with focus on Pinned)"),
+            Line::from("  Ctrl+E           toggle sidebar (opens with focus on Pinned)"),
             Line::from("  Esc         return focus to the outline (sidebar stays open)"),
             Line::from(""),
             Line::from(Span::styled("Inside the sidebar", theme.help_title)),

--- a/crates/outl-tui/src/view/overlays.rs
+++ b/crates/outl-tui/src/view/overlays.rs
@@ -971,8 +971,6 @@ pub(crate) fn render_help_popup(f: &mut ratatui::Frame<'_>, full: Rect, app: &Ap
 /// `outl-shortcuts`, so a chord added to the catalog does NOT appear
 /// here on its own. The guard test at the bottom of this file is what
 /// keeps the reminder chords from silently dropping out again.
-/// Note however, that at least one keybinding *change* was missed -
-/// `\` -> Ctrl+E for the sidebar toggle.
 fn help_tab_body(tab: usize, theme: &Theme) -> Vec<Line<'static>> {
     match HELP_TABS.get(tab).copied().unwrap_or("Normal") {
         "Normal" => vec![

--- a/crates/outl-tui/src/view/overlays.rs
+++ b/crates/outl-tui/src/view/overlays.rs
@@ -1008,7 +1008,7 @@ fn help_tab_body(tab: usize, theme: &Theme) -> Vec<Line<'static>> {
             Line::from("  Ctrl+S      force save"),
             Line::from("  Ctrl+L      reload workspace from disk"),
             Line::from("  B           toggle inline backlinks"),
-            Line::from("  Ctrl+E           toggle left sidebar (opens with focus on Pinned)"),
+            Line::from("  Ctrl+E      toggle left sidebar (opens with focus on Pinned)"),
             Line::from("  q q         quit (chord)"),
             Line::from(""),
             Line::from(Span::styled("Properties (key:: value)", theme.help_title)),
@@ -1060,7 +1060,7 @@ fn help_tab_body(tab: usize, theme: &Theme) -> Vec<Line<'static>> {
         ],
         "Sidebar" => vec![
             Line::from(Span::styled("Open / close", theme.help_title)),
-            Line::from("  Ctrl+E           toggle sidebar (opens with focus on Pinned)"),
+            Line::from("  Ctrl+E      toggle sidebar (opens with focus on Pinned)"),
             Line::from("  Esc         return focus to the outline (sidebar stays open)"),
             Line::from(""),
             Line::from(Span::styled("Inside the sidebar", theme.help_title)),


### PR DESCRIPTION
## What this PR does

The `?` overlay docs were out of date for the sidebar. As a new user, I found this confusing - in general the sidebar overlay docs could probably be improved, but for now this is just a bugfix to the correct key chord (\ -> Ctrl+E). I also note in the comment justifying the inline nature of the docs that this approach didn't catch the sidebar keybinding change.

## How to verify

I didn't actually test. The changes are simple enough that I felt it was higher value to just put up the PR. I haven't gotten tooling set up to build rust crates yet, but I'm happy to do so if you think it's useful. Just not today!

```bash
cargo test --workspace --all-targets
cargo clippy --workspace --all-targets -- -D warnings
cargo fmt --all -- --check
```

## Related issues / docs

Docs in "Pages sidebar": https://outl.app/docs/tui or just confirm keybinding in code / TUI behavior.

## Anything reviewers should look at carefully

N/A

## Out of scope for this PR

It is not suggesting a policy for how to keep keybindings and overlay docs in sync. Honestly, probably an AI review would catch such things. I'm not sure what your stance is on AI, though!

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/outlmd/codesmith/outl/pr/249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790799920&installation_model_id=431529&pr_number=249&repository=outlmd%2Foutl&return_to=https%3A%2F%2Fgithub.com%2Foutlmd%2Foutl%2Fpull%2F249&signature=40c6eb9226dc3aa59ff7bf5d0e87341d52ff1bc6ea548b437ca5b7167dd91566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->