### PR TITLE
fix: lock the workspace before the backlinks index

### DIFF
--- a/crates/outl-tauri-shared/CLAUDE.md
+++ b/crates/outl-tauri-shared/CLAUDE.md
@@ -84,5 +84,10 @@ Turning the refusal into an `Err` would trade a stale page for no page at all on
 - A client that wires `AppHost::backlink_index()` must call `helpers::invalidate_backlink_index` after **every** path that can change what a page's backlinks are.
   That's local mutation (`finish_in_page*` already does this), a peer/workspace reload (`reload_workspace`, desktop's `set_workspace`), and a plugin run that applied ops (`commands/plugin.rs::run` / `sync_hooks`, guarded on `applied > 0`).
   Missing one of these serves stale backlinks until the next unrelated invalidation happens to fire.
+- **Lock order is `workspace` → everything else.**
+  The workspace `Mutex` is the outermost lock; the backlinks index, the undo `history` map and the desktop's `storage_root` slot are only ever taken *inside* it (or on their own).
+  `finish_in_page_with` holds the workspace lock for a whole commit and drops the cached index from in there, so any thread that takes the index first and then waits on the workspace is an ABBA deadlock — `parking_lot::Mutex` has no timeout, so the app freezes until the user force-quits it.
+  `compute_backlinks_offloaded` did exactly that and pasting was the reliable way in: a paste commits twice (draft flush + the paste) and every commit refreshes the panel, so the two collided within a keystroke.
+  Pinned by `tests/backlinks_commit_deadlock.rs`, which stress-runs both paths against a watchdog — a re-inverted order fails the test instead of hanging the app.
 - Never change a DTO shape without checking the TS side (`@outl/shared/api/types`) — the frontends depend on the wire format.
 - Client identity (the `CLIENT` str + capability set) stays in each client's `plugin_service.rs` shim, never here.

--- a/crates/outl-tauri-shared/src/commands/page.rs
+++ b/crates/outl-tauri-shared/src/commands/page.rs
@@ -57,11 +57,6 @@ async fn compute_backlinks_offloaded(
         };
         let backlinks_order = outl_config::load().display.backlinks_order;
 
-        // Phase 2: build the index FROM DISK when stale — reads the `.md`
-        // projection, touches no `Workspace`, holds NO lock. This is what
-        // keeps opening the journal / pressing Esc from freezing: the
-        // O(blocks) work never materializes the vault and never blocks an
-        // edit waiting on the workspace lock.
         let index = match index {
             Some(i) => i,
             None => {
@@ -72,14 +67,12 @@ async fn compute_backlinks_offloaded(
                 return Ok(finish_lookup(ws, &idx, &meta, backlinks_order));
             }
         };
-        if index.lock().is_none() {
-            let fresh = build_backlink_index_from_disk(&metas, &root);
-            let mut g = index.lock();
-            if g.is_none() {
-                *g = Some(fresh);
-            }
-        }
-
+        // Phase 2: build the index FROM DISK when stale — reads the `.md`
+        // projection, touches no `Workspace`, holds NO lock. This is what
+        // keeps opening the journal / pressing Esc from freezing: the
+        // O(blocks) work never materializes the vault and never blocks an
+        // edit waiting on the workspace lock.
+        //
         // Phase 3: O(refs) lookup under a brief lock (`for_page` reads the
         // page's own `template::` property; no block-text scan).
         //
@@ -92,11 +85,36 @@ async fn compute_backlinks_offloaded(
         // is the reliable way in, because it commits twice (draft flush +
         // the paste) and each commit refreshes this panel.
         // See `tests/backlinks_commit_deadlock.rs`.
+        //
+        // Nothing ties the build to the lookup: a commit can run
+        // `invalidate_backlink_index` in between and legitimately empty
+        // the slot again. That is a retry, never a panic: a panic in this
+        // blocking task surfaces as a join error the frontend ignores, and
+        // the panel silently stops refreshing.
+        for _ in 0..3 {
+            if index.lock().is_none() {
+                let fresh = build_backlink_index_from_disk(&metas, &root);
+                let mut g = index.lock();
+                if g.is_none() {
+                    *g = Some(fresh);
+                }
+            }
+            let guard = workspace.lock();
+            let ws = guard.as_ref().ok_or_else(|| ERR_LOADING.to_string())?;
+            let g = index.lock();
+            if let Some(idx) = g.as_ref() {
+                return Ok(finish_lookup(ws, idx, &meta, backlinks_order));
+            }
+            // Invalidated between the build and the lookup: drop both
+            // locks and rebuild.
+        }
+        // Commits are invalidating faster than the cache refills; serve a
+        // one-shot from-disk build directly, same as the host-without-a-slot
+        // path above (marginally stale is fine, the next refresh re-caches).
+        let idx = build_backlink_index_from_disk(&metas, &root);
         let guard = workspace.lock();
         let ws = guard.as_ref().ok_or_else(|| ERR_LOADING.to_string())?;
-        let g = index.lock();
-        let idx = g.as_ref().expect("index just built");
-        Ok(finish_lookup(ws, idx, &meta, backlinks_order))
+        Ok(finish_lookup(ws, &idx, &meta, backlinks_order))
     })
     .await
     .map_err(|e| format!("backlinks task join: {e}"))?

--- a/crates/outl-tauri-shared/src/commands/page.rs
+++ b/crates/outl-tauri-shared/src/commands/page.rs
@@ -67,7 +67,9 @@ async fn compute_backlinks_offloaded(
             None => {
                 // Host without a cached slot: one-shot from-disk build.
                 let idx = build_backlink_index_from_disk(&metas, &root);
-                return finish_lookup(&workspace, &idx, &meta, backlinks_order);
+                let guard = workspace.lock();
+                let ws = guard.as_ref().ok_or_else(|| ERR_LOADING.to_string())?;
+                return Ok(finish_lookup(ws, &idx, &meta, backlinks_order));
             }
         };
         if index.lock().is_none() {
@@ -80,9 +82,21 @@ async fn compute_backlinks_offloaded(
 
         // Phase 3: O(refs) lookup under a brief lock (`for_page` reads the
         // page's own `template::` property; no block-text scan).
+        //
+        // **Workspace first, then the index — never the other way round.**
+        // A commit holds the workspace lock for the whole of
+        // `finish_in_page_with` and drops the cached index from inside it
+        // (`invalidate_backlink_index`), so this thread taking the index
+        // lock first and then waiting on the workspace is an ABBA deadlock
+        // with no timeout: the app freezes until it is force-quit. A paste
+        // is the reliable way in, because it commits twice (draft flush +
+        // the paste) and each commit refreshes this panel.
+        // See `tests/backlinks_commit_deadlock.rs`.
+        let guard = workspace.lock();
+        let ws = guard.as_ref().ok_or_else(|| ERR_LOADING.to_string())?;
         let g = index.lock();
         let idx = g.as_ref().expect("index just built");
-        finish_lookup(&workspace, idx, &meta, backlinks_order)
+        Ok(finish_lookup(ws, idx, &meta, backlinks_order))
     })
     .await
     .map_err(|e| format!("backlinks task join: {e}"))?
@@ -90,26 +104,27 @@ async fn compute_backlinks_offloaded(
 
 /// Look a page up in `index` and shape the reply. GUI rows render only
 /// `source_block.tokens`, so each hit ships through `into_shallow` to
-/// keep the subtree off the IPC wire. Takes a brief workspace lock for
-/// `for_page` (which reads the page's `template::` property).
+/// keep the subtree off the IPC wire.
+///
+/// Takes the already-locked `&Workspace` (`for_page` reads the page's
+/// `template::` property) rather than the `Arc<Mutex<…>>`: the caller owns
+/// the lock order, and the only safe one here is workspace → index.
 fn finish_lookup(
-    workspace: &Arc<Mutex<Option<Workspace>>>,
+    ws: &Workspace,
     index: &BacklinkIndex,
     meta: &PageMeta,
     backlinks_order: outl_config::BacklinksOrder,
-) -> Result<BacklinksReply, String> {
-    let guard = workspace.lock();
-    let ws = guard.as_ref().ok_or_else(|| ERR_LOADING.to_string())?;
+) -> BacklinksReply {
     let mut backlinks: Vec<_> = index
         .for_page(ws, meta)
         .into_iter()
         .map(|b| b.into_shallow())
         .collect();
     sort_backlinks(&mut backlinks, backlinks_order.newest_first());
-    Ok(BacklinksReply {
+    BacklinksReply {
         backlinks,
         backlinks_order,
-    })
+    }
 }
 
 pub fn list_all_pages<S: AppHost>(state: &S) -> Result<Vec<PageMeta>, String> {

--- a/crates/outl-tauri-shared/tests/backlinks_commit_deadlock.rs
+++ b/crates/outl-tauri-shared/tests/backlinks_commit_deadlock.rs
@@ -1,0 +1,147 @@
+//! A local mutation and a backlinks refresh must never deadlock.
+//!
+//! Every GUI commit funnels through `finish_in_page`, which holds the
+//! **workspace** lock and then drops the cached backlinks index
+//! (`invalidate_backlink_index` → **index** lock). `page_backlinks` runs
+//! off-thread and used to do the opposite: take the **index** lock and
+//! then, inside `finish_lookup`, the **workspace** lock. Two locks taken
+//! in opposite orders is an ABBA deadlock, and `parking_lot::Mutex` has
+//! no timeout — the app freezes for good and the user force-quits it.
+//!
+//! The frontend fires both together on every paste (`applyView` refreshes
+//! backlinks after each commit, and a paste commits twice: the draft flush
+//! plus the paste itself), which is why pasting was the reliable way in.
+//!
+//! The guard is a stress loop with a watchdog: on the buggy ordering the
+//! threads park forever and the watchdog fails the test instead of hanging
+//! the suite.
+
+use std::path::PathBuf;
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::time::Duration;
+
+use outl_actions::{
+    append_block, apply_page_md_with_sidecar, edit_text, open_or_create_page, PageKind,
+    SyncTransport,
+};
+use outl_core::hlc::HlcGenerator;
+use outl_core::id::{ActorId, NodeId};
+use outl_core::storage::JsonlStorage;
+use outl_core::workspace::Workspace;
+use outl_exec::RuntimeRegistry;
+use outl_tauri_shared::commands::page::page_backlinks;
+use outl_tauri_shared::helpers::finish_in_page;
+use outl_tauri_shared::host::AppHost;
+use parking_lot::Mutex;
+use tempfile::TempDir;
+
+struct TestHost {
+    workspace: Arc<Mutex<Option<Workspace>>>,
+    hlc: HlcGenerator,
+    root: PathBuf,
+    registry: Arc<RuntimeRegistry>,
+    backlinks: Arc<Mutex<Option<outl_actions::BacklinkIndex>>>,
+}
+
+impl AppHost for TestHost {
+    fn workspace(&self) -> &Mutex<Option<Workspace>> {
+        &self.workspace
+    }
+    fn workspace_arc(&self) -> Arc<Mutex<Option<Workspace>>> {
+        self.workspace.clone()
+    }
+    fn hlc(&self) -> &HlcGenerator {
+        &self.hlc
+    }
+    fn storage_root(&self) -> Result<PathBuf, String> {
+        Ok(self.root.clone())
+    }
+    fn sync_transport(&self) -> Option<Arc<dyn SyncTransport>> {
+        None
+    }
+    fn exec_registry(&self) -> Arc<RuntimeRegistry> {
+        self.registry.clone()
+    }
+    fn backlink_index(&self) -> Option<Arc<Mutex<Option<outl_actions::BacklinkIndex>>>> {
+        Some(self.backlinks.clone())
+    }
+}
+
+#[test]
+fn a_commit_and_a_backlinks_refresh_never_deadlock() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+    let actor = ActorId::new();
+    let hlc = HlcGenerator::new(actor);
+
+    let storage = JsonlStorage::open(root.join("ops"), actor).unwrap();
+    let mut ws =
+        Workspace::open_with_storage(actor, Box::new(storage), Some(root.clone())).unwrap();
+
+    // A page that is referenced from elsewhere, so the backlinks lookup
+    // has real work to do (and the index is worth caching).
+    let target = open_or_create_page(&mut ws, &hlc, "target", "Target", PageKind::Page).unwrap();
+    append_block(&mut ws, &hlc, Some(target), Some("target block")).unwrap();
+    let src = open_or_create_page(&mut ws, &hlc, "src", "Src", PageKind::Page).unwrap();
+    let block = append_block(&mut ws, &hlc, Some(src), Some("see [[target]]")).unwrap();
+    apply_page_md_with_sidecar(&ws, &root, target).unwrap();
+    apply_page_md_with_sidecar(&ws, &root, src).unwrap();
+
+    let host = Arc::new(TestHost {
+        workspace: Arc::new(Mutex::new(Some(ws))),
+        hlc,
+        root,
+        registry: Arc::new(RuntimeRegistry::with_builtins()),
+        backlinks: Arc::new(Mutex::new(None)),
+    });
+
+    let (done_tx, done_rx) = mpsc::channel::<&'static str>();
+
+    // Thread A: the commit path — the workspace lock, then the index.
+    let commits = {
+        let host = host.clone();
+        let done = done_tx.clone();
+        std::thread::spawn(move || {
+            for i in 0..200 {
+                let text = format!("see [[target]] {i}");
+                let _ = finish_in_page(host.as_ref(), src, |ws| {
+                    edit_text(ws, host.hlc(), block, &text).map(|_| ())
+                });
+            }
+            let _ = done.send("commits");
+        })
+    };
+
+    // Thread B: the backlinks path — the index lock, then the workspace.
+    let lookups = {
+        let host = host.clone();
+        let done = done_tx.clone();
+        std::thread::spawn(move || {
+            for _ in 0..200 {
+                let _ = tauri::async_runtime::block_on(page_backlinks(
+                    host.as_ref(),
+                    "target".to_string(),
+                ));
+            }
+            let _ = done.send("backlinks");
+        })
+    };
+
+    // Watchdog: a deadlock parks both threads forever, so turn "never
+    // finished" into a failing assertion instead of a hung test binary.
+    let mut finished = 0;
+    while finished < 2 {
+        match done_rx.recv_timeout(Duration::from_secs(60)) {
+            Ok(_) => finished += 1,
+            Err(_) => panic!(
+                "deadlock: a commit and a backlinks refresh blocked each other \
+                 (workspace/backlink-index lock order inversion)"
+            ),
+        }
+    }
+
+    commits.join().unwrap();
+    lookups.join().unwrap();
+    let _: Option<NodeId> = None;
+}

--- a/crates/outl-tauri-shared/tests/backlinks_commit_deadlock.rs
+++ b/crates/outl-tauri-shared/tests/backlinks_commit_deadlock.rs
@@ -26,7 +26,7 @@ use outl_actions::{
     SyncTransport,
 };
 use outl_core::hlc::HlcGenerator;
-use outl_core::id::{ActorId, NodeId};
+use outl_core::id::ActorId;
 use outl_core::storage::JsonlStorage;
 use outl_core::workspace::Workspace;
 use outl_exec::RuntimeRegistry;
@@ -105,24 +105,27 @@ fn a_commit_and_a_backlinks_refresh_never_deadlock() {
         std::thread::spawn(move || {
             for i in 0..200 {
                 let text = format!("see [[target]] {i}");
-                let _ = finish_in_page(host.as_ref(), src, |ws| {
+                finish_in_page(host.as_ref(), src, |ws| {
                     edit_text(ws, host.hlc(), block, &text).map(|_| ())
-                });
+                })
+                .expect("commit must succeed; an erroring commit path skips the invalidate and the stress proves nothing");
             }
             let _ = done.send("commits");
         })
     };
 
-    // Thread B: the backlinks path — the index lock, then the workspace.
+    // Thread B: the backlinks refresh: the workspace lock, then the
+    // index (the historical bug took them in the opposite order).
     let lookups = {
         let host = host.clone();
         let done = done_tx.clone();
         std::thread::spawn(move || {
             for _ in 0..200 {
-                let _ = tauri::async_runtime::block_on(page_backlinks(
+                tauri::async_runtime::block_on(page_backlinks(
                     host.as_ref(),
                     "target".to_string(),
-                ));
+                ))
+                .expect("backlinks refresh must succeed; an erroring lookup path contends on nothing");
             }
             let _ = done.send("backlinks");
         })
@@ -143,5 +146,4 @@ fn a_commit_and_a_backlinks_refresh_never_deadlock() {
 
     commits.join().unwrap();
     lookups.join().unwrap();
-    let _: Option<NodeId> = None;
 }


### PR DESCRIPTION
A commit holds the workspace lock for the whole of finish_in_page_with and drops the cached backlinks index from inside that guard. Phase 3 of compute_backlinks_offloaded did the opposite, taking the index lock and then waiting on the workspace inside finish_lookup. Two parking_lot mutexes in opposite orders deadlock with no timeout, and this one parks the Tauri IPC main thread, so the window dies with it and Force Quit is the only way out.

Paste is what gets you there. It commits twice, the draft flush plus the paste itself, and applyView refreshes the backlinks panel after each one. A link copied from the browser is what routes a paste through the backend at all, since a plain single line clipboard takes the native splice and issues no command.

finish_lookup now takes the already locked &Workspace instead of the Arc<Mutex<...>>, so the call site owns the order and the only order is workspace then index. tests/backlinks_commit_deadlock.rs runs both paths against each other behind a watchdog. It hangs on the old ordering and passes in 4.3s on this one.

Fixes #251

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/outlmd/codesmith/outl/pr/252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->