### PR TITLE
feat(theme): add gruvbox preset

### DIFF
--- a/crates/outl-cli/src/main.rs
+++ b/crates/outl-cli/src/main.rs
@@ -42,8 +42,8 @@ struct Cli {
     workspace: Option<PathBuf>,
 
     /// TUI theme preset (default-dark, light, logseq-light, dracula,
-    /// solarized-dark, nord, monokai). Overrides `[theme] preset` in
-    /// workspace `config.toml` for this run.
+    /// solarized-dark, nord, monokai, gruvbox). Overrides `[theme]
+    /// preset` in workspace `config.toml` for this run.
     #[arg(long, global = true, value_name = "PRESET")]
     theme: Option<String>,
 

--- a/crates/outl-theme/CLAUDE.md
+++ b/crates/outl-theme/CLAUDE.md
@@ -34,7 +34,7 @@ This is what lets every other crate cheaply depend on us.
 - [`Palette`] — the struct of named hex strings (one per semantic surface).
   Field naming follows "what the surface IS", not "what it looks like" (`ref_link_fg`, not `purple_underline`).
   Two surfaces that genuinely share a style share the field.
-- The nine built-in presets in `src/presets.rs`: `outl`, `outl-light`, `default-dark`, `light`, `logseq-light`, `dracula`, `solarized-dark`, `nord`, `monokai`.
+- The ten built-in presets in `src/presets.rs`: `outl`, `outl-light`, `default-dark`, `light`, `logseq-light`, `dracula`, `solarized-dark`, `nord`, `monokai`, `gruvbox`.
 - [`PRESETS`] — the canonical user-visible order (alphabetical-ish, brand first).
 - [`by_name`] — case- and separator-insensitive lookup so `"Solarized Dark"`, `"solarized_dark"`, and `"solarized-dark"` all resolve.
 - [`default`] / [`all`] — fallback + iterator helpers for pickers.

--- a/crates/outl-theme/src/lib.rs
+++ b/crates/outl-theme/src/lib.rs
@@ -46,6 +46,7 @@ pub const PRESETS: &[&str] = &[
     "solarized-dark",
     "nord",
     "monokai",
+    "gruvbox",
 ];
 
 /// Resolve a preset by name. Accepts the canonical name or any of
@@ -74,6 +75,7 @@ pub fn by_name(name: &str) -> Option<Palette> {
         "solarized-dark" | "solarized" => Some(presets::solarized_dark()),
         "nord" => Some(presets::nord()),
         "monokai" => Some(presets::monokai()),
+        "gruvbox" | "gruvbox-dark" => Some(presets::gruvbox()),
         _ => None,
     }
 }

--- a/crates/outl-theme/src/presets.rs
+++ b/crates/outl-theme/src/presets.rs
@@ -601,3 +601,71 @@ pub fn monokai() -> Palette {
         help_title_fg: yellow.into(),
     }
 }
+
+/// Gruvbox Dark — morhetz's retro-groove palette. Warm charcoal
+/// background (`#282828`), cream text (`#ebdbb2`), and the classic
+/// muted yellow / green / aqua / purple accents. Hex values sourced
+/// from the canonical gruvbox palette (dark variant).
+pub fn gruvbox() -> Palette {
+    let bg = "#282828"; // bg0
+    let bg_elev = "#3c3836"; // bg1
+    let border = "#504945"; // bg2
+    let fg = "#ebdbb2"; // fg1
+    let fg_soft = "#d5c4a1"; // fg2
+    let fg_dim = "#a89984"; // fg4
+    let fg_dimmer = "#7c6f64"; // fg5
+    let yellow = "#fabd2f";
+    let orange = "#fe8019";
+    let green = "#b8bb26";
+    let aqua = "#8ec07c";
+    let blue = "#458588";
+    let purple = "#d3869b";
+    let red = "#fb4934"; // bright red — #cc241d is too dim on bg0 for a destructive hue
+
+    Palette {
+        name: "gruvbox".into(),
+        bg: bg.into(),
+        bg_elev: bg_elev.into(),
+        fg: fg.into(),
+        fg_dim: fg_dim.into(),
+        fg_dimmer: fg_dimmer.into(),
+        border: border.into(),
+        hint: fg_dim.into(),
+        accent: yellow.into(),
+        accent_soft: orange.into(),
+        accent_alt: green.into(),
+        warn: orange.into(),
+        destructive: red.into(),
+        ref_link_fg: aqua.into(),
+        tag_link_fg: purple.into(),
+        md_link_fg: blue.into(),
+        bold_fg: fg.into(),
+        italic_fg: fg_soft.into(),
+        strike_fg: fg_dimmer.into(),
+        highlight_bg: yellow.into(),
+        highlight_fg: bg.into(),
+        code_fg: green.into(),
+        todo_open_fg: orange.into(),
+        todo_done_fg: green.into(),
+        todo_done_body_fg: fg_dimmer.into(),
+        property_key_fg: fg_dimmer.into(),
+        property_value_fg: fg_soft.into(),
+        heading_fg: fg.into(),
+        dim_fg: fg_dimmer.into(),
+        selected_bullet_bg: yellow.into(),
+        selected_bullet_fg: bg.into(),
+        cursor_block_bg: fg.into(),
+        cursor_block_fg: bg.into(),
+        cursor_caret_fg: fg_soft.into(),
+        status_normal_bg: yellow.into(),
+        status_normal_fg: bg.into(),
+        status_insert_bg: green.into(),
+        status_insert_fg: bg.into(),
+        status_visual_bg: purple.into(),
+        status_visual_fg: bg.into(),
+        status_message_fg: orange.into(),
+        list_selected_bg: border.into(),
+        list_selected_fg: fg.into(),
+        help_title_fg: yellow.into(),
+    }
+}

--- a/crates/outl-tui/src/theme.rs
+++ b/crates/outl-tui/src/theme.rs
@@ -227,6 +227,7 @@ pub const PRESETS: &[&str] = &[
     "solarized-dark",
     "nord",
     "monokai",
+    "gruvbox",
 ];
 
 /// Look up a preset by name. Case-insensitive; dashes and underscores
@@ -251,6 +252,7 @@ pub fn by_name(name: &str) -> Option<Theme> {
         "nord" => Some(nord()),
         "monokai" => Some(monokai()),
         "outl-light" => Some(outl_light()),
+        "gruvbox" | "gruvbox-dark" => Some(gruvbox()),
         _ => None,
     }
 }
@@ -444,6 +446,11 @@ pub fn nord() -> Theme {
 /// Monokai — Wimer Hazenberg's high-contrast palette.
 pub fn monokai() -> Theme {
     theme_from_palette("monokai", &outl_theme::presets::monokai())
+}
+
+/// Gruvbox Dark — morhetz's retro-groove palette.
+pub fn gruvbox() -> Theme {
+    theme_from_palette("gruvbox", &outl_theme::presets::gruvbox())
 }
 
 #[cfg(test)]

--- a/docs/config.md
+++ b/docs/config.md
@@ -129,7 +129,7 @@ That is a one-time, behaviour-preserving change to the file, since `ThemeCfg::da
 
 `outl doctor` warns when a configured pair has two light or two dark sides (e.g. `mode = "light"` naming a dark preset) — a misconfigured pair, not a resolution bug.
 
-Available presets: `outl`, `outl-light`, `default-dark`, `light`, `logseq-light`, `dracula`, `solarized-dark`, `nord`, `monokai`.
+Available presets: `outl`, `outl-light`, `default-dark`, `light`, `logseq-light`, `dracula`, `solarized-dark`, `nord`, `monokai`, `gruvbox`.
 See [theming.md](theming.md) for the look of each.
 
 #### `[editor]`

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,6 +1,6 @@
 # Theming
 
-outl ships nine built-in palettes (`outl`, `outl-light`, `default-dark`, `light`, `logseq-light`, `dracula`, `solarized-dark`, `nord`, `monokai`).
+outl ships ten built-in palettes (`outl`, `outl-light`, `default-dark`, `light`, `logseq-light`, `dracula`, `solarized-dark`, `nord`, `monokai`, `gruvbox`).
 The hex values live in the shared **`outl-theme`** crate — every styled surface (`ref_link_fg`, `cursor_block_bg`, `bold_fg`, `status_normal_bg`, …) is a named field on a `Palette` struct, and the TUI / desktop / mobile clients each turn those hex strings into whatever their renderer expects.
 
 This means a color change in `outl-theme/src/presets.rs` propagates to every client without a coordinated edit.
@@ -89,6 +89,7 @@ Now that the modal owns all three fields, restoring any of them would silently d
 | `solarized-dark` | Ethan Schoonover's classic. Muted base03 background. |
 | `nord` | Arctic blue-greys. Cool, low-contrast. |
 | `monokai` | Wimer Hazenberg's high-contrast. Hot pink for highlights. |
+| `gruvbox` | morhetz's retro-groove dark. Warm charcoal, cream text, muted yellow/green/aqua. Alias: `gruvbox-dark`. |
 
 `outl theme list` prints them on a terminal.
 `outl theme show <name>` dumps every style in that preset (`ref_link = Style { fg: ..., ... }`).
@@ -167,7 +168,7 @@ The `every_palette_field_is_hex` test catches a typo like `"#xyz123"` or a misse
 
 - **Don't overlap modifiers on the same field across themes.** Solarized's `bold` is `fg(orange) + BOLD`; Dracula's is similar but on orange too.
   Keep modifiers semantic (BOLD for bold, etc.) and let the color carry the personality.
-- **Backgrounds**: the RGB presets (`outl`, `logseq-light`, `dracula`, `solarized-dark`, `nord`, `monokai`) paint `bg` across the whole TUI canvas and use `fg` as the base text color, so a light theme stays readable on a dark terminal (and vice versa).
+- **Backgrounds**: the RGB presets (`outl`, `logseq-light`, `dracula`, `solarized-dark`, `nord`, `monokai`, `gruvbox`) paint `bg` across the whole TUI canvas and use `fg` as the base text color, so a light theme stays readable on a dark terminal (and vice versa).
   Only the two ANSI presets (`default-dark`, `light`) keep `Color::Reset` and inherit the terminal's own background/foreground — that's their point.
 - **Underline on `ref_link` and `tag_link` is intentional.** They're the only "clickable" things in pretty-render mode, and the underline is the visual affordance.
 - **Contrast matters more than tone.** Test your theme against a workspace with lots of refs, tags, code, and TODOs.
@@ -176,7 +177,7 @@ The `every_palette_field_is_hex` test catches a typo like `"#xyz123"` or a misse
 
 | Client | What it does with the hex |
 |---|---|
-| **`outl-tui`** | `crates/outl-tui/src/theme.rs::theme_from_palette` converts each `#rrggbb` to `ratatui::Color::Rgb(r, g, b)` and re-applies the consistent modifiers (`BOLD` on `bold`, `UNDERLINED` on links, `ITALIC` on `italic`, `CROSSED_OUT` on `strike`). The six RGB presets (`outl`, `logseq-light`, `dracula`, `solarized-dark`, `nord`, `monokai`) are one-line delegates; `default-dark` and `light` stay manual on ANSI named colors. |
+| **`outl-tui`** | `crates/outl-tui/src/theme.rs::theme_from_palette` converts each `#rrggbb` to `ratatui::Color::Rgb(r, g, b)` and re-applies the consistent modifiers (`BOLD` on `bold`, `UNDERLINED` on links, `ITALIC` on `italic`, `CROSSED_OUT` on `strike`). The seven RGB presets (`outl`, `logseq-light`, `dracula`, `solarized-dark`, `nord`, `monokai`, `gruvbox`) are one-line delegates; `default-dark` and `light` stay manual on ANSI named colors. |
 | **`outl-desktop`** | The Tauri commands `list_themes()` and `get_theme(name)` return the `Palette` as JSON. The frontend writes each field as a CSS custom property on `<html>` (`--color-outl-accent`, `--color-outl-ref-link-fg`, …) so Tailwind class utilities like `text-(--color-outl-accent)` resolve at runtime, and flips `color-scheme` (light/dark) from the palette's `bg` luminance so native controls and scrollbars follow. Settings modal exposes the dropdown. Chrome surfaces never hardcode a hue — translucent layers derive from `--color-outl-fg` (`bg-(--color-outl-fg)/10`) so they adapt to light and dark presets alike. |
 | **`outl-mobile`** | Shared `@outl/shared/theme::installTheme` fetches both sides of the configured pair and holds both `Palette` objects in memory, then calls `applyPaletteToRoot` (RFC 0022, issue #22). A `prefers-color-scheme` media-query listener swaps tokens on an OS appearance flip without a second backend round-trip; a fresh default config uses `outl-light` / `outl`. |
 


### PR DESCRIPTION
## What this PR does

Gruvbox is one of the most widely used terminal and editor palettes, but outl ships no matching preset, so a TUI user running gruvbox everywhere else cannot make outl match their environment. This adds the Gruvbox Dark palette (morhetz's canonical hex values) to `outl-theme`, wires it through the TUI delegate and the CLI `--theme` help, and documents it. Desktop and mobile pick it up automatically via `list_themes`.

## How to verify

```bash
cargo test --workspace --all-targets
cargo clippy --workspace --all-targets -- -D warnings
cargo fmt --all -- --check
```

Plus: `outl --theme gruvbox` boots the TUI in the new palette; `by_name` resolves `gruvbox` and the alias `gruvbox-dark`. The existing preset tests (`every_palette_field_is_hex`, `every_listed_preset_resolves`) cover the new entry.

## Related issues / docs

Related to #258
Updated docs: `docs/theming.md`, `docs/config.md`, `crates/outl-theme/CLAUDE.md`

## Anything reviewers should look at carefully

- No CRDT-, markdown-format-, or public-API implication — purely additive preset.
- `destructive` uses gruvbox bright red `#fb4934`; the classic `#cc241d` is too dim on bg0 for a destructive hue.

## Out of scope for this PR

- No light-gruvbox variant (natural follow-up if wanted).
- No per-client overrides; every client consumes the same `Palette`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/outlmd/codesmith/outl/pr/259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791409583&installation_model_id=431529&pr_number=259&repository=outlmd%2Foutl&return_to=https%3A%2F%2Fgithub.com%2Foutlmd%2Foutl%2Fpull%2F259&signature=55ff6750b31f36425b2faeac67626e2d35a1109e2e976fa3dec484276447c11a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->