### PR TITLE
Fix Homebrew install command for outl-beta (mutliple matches)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Tree CRDT sync ([Kleppmann et al. 2022][paper]), per-device append-only op log, 
 # macOS / Linux via Homebrew (beta channel — every push to main)
 brew tap outlmd/outl https://github.com/outlmd/outl
 brew trust outlmd/outl # one-time, third-party tap
-brew install outl-beta # TUI/CLI/MCP
+brew install outlmd/outl/outl-beta # TUI/CLI/MCP
 brew install --cask outl-desktop-beta # GUI
 ```
 


### PR DESCRIPTION
Updated Homebrew installation command for outl-beta.

## What this PR does

One paragraph.
The *why* first, then the *what*.

## How to verify

```bash
cargo test --workspace --all-targets
cargo clippy --workspace --all-targets -- -D warnings
cargo fmt --all -- --check
```

Plus any feature-specific checks (manual smoke, fixture files, screenshot of TUI state, ...).

## Related issues / docs

Closes #...
Related to #...
Updated docs: `docs/...`

## Anything reviewers should look at carefully

- Is there a CRDT-correctness implication?
  Did `crdt-invariant-checker` pass?
- Is there a markdown-format implication?
  Did `markdown-roundtrip-tester` pass?
- New public API on `outl-core` / `outl-md`?
  Is it documented in the per-crate CLAUDE.md?
- Any change to keymaps in `outl-tui`?
  Updated `docs/tui.md` and the in-app help popup?

## Out of scope for this PR

What this PR is *not* doing, even if related.
Helps reviewers not nudge for scope creep.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/outlmd/codesmith/outl/pr/267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791554856&installation_model_id=431529&pr_number=267&repository=outlmd%2Foutl&return_to=https%3A%2F%2Fgithub.com%2Foutlmd%2Foutl%2Fpull%2F267&signature=315c2abe92453e8d6dbc9e4811b7f44191185571c301aa775672a0cb8e33a152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->