### PR TITLE
Mcp token diet

### DIFF
--- a/crates/outl-cli/CLAUDE.md
+++ b/crates/outl-cli/CLAUDE.md
@@ -344,7 +344,7 @@ src/
     └── prompts.rs         # /outl-* prompts
 ```
 
-Every `commands/*.rs` handler is `pub fn` so `mcp/tools/dispatch.rs` reuses it directly.
+Every `cmd/*.rs` handler is `pub fn` so `mcp/tools/dispatch.rs` reuses it directly.
 New tools land by:
 
 1. Adding a function in the relevant `cmd/*.rs` returning `Result<Value, ApiError>`.

--- a/crates/outl-cli/CLAUDE.md
+++ b/crates/outl-cli/CLAUDE.md
@@ -220,6 +220,14 @@ The full mapping (CLI ↔ MCP tool) is documented in [`docs/cli.md`](../../docs/
 - `outl mcp serve [--workspace=…]` — JSON-RPC 2.0 over stdio implementing the MCP protocol surface Claude Desktop expects (`initialize`, `tools/list`, `tools/call`, `resources/list`, `resources/read`, `prompts/list`, `prompts/get`).
   Every tool is a thin router that delegates to the same handler the CLI subcommand calls — there is no second business-logic path.
 
+**The response is projected for an LLM consumer, not a script — this is the one place the MCP surface diverges from the CLI, and the handler is untouched.**
+`mcp/tools/payload.rs` owns the wrapping.
+A **success** reply is content-only: the handler's `data` as compact JSON in `content[0].text` (no `structuredContent` — at protocol `2024-11-05` that was a discarded second copy), or the raw `.md` for markdown-first tools (`export_md`, `page_render`, `daily_*`).
+It also drops fields only a GUI renderer reads — an outline node's `tokens` (a pre-tokenized inline AST that restates `text`), and default-valued `collapsed` / `todo` / empty `properties` — because the shared `project_outline` shape serves the Tauri clients too and an LLM already has `text`.
+The CLI's own `--json` keeps every field.
+An **error** reply is the deliberate exception: it sets `isError: true` and keeps `structuredContent: { ok: false, error }` so `error.data` (RFC 0255's `PAGE_MARKDOWN_AHEAD_OF_LOG` carries `path` / `lines` / `sample` / `recovery_command`) is machine-readable.
+Pruning keys off the outline-node signature (`text` + `children`) so a same-named field on another payload (`page_prop_list`'s `properties`) is never touched; pinned by `mcp/tools/payload.rs`'s tests.
+
 ## P2P sync: the MCP takes the endpoint when nobody else has it
 
 iroh's relay routes only ONE endpoint per `node_id` at a time.
@@ -324,19 +332,23 @@ src/
 │   ├── batch.rs           # outl batch
 │   └── workspace_info.rs  # outl workspace info
 └── mcp/
-    ├── mod.rs             # stdio loop, dispatch
+    ├── mod.rs             # stdio loop, dispatch, ServerCtx
     ├── protocol.rs        # JSON-RPC 2.0 shapes + error codes
-    ├── tools.rs           # tool registry + handler dispatch
+    ├── tools/
+    │   ├── mod.rs         #   shared helpers (tool_def, require_str, …)
+    │   ├── registry.rs    #   tools/list schema list
+    │   ├── dispatch.rs    #   tools/call router → cmd/* handlers
+    │   └── payload.rs     #   LLM-facing result projection (see MCP section)
     ├── resources.rs       # outl:// URI handlers + templates
     └── prompts.rs         # /outl-* prompts
 ```
 
-Every `commands/*.rs` handler is `pub fn` so `mcp/tools.rs` reuses it directly.
+Every `commands/*.rs` handler is `pub fn` so `mcp/tools/dispatch.rs` reuses it directly.
 New tools land by:
 
 1. Adding a function in the relevant `cmd/*.rs` returning `Result<Value, ApiError>`.
 2. Threading it through the local `Subcommand` and `run()` switch.
-3. Registering the tool in `mcp/tools::list` (schema) and `mcp/tools::run_tool` (dispatch).
+3. Registering the tool in `mcp/tools::registry::list` (schema) and `mcp/tools::dispatch::run_tool` (dispatch).
 
 ## Mutating a page: use the commit pipeline
 

--- a/crates/outl-cli/CLAUDE.md
+++ b/crates/outl-cli/CLAUDE.md
@@ -222,10 +222,11 @@ The full mapping (CLI ↔ MCP tool) is documented in [`docs/cli.md`](../../docs/
 
 **The response is projected for an LLM consumer, not a script — this is the one place the MCP surface diverges from the CLI, and the handler is untouched.**
 `mcp/tools/payload.rs` owns the wrapping.
-A **success** reply is content-only: the handler's `data` as compact JSON in `content[0].text` (no `structuredContent` — at protocol `2024-11-05` that was a discarded second copy), or the raw `.md` for markdown-first tools (`export_md`, `page_render`, `daily_*`).
+A **success** reply is content-only: the handler's `data` as compact JSON in `content[0].text`, or the raw `.md` for markdown-first tools (`export_md`, `page_render`, `daily_*`).
+No `structuredContent` — the text already holds the full payload, so an envelope around it is a duplicate.
 It also drops fields only a GUI renderer reads — an outline node's `tokens` (a pre-tokenized inline AST that restates `text`), and default-valued `collapsed` / `todo` / empty `properties` — because the shared `project_outline` shape serves the Tauri clients too and an LLM already has `text`.
 The CLI's own `--json` keeps every field.
-An **error** reply is the deliberate exception: it sets `isError: true` and keeps `structuredContent: { ok: false, error }` so `error.data` (RFC 0255's `PAGE_MARKDOWN_AHEAD_OF_LOG` carries `path` / `lines` / `sample` / `recovery_command`) is machine-readable.
+An **error** reply is the deliberate exception: its text is only a `code: message` summary, so it sets `isError: true` and keeps `structuredContent: { ok: false, error }` — the sole machine-readable copy of `error.data` (RFC 0255's `PAGE_MARKDOWN_AHEAD_OF_LOG` carries `path` / `lines` / `sample` / `recovery_command`).
 Pruning keys off the outline-node signature (`text` + `children`) so a same-named field on another payload (`page_prop_list`'s `properties`) is never touched; pinned by `mcp/tools/payload.rs`'s tests.
 
 ## P2P sync: the MCP takes the endpoint when nobody else has it

--- a/crates/outl-cli/src/mcp/mod.rs
+++ b/crates/outl-cli/src/mcp/mod.rs
@@ -21,7 +21,7 @@ use parking_lot::Mutex;
 use serde_json::{json, Value};
 use tracing::{debug, warn};
 
-use crate::output::{codes, ApiError, Envelope};
+use crate::output::{codes, ApiError};
 use crate::ws::{self, WsCtx};
 use outl_actions::SyncTransport;
 use outl_md::index::WorkspaceIndex;
@@ -394,74 +394,6 @@ fn dispatch(
         "prompts/get" => prompts::get(params, ctx),
         other => Err(protocol::JsonRpcError::method_not_found(other)),
     }
-}
-
-/// Wrap an [`ApiError`] into MCP tool output. MCP tool errors flow
-/// through the response shape `{ content: [...], isError: true }`
-/// rather than as JSON-RPC errors, so the client gets a recoverable
-/// signal instead of a protocol-level fault.
-///
-/// `structuredContent` carries the same `Envelope` shape a success
-/// reply does (`{ ok, data, error }`), so a caller that already reads
-/// structured replies doesn't need a second parser for the failure
-/// case. This is what makes `ApiError::data` reach the wire: a code
-/// like `PAGE_MARKDOWN_AHEAD_OF_LOG` alone tells a caller *that* a
-/// page stopped syncing, but `error.data.path` / `.lines` / `.sample`
-/// / `.recovery_command` is what lets it act instead of just
-/// reporting the failure onward (RFC 0255).
-pub(crate) fn tool_error_payload(err: &ApiError) -> Value {
-    let envelope = Envelope::<Value>::failure(err.clone());
-    json!({
-        "content": [
-            { "type": "text", "text": format!("{}: {}", err.code, err.message) }
-        ],
-        "structuredContent": serde_json::to_value(&envelope).unwrap_or(Value::Null),
-        "isError": true,
-    })
-}
-
-/// Wrap a successful tool result into the MCP tool-output envelope.
-///
-/// `tool_name` lets us pick a more useful `text` representation than
-/// "pretty-printed JSON" for the tools where the user is asking for
-/// raw markdown (`export_md`, `page_render`, etc.). The
-/// `structuredContent` field always carries the full envelope so
-/// callers that prefer machine shape still get it.
-pub(crate) fn tool_success_payload(tool_name: &str, payload: &Value) -> Value {
-    let text = preferred_text_for(tool_name, payload);
-    let envelope = Envelope::success(payload.clone());
-    json!({
-        "content": [ { "type": "text", "text": text } ],
-        "structuredContent": serde_json::to_value(&envelope).unwrap_or(Value::Null),
-        "isError": false,
-    })
-}
-
-/// Pick a text content best suited for `tool_name`.
-///
-/// Tools that produce a single big string (rendered markdown, summary
-/// text) flatten the payload by reading its natural field. Everything
-/// else stays as pretty-printed JSON so structured callers always see
-/// the same shape.
-fn preferred_text_for(tool_name: &str, payload: &Value) -> String {
-    let take_field = |field: &str| -> Option<String> {
-        payload
-            .get(field)
-            .and_then(Value::as_str)
-            .map(str::to_string)
-    };
-
-    match tool_name {
-        // Pure-markdown surfaces: prefer the raw `md` field.
-        "outl_export_md" | "outl_page_render" => take_field("md"),
-        // Daily / page surfaces ship both `md` and a structured outline;
-        // the host shows the markdown as the "natural" text content.
-        "outl_daily_today" | "outl_daily_get" => take_field("md"),
-        _ => None,
-    }
-    .unwrap_or_else(|| {
-        serde_json::to_string_pretty(payload).unwrap_or_else(|_| payload.to_string())
-    })
 }
 
 #[cfg(test)]

--- a/crates/outl-cli/src/mcp/tools/dispatch.rs
+++ b/crates/outl-cli/src/mcp/tools/dispatch.rs
@@ -109,7 +109,7 @@ pub fn call(params: Value, ctx: &Arc<ServerCtx>) -> Result<Value, JsonRpcError> 
     }
 
     Ok(match outcome {
-        Ok(v) => tool_success_payload(name, &v),
+        Ok(v) => tool_success_payload(name, v),
         Err(e) => tool_error_payload(&e),
     })
 }

--- a/crates/outl-cli/src/mcp/tools/dispatch.rs
+++ b/crates/outl-cli/src/mcp/tools/dispatch.rs
@@ -50,8 +50,10 @@ use crate::cmd::{
     template as tpl_cmd, workspace_info as wi_cmd,
 };
 use crate::mcp::protocol::JsonRpcError;
-use crate::mcp::{tool_error_payload, tool_success_payload, ServerCtx};
+use crate::mcp::ServerCtx;
 use crate::output::ApiError;
+
+use super::payload::{tool_error_payload, tool_success_payload};
 
 use super::{opt_params, opt_str, require_str};
 

--- a/crates/outl-cli/src/mcp/tools/mod.rs
+++ b/crates/outl-cli/src/mcp/tools/mod.rs
@@ -15,6 +15,7 @@ use serde_json::{json, Value};
 use crate::output::ApiError;
 
 mod dispatch;
+mod payload;
 mod registry;
 
 pub use dispatch::call;

--- a/crates/outl-cli/src/mcp/tools/payload.rs
+++ b/crates/outl-cli/src/mcp/tools/payload.rs
@@ -1,0 +1,232 @@
+//! MCP tool-output wrapping.
+//!
+//! Turns a handler's `serde_json::Value` (or an [`ApiError`]) into the
+//! `tools/call` result shape. This is the one place the MCP surface
+//! diverges from the CLI's JSON envelope, on purpose: the shared
+//! `cmd/*` handler is untouched, only the copy that crosses the MCP
+//! wire is projected down to what an LLM consumer needs.
+
+use serde_json::{json, Value};
+
+use crate::output::{ApiError, Envelope};
+
+/// Wrap an [`ApiError`] into MCP tool output. MCP tool errors flow
+/// through the response shape `{ content: [...], isError: true }`
+/// rather than as JSON-RPC errors, so the client gets a recoverable
+/// signal instead of a protocol-level fault.
+///
+/// `structuredContent` carries the full `{ ok, data, error }` envelope
+/// — the deliberate exception to the content-only success shape. This
+/// is what makes `ApiError::data` reach the wire: a code like
+/// `PAGE_MARKDOWN_AHEAD_OF_LOG` alone tells a caller *that* a page
+/// stopped syncing, but `error.data.path` / `.lines` / `.sample` /
+/// `.recovery_command` is what lets it act instead of just reporting
+/// the failure onward (RFC 0255).
+pub(crate) fn tool_error_payload(err: &ApiError) -> Value {
+    let envelope = Envelope::<Value>::failure(err.clone());
+    json!({
+        "content": [
+            { "type": "text", "text": format!("{}: {}", err.code, err.message) }
+        ],
+        "structuredContent": serde_json::to_value(&envelope).unwrap_or(Value::Null),
+        "isError": true,
+    })
+}
+
+/// Wrap a successful tool result for the MCP wire.
+///
+/// The result is **content-only**. A client speaking this server's
+/// protocol version (`2024-11-05`) reads `content[0].text`; that
+/// revision has no `structuredContent`, so a success envelope carried
+/// there was a second, discarded copy of the same payload. Errors are
+/// the exception — [`tool_error_payload`] keeps `structuredContent`
+/// because a caller needs `error.data` (RFC 0255) and the failure
+/// signal is otherwise just prose.
+///
+/// Two token-saving projections happen here, both scoped to this
+/// consumer so the CLI's own `--json` output is untouched:
+///
+/// - **GUI-only fields are pruned** ([`lean_for_mcp`]) — an
+///   `OutlineNode`'s `tokens` (a pre-tokenized inline AST the mobile /
+///   desktop renderers consume) restates `text` at 2-3x its size, and
+///   an LLM already has `text`.
+/// - **JSON is compact, not pretty** — `content[0].text` is what the
+///   model reads, and the indentation was pure overhead.
+///
+/// `tool_name` still lets markdown-first tools (`export_md`,
+/// `page_render`, `daily_*`) flatten to their raw `.md` string, which
+/// is leaner still than any JSON form.
+pub(crate) fn tool_success_payload(tool_name: &str, payload: &Value) -> Value {
+    let lean = lean_for_mcp(payload);
+    let text = preferred_text_for(tool_name, &lean);
+    json!({
+        "content": [ { "type": "text", "text": text } ],
+        "isError": false,
+    })
+}
+
+/// Project a tool payload down to what an LLM consumer needs, dropping
+/// fields only a GUI renderer reads. Per-consumer: the shared handler
+/// still returns the full shape to the CLI, this only trims the copy
+/// that crosses the MCP wire.
+fn lean_for_mcp(payload: &Value) -> Value {
+    let mut v = payload.clone();
+    prune_gui_fields(&mut v);
+    v
+}
+
+/// Recursively strip GUI-only noise from a payload.
+///
+/// - `tokens` is only ever [`outl_actions::OutlineNode`]'s inline AST,
+///   so it is safe to drop wherever it appears.
+/// - `collapsed: false`, `todo: null`, and an empty `properties` are
+///   default-valued noise emitted on every outline node. They are
+///   pruned **only** on objects carrying the outline-node signature
+///   (`text` + `children`), so a same-named field on another tool's
+///   payload (e.g. `page_prop_list`'s `properties`) is left intact.
+fn prune_gui_fields(v: &mut Value) {
+    match v {
+        Value::Object(map) => {
+            map.remove("tokens");
+            let is_outline_node = map.contains_key("text") && map.contains_key("children");
+            if is_outline_node {
+                if map.get("collapsed") == Some(&Value::Bool(false)) {
+                    map.remove("collapsed");
+                }
+                if map.get("todo") == Some(&Value::Null) {
+                    map.remove("todo");
+                }
+                if matches!(map.get("properties"), Some(Value::Array(a)) if a.is_empty()) {
+                    map.remove("properties");
+                }
+            }
+            for child in map.values_mut() {
+                prune_gui_fields(child);
+            }
+        }
+        Value::Array(arr) => arr.iter_mut().for_each(prune_gui_fields),
+        _ => {}
+    }
+}
+
+/// Pick a text content best suited for `tool_name`.
+///
+/// Tools that produce a single big string (rendered markdown, summary
+/// text) flatten the payload by reading its natural field. Everything
+/// else is emitted as compact JSON — `content[0].text` is what the
+/// model reads, so no whitespace is spent on indentation.
+fn preferred_text_for(tool_name: &str, payload: &Value) -> String {
+    let take_field = |field: &str| -> Option<String> {
+        payload
+            .get(field)
+            .and_then(Value::as_str)
+            .map(str::to_string)
+    };
+
+    match tool_name {
+        // Pure-markdown surfaces: prefer the raw `md` field.
+        "outl_export_md" | "outl_page_render" => take_field("md"),
+        // Daily / page surfaces ship both `md` and a structured outline;
+        // the host shows the markdown as the "natural" text content.
+        "outl_daily_today" | "outl_daily_get" => take_field("md"),
+        _ => None,
+    }
+    .unwrap_or_else(|| serde_json::to_string(payload).unwrap_or_else(|_| payload.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::codes;
+
+    /// A success reply is content-only and compact — no `structuredContent`
+    /// second copy, no pretty-print whitespace. The model reads
+    /// `content[0].text`, so that is the only thing worth paying for.
+    #[test]
+    fn success_payload_is_content_only_and_compact() {
+        let payload = json!({ "meta": { "slug": "ideas", "title": "Ideas" } });
+        let out = tool_success_payload("outl_page_get", &payload);
+
+        assert_eq!(out["isError"], false);
+        assert!(
+            out.get("structuredContent").is_none(),
+            "success replies must not carry a duplicate structuredContent envelope"
+        );
+        let text = out["content"][0]["text"].as_str().unwrap();
+        assert!(
+            !text.contains('\n'),
+            "content text must be compact JSON: {text}"
+        );
+        // Round-trips back to the same payload.
+        let parsed: Value = serde_json::from_str(text).unwrap();
+        assert_eq!(parsed, payload);
+    }
+
+    /// GUI-only outline fields (`tokens`, and default-valued `collapsed` /
+    /// `todo` / empty `properties`) are stripped from the MCP copy, while a
+    /// same-named field on a non-outline payload is left intact.
+    #[test]
+    fn success_payload_strips_gui_only_outline_fields() {
+        let payload = json!({
+            "outline": [
+                {
+                    "id": "01ABC",
+                    "text": "hello",
+                    "todo": null,
+                    "collapsed": false,
+                    "properties": [],
+                    "tokens": [ { "type": "plain", "text": "hello" } ],
+                    "children": [
+                        {
+                            "id": "01DEF",
+                            "text": "child",
+                            "todo": "TODO",
+                            "collapsed": true,
+                            "properties": [ ["k", "v"] ],
+                            "tokens": [ { "type": "plain", "text": "child" } ],
+                            "children": []
+                        }
+                    ]
+                }
+            ]
+        });
+        let lean = lean_for_mcp(&payload);
+        let root = &lean["outline"][0];
+
+        assert!(root.get("tokens").is_none(), "tokens must be dropped");
+        assert!(root.get("collapsed").is_none(), "collapsed:false is noise");
+        assert!(root.get("todo").is_none(), "todo:null is noise");
+        assert!(
+            root.get("properties").is_none(),
+            "empty properties is noise"
+        );
+        assert_eq!(root["text"], "hello");
+
+        // Meaningful (non-default) values survive.
+        let child = &root["children"][0];
+        assert!(child.get("tokens").is_none());
+        assert_eq!(child["todo"], "TODO");
+        assert_eq!(child["collapsed"], true);
+        assert_eq!(child["properties"], json!([["k", "v"]]));
+
+        // A `properties` key outside an outline node (no text+children
+        // signature) is not an outline node and must be untouched.
+        let other = lean_for_mcp(&json!({ "properties": [] }));
+        assert_eq!(other, json!({ "properties": [] }));
+    }
+
+    /// Errors are the deliberate exception: they keep `structuredContent`
+    /// so a caller can read `error.data` (RFC 0255) rather than parse prose.
+    #[test]
+    fn error_payload_keeps_structured_content() {
+        let err = ApiError::new(codes::PAGE_NOT_FOUND, "page `x` not found".to_string());
+        let out = tool_error_payload(&err);
+
+        assert_eq!(out["isError"], true);
+        assert_eq!(out["structuredContent"]["ok"], false);
+        assert_eq!(
+            out["structuredContent"]["error"]["code"],
+            codes::PAGE_NOT_FOUND
+        );
+    }
+}

--- a/crates/outl-cli/src/mcp/tools/payload.rs
+++ b/crates/outl-cli/src/mcp/tools/payload.rs
@@ -1,27 +1,30 @@
 //! MCP tool-output wrapping.
 //!
 //! Turns a handler's `serde_json::Value` (or an [`ApiError`]) into the
-//! `tools/call` result shape. This is the one place the MCP surface
-//! diverges from the CLI's JSON envelope, on purpose: the shared
-//! `cmd/*` handler is untouched, only the copy that crosses the MCP
-//! wire is projected down to what an LLM consumer needs.
+//! `tools/call` result shape, projected for an LLM consumer. The shared
+//! `cmd/*` handler is untouched; only this wire copy is trimmed.
 
 use serde_json::{json, Value};
 
 use crate::output::{ApiError, Envelope};
 
-/// Wrap an [`ApiError`] into MCP tool output. MCP tool errors flow
-/// through the response shape `{ content: [...], isError: true }`
-/// rather than as JSON-RPC errors, so the client gets a recoverable
-/// signal instead of a protocol-level fault.
+/// The payload field whose raw string is the natural text content for a
+/// markdown-first tool — leaner than any JSON form. `None` for tools
+/// whose result is structured.
+fn markdown_field(tool_name: &str) -> Option<&'static str> {
+    match tool_name {
+        "outl_export_md" | "outl_page_render" | "outl_daily_today" | "outl_daily_get" => Some("md"),
+        _ => None,
+    }
+}
+
+/// Wrap an [`ApiError`] as a recoverable tool error (`isError: true`),
+/// not a JSON-RPC protocol fault.
 ///
-/// `structuredContent` carries the full `{ ok, data, error }` envelope
-/// — the deliberate exception to the content-only success shape. This
-/// is what makes `ApiError::data` reach the wire: a code like
-/// `PAGE_MARKDOWN_AHEAD_OF_LOG` alone tells a caller *that* a page
-/// stopped syncing, but `error.data.path` / `.lines` / `.sample` /
-/// `.recovery_command` is what lets it act instead of just reporting
-/// the failure onward (RFC 0255).
+/// Unlike success, this keeps `structuredContent`: the text content is
+/// only a `code: message` summary, so `error.data` (RFC 0255 —
+/// `PAGE_MARKDOWN_AHEAD_OF_LOG` carries `path` / `lines` / `sample` /
+/// `recovery_command`) would otherwise not reach the caller.
 pub(crate) fn tool_error_payload(err: &ApiError) -> Value {
     let envelope = Envelope::<Value>::failure(err.clone());
     json!({
@@ -33,63 +36,46 @@ pub(crate) fn tool_error_payload(err: &ApiError) -> Value {
     })
 }
 
-/// Wrap a successful tool result for the MCP wire.
+/// Wrap a successful tool result, content-only.
 ///
-/// The result is **content-only**. A client speaking this server's
-/// protocol version (`2024-11-05`) reads `content[0].text`; that
-/// revision has no `structuredContent`, so a success envelope carried
-/// there was a second, discarded copy of the same payload. Errors are
-/// the exception — [`tool_error_payload`] keeps `structuredContent`
-/// because a caller needs `error.data` (RFC 0255) and the failure
-/// signal is otherwise just prose.
-///
-/// Two token-saving projections happen here, both scoped to this
-/// consumer so the CLI's own `--json` output is untouched:
-///
-/// - **GUI-only fields are pruned** ([`lean_for_mcp`]) — an
-///   `OutlineNode`'s `tokens` (a pre-tokenized inline AST the mobile /
-///   desktop renderers consume) restates `text` at 2-3x its size, and
-///   an LLM already has `text`.
-/// - **JSON is compact, not pretty** — `content[0].text` is what the
-///   model reads, and the indentation was pure overhead.
-///
-/// `tool_name` still lets markdown-first tools (`export_md`,
-/// `page_render`, `daily_*`) flatten to their raw `.md` string, which
-/// is leaner still than any JSON form.
-pub(crate) fn tool_success_payload(tool_name: &str, payload: &Value) -> Value {
-    let lean = lean_for_mcp(payload);
-    let text = preferred_text_for(tool_name, &lean);
+/// `content[0].text` carries the payload as compact JSON — or, for
+/// markdown-first tools, the raw `.md`. No `structuredContent`: the text
+/// already holds the full payload, so an envelope around it is a
+/// duplicate. (The error path is the exception; see [`tool_error_payload`].)
+/// [`prune_gui_fields`] drops fields only a GUI renderer reads before
+/// serializing.
+pub(crate) fn tool_success_payload(tool_name: &str, mut payload: Value) -> Value {
+    let text = markdown_field(tool_name)
+        .and_then(|field| {
+            payload
+                .get(field)
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| {
+            prune_gui_fields(&mut payload);
+            serde_json::to_string(&payload).unwrap_or_else(|_| payload.to_string())
+        });
     json!({
         "content": [ { "type": "text", "text": text } ],
         "isError": false,
     })
 }
 
-/// Project a tool payload down to what an LLM consumer needs, dropping
-/// fields only a GUI renderer reads. Per-consumer: the shared handler
-/// still returns the full shape to the CLI, this only trims the copy
-/// that crosses the MCP wire.
-fn lean_for_mcp(payload: &Value) -> Value {
-    let mut v = payload.clone();
-    prune_gui_fields(&mut v);
-    v
-}
-
-/// Recursively strip GUI-only noise from a payload.
+/// Drop GUI-only fields from a payload, in place.
 ///
-/// - `tokens` is only ever [`outl_actions::OutlineNode`]'s inline AST,
-///   so it is safe to drop wherever it appears.
-/// - `collapsed: false`, `todo: null`, and an empty `properties` are
-///   default-valued noise emitted on every outline node. They are
-///   pruned **only** on objects carrying the outline-node signature
-///   (`text` + `children`), so a same-named field on another tool's
-///   payload (e.g. `page_prop_list`'s `properties`) is left intact.
+/// `tokens` (an outline node's pre-tokenized inline AST, a verbose
+/// restatement of `text`) is dropped wherever it appears — the key is
+/// unique to that type. `collapsed: false`, `todo: null` and an empty
+/// `properties` are default noise, dropped only on an outline node
+/// (identified by `text` + `children`) so a same-named field elsewhere
+/// (e.g. `page_prop_list`'s `properties`, `block_get`'s `todo`) is left
+/// intact.
 fn prune_gui_fields(v: &mut Value) {
     match v {
         Value::Object(map) => {
             map.remove("tokens");
-            let is_outline_node = map.contains_key("text") && map.contains_key("children");
-            if is_outline_node {
+            if map.contains_key("text") && map.contains_key("children") {
                 if map.get("collapsed") == Some(&Value::Bool(false)) {
                     map.remove("collapsed");
                 }
@@ -100,38 +86,11 @@ fn prune_gui_fields(v: &mut Value) {
                     map.remove("properties");
                 }
             }
-            for child in map.values_mut() {
-                prune_gui_fields(child);
-            }
+            map.values_mut().for_each(prune_gui_fields);
         }
         Value::Array(arr) => arr.iter_mut().for_each(prune_gui_fields),
         _ => {}
     }
-}
-
-/// Pick a text content best suited for `tool_name`.
-///
-/// Tools that produce a single big string (rendered markdown, summary
-/// text) flatten the payload by reading its natural field. Everything
-/// else is emitted as compact JSON — `content[0].text` is what the
-/// model reads, so no whitespace is spent on indentation.
-fn preferred_text_for(tool_name: &str, payload: &Value) -> String {
-    let take_field = |field: &str| -> Option<String> {
-        payload
-            .get(field)
-            .and_then(Value::as_str)
-            .map(str::to_string)
-    };
-
-    match tool_name {
-        // Pure-markdown surfaces: prefer the raw `md` field.
-        "outl_export_md" | "outl_page_render" => take_field("md"),
-        // Daily / page surfaces ship both `md` and a structured outline;
-        // the host shows the markdown as the "natural" text content.
-        "outl_daily_today" | "outl_daily_get" => take_field("md"),
-        _ => None,
-    }
-    .unwrap_or_else(|| serde_json::to_string(payload).unwrap_or_else(|_| payload.to_string()))
 }
 
 #[cfg(test)]
@@ -139,32 +98,38 @@ mod tests {
     use super::*;
     use crate::output::codes;
 
-    /// A success reply is content-only and compact — no `structuredContent`
-    /// second copy, no pretty-print whitespace. The model reads
-    /// `content[0].text`, so that is the only thing worth paying for.
-    #[test]
-    fn success_payload_is_content_only_and_compact() {
-        let payload = json!({ "meta": { "slug": "ideas", "title": "Ideas" } });
-        let out = tool_success_payload("outl_page_get", &payload);
-
+    fn success_json(tool: &str, payload: Value) -> Value {
+        let out = tool_success_payload(tool, payload);
         assert_eq!(out["isError"], false);
         assert!(
             out.get("structuredContent").is_none(),
             "success replies must not carry a duplicate structuredContent envelope"
         );
-        let text = out["content"][0]["text"].as_str().unwrap();
+        let text = out["content"][0]["text"].as_str().unwrap().to_string();
         assert!(
             !text.contains('\n'),
             "content text must be compact JSON: {text}"
         );
-        // Round-trips back to the same payload.
-        let parsed: Value = serde_json::from_str(text).unwrap();
-        assert_eq!(parsed, payload);
+        serde_json::from_str(&text).unwrap()
     }
 
-    /// GUI-only outline fields (`tokens`, and default-valued `collapsed` /
-    /// `todo` / empty `properties`) are stripped from the MCP copy, while a
-    /// same-named field on a non-outline payload is left intact.
+    /// A structured tool's success payload round-trips through the compact
+    /// content text unchanged (minus the GUI-only pruning tested below).
+    #[test]
+    fn success_payload_is_content_only_and_compact() {
+        let payload = json!({ "meta": { "slug": "ideas", "title": "Ideas" } });
+        assert_eq!(success_json("outl_page_get", payload.clone()), payload);
+    }
+
+    /// A markdown-first tool flattens to its raw `.md` string.
+    #[test]
+    fn markdown_first_tool_returns_raw_md() {
+        let out = tool_success_payload("outl_page_render", json!({ "slug": "x", "md": "- hi" }));
+        assert_eq!(out["content"][0]["text"], "- hi");
+    }
+
+    /// GUI-only outline fields are stripped; meaningful values and a
+    /// same-named field on a non-outline object survive.
     #[test]
     fn success_payload_strips_gui_only_outline_fields() {
         let payload = json!({
@@ -188,10 +153,12 @@ mod tests {
                         }
                     ]
                 }
-            ]
+            ],
+            // Not an outline node (no text+children): must be untouched.
+            "prop_list": { "properties": [] }
         });
-        let lean = lean_for_mcp(&payload);
-        let root = &lean["outline"][0];
+        let out = success_json("outl_page_get", payload);
+        let root = &out["outline"][0];
 
         assert!(root.get("tokens").is_none(), "tokens must be dropped");
         assert!(root.get("collapsed").is_none(), "collapsed:false is noise");
@@ -202,27 +169,21 @@ mod tests {
         );
         assert_eq!(root["text"], "hello");
 
-        // Meaningful (non-default) values survive.
         let child = &root["children"][0];
         assert!(child.get("tokens").is_none());
         assert_eq!(child["todo"], "TODO");
         assert_eq!(child["collapsed"], true);
         assert_eq!(child["properties"], json!([["k", "v"]]));
 
-        // A `properties` key outside an outline node (no text+children
-        // signature) is not an outline node and must be untouched.
-        let other = lean_for_mcp(&json!({ "properties": [] }));
-        assert_eq!(other, json!({ "properties": [] }));
+        assert_eq!(out["prop_list"], json!({ "properties": [] }));
     }
 
-    /// Errors are the deliberate exception: they keep `structuredContent`
-    /// so a caller can read `error.data` (RFC 0255) rather than parse prose.
+    /// Errors keep `structuredContent` so `error.data` (RFC 0255) survives.
     #[test]
     fn error_payload_keeps_structured_content() {
         let err = ApiError::new(codes::PAGE_NOT_FOUND, "page `x` not found".to_string());
         let out = tool_error_payload(&err);
 
-        assert_eq!(out["isError"], true);
         assert_eq!(out["structuredContent"]["ok"], false);
         assert_eq!(
             out["structuredContent"]["error"]["code"],

--- a/crates/outl-cli/src/mcp/tools/registry.rs
+++ b/crates/outl-cli/src/mcp/tools/registry.rs
@@ -124,7 +124,7 @@ pub fn list() -> Vec<Value> {
         ),
         tool_def(
             "outl_block_append_tree",
-            "Append a subtree as the last child of a page or block in one call. `tree` is `{text, children?}`. Prefer over chained `outl_block_append` for structured content.",
+            "Append a subtree as the last child of a page or block in one call. `tree` is `{text, children?: [tree, …]}` — `children` is an array of recursive tree objects, not strings. Prefer over chained `outl_block_append` for structured content.",
             json!({
                 "type": "object",
                 "properties": {

--- a/crates/outl-cli/src/mcp/tools/registry.rs
+++ b/crates/outl-cli/src/mcp/tools/registry.rs
@@ -124,7 +124,7 @@ pub fn list() -> Vec<Value> {
         ),
         tool_def(
             "outl_block_append_tree",
-            "Append a whole subtree (root + recursive children) as the last child of a page or block in a single call. `tree` is `{text, children?: [tree, ...]}`. Prefer this over chained `outl_block_append` calls when writing structured content.",
+            "Append a subtree as the last child of a page or block in one call. `tree` is `{text, children?}`. Prefer over chained `outl_block_append` for structured content.",
             json!({
                 "type": "object",
                 "properties": {
@@ -251,7 +251,7 @@ pub fn list() -> Vec<Value> {
         // Asset
         tool_def(
             "outl_asset_add",
-            "Import a file (PDF, image, …) into the workspace's `assets/` dir and append its markdown link as a new block. `path` is a filesystem path to the file on this machine (MCP is stdio — pass a path, not bytes). The link is appended to today's journal by default; pass `page` (a slug) to append it to that page instead. `daily` and `page` are mutually exclusive — you never need to set `daily` explicitly, it is just the default when `page` is omitted.",
+            "Import a file into `assets/` and append its markdown link as a new block. `path` is a filesystem path on this machine (stdio — pass a path, not bytes). Appends to today's journal by default; pass `page` (a slug) to target a page instead. `daily` is just that default and never needs setting.",
             json!({
                 "type": "object",
                 "properties": {
@@ -405,7 +405,7 @@ pub fn list() -> Vec<Value> {
         // Batch
         tool_def(
             "outl_batch",
-            "Apply a sequence of write ops in one workspace session. Stops on first error and reports `failed_at` + `applied`. Use this for multi-step authoring (page + outline + props) so each op doesn't cost a round-trip. Supported `op` names: page_create, page_update, page_delete, page_rename, block_append, block_append_tree, block_insert, block_update, block_move, block_delete, block_toggle_todo, daily_append, page_prop_set. Each op's `args` mirror the matching `outl_<op>` tool.",
+            "Apply write ops in one session (stops on first error, reports `failed_at` + `applied`). Use for multi-step authoring so each op skips a round-trip. `op` is one of: page_create, page_update, page_delete, page_rename, block_append, block_append_tree, block_insert, block_update, block_move, block_delete, block_toggle_todo, daily_append, page_prop_set; each op's `args` mirror the matching `outl_<op>` tool.",
             json!({
                 "type": "object",
                 "properties": {

--- a/crates/outl-cli/src/output.rs
+++ b/crates/outl-cli/src/output.rs
@@ -201,11 +201,7 @@ impl Envelope<Value> {
 /// Print a success envelope as JSON to stdout. Convenience for CLI
 /// handlers that always emit JSON when `--json` is set.
 pub fn print_success_json<T: Serialize>(data: &T) {
-    let env = Envelope {
-        ok: true,
-        data: Some(data),
-        error: None::<ApiError>,
-    };
+    let env = Envelope::success(data);
     match serde_json::to_string(&env) {
         Ok(s) => println!("{s}"),
         Err(e) => eprintln!("internal: could not serialize success envelope: {e}"),

--- a/crates/outl-cli/tests/mcp_smoke.rs
+++ b/crates/outl-cli/tests/mcp_smoke.rs
@@ -61,6 +61,23 @@ impl McpClient {
     }
 }
 
+/// Parse the data payload out of a **successful** `tools/call` result.
+///
+/// Success replies are content-only (no `structuredContent` at this
+/// protocol version); the data lives as compact JSON in
+/// `content[0].text`. Markdown-first tools put raw `.md` there instead,
+/// so this is only for the JSON-shaped tools.
+fn success_data(result: &Value) -> Value {
+    assert_eq!(
+        result["isError"], false,
+        "expected a success reply: {result}"
+    );
+    let text = result["content"][0]["text"]
+        .as_str()
+        .expect("content[0].text is a string");
+    serde_json::from_str(text).expect("success content is JSON")
+}
+
 impl Drop for McpClient {
     fn drop(&mut self) {
         // Closing stdin makes the MCP loop exit.
@@ -109,9 +126,8 @@ fn initialize_then_call_workspace_info() {
         }
     }));
     assert_eq!(call["id"], 3);
-    let structured = &call["result"]["structuredContent"];
-    assert_eq!(structured["ok"], true);
-    assert!(structured["data"]["root"].is_string());
+    let data = success_data(&call["result"]);
+    assert!(data["root"].is_string());
 }
 
 #[test]
@@ -137,9 +153,8 @@ fn doctor_via_mcp_does_not_lie_about_lock() {
         "method": "tools/call",
         "params": { "name": "outl_workspace_doctor", "arguments": {} }
     }));
-    let structured = &resp["result"]["structuredContent"];
-    assert_eq!(structured["ok"], true, "doctor must succeed inside MCP");
-    let findings = structured["data"]["findings"].as_array().unwrap();
+    let data = success_data(&resp["result"]);
+    let findings = data["findings"].as_array().unwrap();
     let has_lock_warning = findings.iter().any(|f| {
         f["message"]
             .as_str()
@@ -220,9 +235,8 @@ fn page_create_then_get_via_mcp() {
             "arguments": { "slug": "ideas", "title": "Ideas" }
         }
     }));
-    let structured = &create["result"]["structuredContent"];
-    assert_eq!(structured["ok"], true);
-    assert_eq!(structured["data"]["meta"]["slug"], "ideas");
+    let data = success_data(&create["result"]);
+    assert_eq!(data["meta"]["slug"], "ideas");
 
     let get = client.call(serde_json::json!({
         "jsonrpc": "2.0",
@@ -233,9 +247,8 @@ fn page_create_then_get_via_mcp() {
             "arguments": { "slug": "ideas" }
         }
     }));
-    let s2 = &get["result"]["structuredContent"];
-    assert_eq!(s2["ok"], true);
-    assert_eq!(s2["data"]["meta"]["title"], "Ideas");
+    let data = success_data(&get["result"]);
+    assert_eq!(data["meta"]["title"], "Ideas");
 }
 
 /// RFC 0255 Part 1: a page that stopped syncing must come back as a
@@ -271,7 +284,7 @@ fn frozen_page_update_returns_structured_refusal_not_a_generic_error() {
                 }
             }
         }));
-        assert_eq!(create["result"]["structuredContent"]["ok"], true);
+        assert_eq!(create["result"]["isError"], false);
     }
 
     // Reproduce the exact state invariant 8 guards against: the `.md`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -91,8 +91,12 @@ A script can then tell "I flushed" from "someone else will" without reading eith
 
 Add `--json` to any command to force JSON.
 Without the flag, output is human-readable (tables, colored).
-MCP tools wrap the same envelope in the MCP tool-result shape: `structuredContent` carries the full `{ ok, data, error }` envelope and `content[].text` carries either a pretty-printed payload or, for markdown-first tools (`outl_export_md`, `outl_page_render`, `outl_daily_today`, `outl_daily_get`), the raw `.md` string.
-Clients should read `structuredContent.data` for typed access.
+MCP tools return the same data, projected for an LLM consumer rather than a script.
+A **success** reply is content-only: `content[].text` carries the payload as compact JSON, or — for markdown-first tools (`outl_export_md`, `outl_page_render`, `outl_daily_today`, `outl_daily_get`) — the raw `.md` string.
+There is no `structuredContent` on success; at the server's protocol version (`2024-11-05`) it was a second, discarded copy of the same payload.
+The MCP copy also drops fields only a GUI renderer reads (an outline node's `tokens`, and default-valued `collapsed` / `todo` / empty `properties`); the CLI's own `--json` output keeps them.
+An **error** reply is the deliberate exception: it sets `isError: true` and keeps `structuredContent: { ok: false, error }`.
+That lets a caller read `error.data` — e.g. `PAGE_MARKDOWN_AHEAD_OF_LOG`'s `path` / `lines` / `sample` / `recovery_command` — instead of parsing prose.
 
 ## Commands by domain
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -93,7 +93,7 @@ Add `--json` to any command to force JSON.
 Without the flag, output is human-readable (tables, colored).
 MCP tools return the same data, projected for an LLM consumer rather than a script.
 A **success** reply is content-only: `content[].text` carries the payload as compact JSON, or — for markdown-first tools (`outl_export_md`, `outl_page_render`, `outl_daily_today`, `outl_daily_get`) — the raw `.md` string.
-There is no `structuredContent` on success; at the server's protocol version (`2024-11-05`) it was a second, discarded copy of the same payload.
+There is no `structuredContent` on success — the text already carries the full payload as JSON, so an envelope around it is a duplicate.
 The MCP copy also drops fields only a GUI renderer reads (an outline node's `tokens`, and default-valued `collapsed` / `todo` / empty `properties`); the CLI's own `--json` output keeps them.
 An **error** reply is the deliberate exception: it sets `isError: true` and keeps `structuredContent: { ok: false, error }`.
 That lets a caller read `error.data` — e.g. `PAGE_MARKDOWN_AHEAD_OF_LOG`'s `path` / `lines` / `sample` / `recovery_command` — instead of parsing prose.

--- a/docs/mcp-recipes.md
+++ b/docs/mcp-recipes.md
@@ -152,7 +152,7 @@ The fixed pieces are *what to read, how to bucket it, what to produce* — the t
 
 - **Markdown dialect.** Writes must follow [`docs/markdown-format.md`](markdown-format.md): ISO date links (`[[2026-04-22]]`), 2-space indent per level, literal `TODO` / `DONE` prefixes. The server doesn't transform input.
 - **Best-effort reads.** If a call fails or returns empty, continue with what the rest of the calls produced — don't block the whole command on one miss.
-- **Output shape.** Tools return `structuredContent: { ok, data, error }` and `content[].text`. For markdown-first tools (`outl_daily_*`, `outl_page_render`, `outl_export_md`), `content[].text` is the raw `.md` — easier to feed the model than the JSON form.
+- **Output shape.** Success is content-only — compact JSON in `content[].text`, or raw `.md` for markdown-first tools (`outl_daily_*`, `outl_page_render`, `outl_export_md`). Errors set `isError: true` and keep `structuredContent: { ok: false, error }` so `error.data` is readable.
 - **Workspace errors.** If `outl mcp serve` was launched without `--workspace` (and `OUTL_WORKSPACE` isn't set), every tool returns "no workspace". Tell the user to fix the host config — the prompt can't recover.
 
 ## See also

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -60,7 +60,10 @@ If both lines come back with valid JSON-RPC responses, the server is healthy.
 Every CLI subcommand documented in [`docs/cli.md`](cli.md#commands-by-domain) is registered as an MCP tool.
 Names are `outl_<command>_<verb>` (e.g.
 `outl_page_get`, `outl_block_append`, `outl_daily_today`, `outl_search`, `outl_query`).
-Input schema mirrors the CLI flags; the response is the JSON envelope's `data` field wrapped in MCP's `content` shape.
+Input schema mirrors the CLI flags.
+A success response is content-only — the handler's `data` as compact JSON (or raw `.md` for markdown-first tools) in `content[].text`, with GUI-only outline fields dropped.
+An error keeps the `{ ok: false, error }` envelope in `structuredContent` for `error.data`.
+Full shape in [`docs/cli.md`](cli.md#commands-by-domain).
 
 Destructive tools (`outl_page_delete`, `outl_block_delete`) require `confirm: true` in the input.
 Without it they return a recoverable `CONFIRM_REQUIRED` error and the workspace is untouched.


### PR DESCRIPTION
MCP tool replies were sending their payload twice. Every successful `tools/call` put pretty-printed JSON in `content[0].text`, then the same data again as a `{ ok, data, error }` envelope in `structuredContent`. On top of that, every outline node carried `tokens`, a pre-tokenized inline AST that exists so the Tauri renderers don't need their own inline tokenizer, and which restates the `text` an LLM already has.

Measured against a 2,862-page workspace before any of this was written:

| call | before | after |
|---|---|---|
| `outl_daily_today` | ~12.2k chars | ~5.9k |
| `outl_page_get` on a journal | ~22k | ~5.9k |
| `outl_page_list` | ~726k | ~303k |

A success reply is content-only and compact now, with `tokens` and default-valued `collapsed` / `todo` / empty `properties` dropped. The shared `cmd/*` handlers and the CLI's own `--json` are untouched. All of it happens in one new file, `mcp/tools/payload.rs`, so the projection has one owner instead of being smeared across the dispatcher.

**Errors keep their envelope, and that is the deliberate exception.** An error's text content is only a `code: message` summary, so `structuredContent: { ok: false, error }` is the only machine-readable copy of `error.data`. RFC 0255's `PAGE_MARKDOWN_AHEAD_OF_LOG` carries `path` / `lines` / `sample` / `recovery_command`, and a caller that can read nothing but prose can report a page stopped syncing without being able to do anything about it.

**This is a wire break for any client reading `structuredContent` on success**, and the advice being broken is advice this repo published: `docs/cli.md` used to say "Clients should read `structuredContent.data` for typed access". Nothing in the repo consumes it outside the smoke test, and desktop and mobile speak Tauri rather than MCP. No tool declares an `outputSchema`, which is what makes omitting `structuredContent` legal under the MCP spec rather than merely convenient. There is a decision hiding in that sentence: taking this change is choosing not to declare output schemas later, because declaring one obliges the server to send `structuredContent` back.

## Two things are deliberately not trimmed

Both were got wrong on the first pass, both in the same way, and the way is worth naming: **a projection is a place to drop what the caller can re-derive, never a place to drop the only copy.**

**The journal reads look markdown-shaped and are not flattened.** `outl_daily_today` / `outl_daily_get` return `{date, meta, outline, md}`, and `outline` is the only place a block id appears, because ids live in the sidecar and never in rendered markdown. Every block-targeting write tool needs one, so flattening these two broke "read today's journal, tick a task" with nothing to report it. `date` goes the same way: `outl_daily_today` takes no argument, so its reply is the only thing naming the journal it opened. `outl_page_render` and `outl_export_md` do flatten, because `{slug, md}` minus `md` is a slug the caller just sent.

So the test for the next tool somebody adds here is not "is markdown the useful part". It is "does the caller already have what I'm about to drop".

**Pruning keys on an outline node's `id`, not just its `text` + `children`.** There are two `OutlineNode` types in this workspace. The one in `outl_actions` has an `id`. The one in `outl_md::ast` is `{text, properties, children}` and does not, `outl_export_json` returns that one, and its `properties` field has no `#[serde(default)]`. A `text` + `children` guard dropped the empty `properties` there and stopped the export deserializing back into the type that produced it, on every block that has no property, which is most of them. Silently, because the JSON still reads fine to anyone looking at it.

## Testing

Both of those passed CI green, which is the part worth fixing. The unit tests used hand-written payloads rather than anything a handler produces, and `mcp_smoke.rs` never called a single one of the four tools where the projection changes most.

Four tests close that. `journal_reads_keep_their_ids_and_date` and `pruning_leaves_the_parser_ast_alone` cover the projection in `payload.rs`. Two integration tests drive the real server: one reads a journal over MCP and uses the id it gets back as an actual write target, the other deserializes `outl_export_json`'s output into `outl_md::OutlineNode`. All four were run against the projection without the fixes and confirmed to fail, so they pin the behaviour rather than describe it.

Full suite: `cargo fmt --check`, `clippy -D warnings`, 2,143 Rust tests, `cargo doc` with `RUSTDOCFLAGS=-D warnings`, `tsc --noEmit` across all 14 packages, 210 frontend tests.

Behaviour checked by hand: `outl daily today --json` still emits `tokens`, `collapsed` and `properties` (the CLI path never changed), and driving `outl mcp serve` directly shows a success reply with no `structuredContent`, compact text, and an outline node that kept `id` and `text` with `tokens` gone.

## Docs

`docs/cli.md`, `docs/mcp.md` and `docs/mcp-recipes.md` carry the new shape. `crates/outl-cli/CLAUDE.md` had a `## JSON envelope (CLI + MCP)` section that stopped being true for MCP here, so it is `(CLI)` now and links to `docs/cli.md` instead of restating the contract. `CHANGELOG.md` gets the `### Changed` entry naming the wire break. The PR template gained two checklist items, on wire contracts and on when a change needs an RFC, because nothing in it asked either question.

## Out of scope

CLI output shape and `cmd/*` handler logic, both unchanged. The set of MCP tools. Read-side slicing, which is the larger cost and a separate change: `outl_page_get` and `outl_block_tree` take no `depth` and `outl_page_list` takes no `limit`, so on a big workspace a single call can still swamp a context window after every saving here. That is additive to the schemas and breaks nothing, which is exactly why it doesn't belong in a PR that breaks a wire format.

---

Original work by @waldnzwrld. The two projection fixes, the four regression tests and the docs came out of review, on top of the branch.
